### PR TITLE
Add basic ping smoke test and govuk-slack notification

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -1,4 +1,10 @@
 ---
+resource_types:
+  - name: slack-notification
+    type: docker-image
+    source:
+      repository: cfcommunity/slack-notification-resource
+      tag: latest
 resources:
   - name: git-master
     type: git
@@ -7,6 +13,10 @@ resources:
       uri: git@github.com:alphagov/govuk-account-manager-prototype.git
       branch: master
       private_key: ((concourse_ci_github_ssh_read_only))
+  - name: govuk-slack
+    type: slack-notification
+    source:
+      url: https://hooks.slack.com/((slack_webhook_url))
 jobs:
   - name: update-pipeline
     plan:
@@ -40,4 +50,26 @@ jobs:
           KEYCLOAK_REDIRECT_BASE_URL: https://((keycloak-redirect-base-url))
           NOTIFY_API_KEY: ((notify-api-key))
           NOTIFY_TEMPLATE_ID: 6074fdc2-03b3-4bb6-83fe-31220779c13b
-
+  - name: ping-test
+    serial: true
+    plan:
+      - get: git-master
+        trigger: true
+        passed: [deploy-app]
+      - task: ping-smoke-test
+        file: git-master/concourse/tasks/ping-smoke-test.yml
+        timeout: 5m
+        params:
+          URL: 'https://govuk-account-manager.cloudapps.digital/register'
+          MESSAGE: "Checks that the application deployed to production is not serving HTTP error codes. If this fails, you should investigate immediately."
+        on_failure:
+          put: govuk-slack
+          params:
+            channel: '#govuk-accounts-tech'
+            username: 'Concourse (GOV.UK Accounts)'
+            icon_emoji: ':concourse:'
+            silent: true
+            text: |
+              :kaboom:
+              Production smoke tests for the GOV.UK Account manager have failed
+              Failed build: http://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME

--- a/concourse/tasks/ping-smoke-test.yml
+++ b/concourse/tasks/ping-smoke-test.yml
@@ -1,0 +1,14 @@
+
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: governmentpaas/curl-ssl
+run:
+  path: sh
+  args:
+    - '-c'
+    - |
+      set -eu
+      echo "$MESSAGE"
+      curl --fail --silent --verbose "$URL"


### PR DESCRIPTION
Will give us some kind of heads up if a deploy ever fails.

We can add more expansive smoke tests if we get around to having integration tests we want to run against live.