### PR TITLE
Fix configuration errors in concourse deploy

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -4,10 +4,9 @@ resources:
     type: git
     icon: github-circle
     source:
-      uri: https://github.com/alphagov/govuk-account-manager-prototype.git
+      uri: git@github.com:alphagov/govuk-account-manager-prototype.git
       branch: master
-      private_key: |
-          ((govuk_ci_ssh_private_key))
+      private_key: ((concourse_ci_github_ssh_read_only))
 jobs:
   - name: update-pipeline
     plan:
@@ -27,9 +26,9 @@ jobs:
           CF_ORG: govuk_development
           CF_APP_NAME: govuk-account-manager
           CF_SPACE: sandbox
-          CF_INSTANCES: 1
           CF_STARTUP_TIMEOUT: 15 # minutes
-          CF_WORKERS: 1
+          APP_INSTANCES: 1
+          WORKER_INSTANCES: 1
           APP_DOMAIN: www.gov.uk
           WEBSITE_ROOT: https://www.gov.uk
           KEYCLOAK_ADMIN_PASSWORD: ((keycloak-admin-password))

--- a/concourse/tasks/deploy-to-govuk-paas.yml
+++ b/concourse/tasks/deploy-to-govuk-paas.yml
@@ -25,22 +25,22 @@ run:
       cf t -o "$CF_ORG" -s "$CF_SPACE"
       cf v3-create-app $CF_APP_NAME || true
       cf v3-apply-manifest -f manifest.yml
-      cf set-env CF_APP_NAME CF_STARTUP_TIMEOUT "$CF_STARTUP_TIMEOUT"
+      cf set-env $CF_APP_NAME CF_STARTUP_TIMEOUT "$CF_STARTUP_TIMEOUT"
 
-      cf scale -i "$CF_INSTANCES" "$CF_APP_NAME"
-      cf v3-scale --process worker -i "$CF_WORKERS" "$CF_APP_NAME"
+      cf scale -i "$APP_INSTANCES" $CF_APP_NAME
+      cf v3-scale --process worker -i "$WORKER_INSTANCES" $CF_APP_NAME
 
-      cf set-env "$CF_APP_NAME" GOVUK_APP_DOMAIN "$GOVUK_APP_DOMAIN"
-      cf set-env "$CF_APP_NAME" GOVUK_WEBSITE_ROOT "$WEBSITE_ROOT"
-      cf set-env "$CF_APP_NAME" KEYCLOAK_ADMIN_PASSWORD "$KEYCLOAK_ADMIN_PASSWORD"
-      cf set-env "$CF_APP_NAME" KEYCLOAK_ADMIN_USER "$KEYCLOAK_ADMIN_USER"
-      cf set-env "$CF_APP_NAME" KEYCLOAK_CLIENT_ID "$KEYCLOAK_CLIENT_ID"
-      cf set-env "$CF_APP_NAME" KEYCLOAK_CLIENT_SECRET "$KEYCLOAK_CLIENT_SECRET"
-      cf set-env "$CF_APP_NAME" KEYCLOAK_REALM_ID "$KEYCLOAK_REALM_ID"
-      cf set-env "$CF_APP_NAME" KEYCLOAK_SERVER_URL "$KEYCLOAK_SERVER_URL"
-      cf set-env "$CF_APP_NAME" NOTIFY_API_KEY "$NOTIFY_API_KEY"
-      cf set-env "$CF_APP_NAME" GOVUK_NOTIFY_TEMPLATE_ID "$NOTIFY_TEMPLATE_ID"
-      cf set-env "$CF_APP_NAME" REDIRECT_BASE_URL "$REDIRECT_BASE_URL"
+      cf set-env $CF_APP_NAME GOVUK_APP_DOMAIN "$APP_DOMAIN"
+      cf set-env $CF_APP_NAME GOVUK_WEBSITE_ROOT "$WEBSITE_ROOT"
+      cf set-env $CF_APP_NAME KEYCLOAK_ADMIN_PASSWORD "$KEYCLOAK_ADMIN_PASSWORD"
+      cf set-env $CF_APP_NAME KEYCLOAK_ADMIN_USER "$KEYCLOAK_ADMIN_USER"
+      cf set-env $CF_APP_NAME KEYCLOAK_CLIENT_ID "$KEYCLOAK_CLIENT_ID"
+      cf set-env $CF_APP_NAME KEYCLOAK_CLIENT_SECRET "$KEYCLOAK_CLIENT_SECRET"
+      cf set-env $CF_APP_NAME KEYCLOAK_REALM_ID "$KEYCLOAK_REALM_ID"
+      cf set-env $CF_APP_NAME KEYCLOAK_SERVER_URL "$KEYCLOAK_SERVER_URL"
+      cf set-env $CF_APP_NAME NOTIFY_API_KEY "$NOTIFY_API_KEY"
+      cf set-env $CF_APP_NAME GOVUK_NOTIFY_TEMPLATE_ID "$NOTIFY_TEMPLATE_ID"
+      cf set-env $CF_APP_NAME REDIRECT_BASE_URL "$KEYCLOAK_REDIRECT_BASE_URL"
 
-      cf v3-zdt-push "$CF_APP_NAME" --wait-for-deploy-complete --no-route
-      cf map-route "$CF_APP_NAME" cloudapps.digital --hostname "$HOSTNAME"
+      cf v3-zdt-push $CF_APP_NAME --wait-for-deploy-complete --no-route
+      cf map-route $CF_APP_NAME cloudapps.digital --hostname "$HOSTNAME"


### PR DESCRIPTION
Fixes the following:
- My linter had said that all git source URIs in resources should end in
.git. I'd changed that but left it pointing to the HTTPS source. URI's
for git resources should use the proper git@github ssh route

- Renamed and uploaded a correct private key to gain access to the
private repo (had to do it with hijack there may be a bug that adds
spaces instead of newlines in gds-api - will raise an issue).

- Having refactored the app instance out of the task and into a pipeline
variable, I needed to prepend it with a $ to be correctly interpolated
into the command.

- Corrected various naming errors

Amend concourse git link to use ssh protocol

Also a helpful test to see that when we merge into the main branch the pipeline updates itself