### PR TITLE
Include authenticity token in the registration form

### DIFF
--- a/app/controllers/register_controller.rb
+++ b/app/controllers/register_controller.rb
@@ -1,7 +1,4 @@
 class RegisterController < ApplicationController
-  # bad!
-  skip_before_action :verify_authenticity_token
-
   rescue_from RestClient::Conflict, with: :conflict
 
   def show; end

--- a/app/views/register/show.html.erb
+++ b/app/views/register/show.html.erb
@@ -9,7 +9,8 @@
       Complete your details to register.
     </p>
 
-    <form method="post">
+    <%= form_tag do %>
+
       <%= render "govuk_publishing_components/components/input", {
         label: {
           text: "Email address"
@@ -29,6 +30,8 @@
       <%= render "govuk_publishing_components/components/button", {
         text: "Register"
       } %>
-    </form>
+
+    <% end %>
+
   </div>
 </div>


### PR DESCRIPTION
We were previously skipping checking the authenticity token in the register controller.  Adding a form tag so Rails will automatically include the authenticity token and we can remove the skip.