### PR TITLE
Add HOSTNAME env var for deploying to PaaS

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -108,6 +108,7 @@ jobs:
           CF_STARTUP_TIMEOUT: 15 # minutes
           APP_INSTANCES: 1
           WORKER_INSTANCES: 1
+          HOSTNAME: govuk-account-manager
           REQUIRE_BASIC_AUTH: "true"
           BASIC_AUTH_USERNAME: ((basic-auth-username))
           BASIC_AUTH_PASSWORD: ((basic-auth-password))


### PR DESCRIPTION
This variable was missing so the application was never associated with a defined route.