### PR TITLE
Run `bundle` on start-up

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.7'
 services:
   app:
     build: .
-    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
+    command: bash -c "rm -f tmp/pids/server.pid && bundle && bundle exec rails s -p 3000 -b '0.0.0.0'"
     environment:
       KEYCLOAK_ADMIN_USER: govuk
       KEYCLOAK_ADMIN_PASSWORD: mypassword


### PR DESCRIPTION
This removes the need to run `docker-compose build` whenever we change
the Gemfile.lock.