### PR TITLE
Deploy app to staging and production

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -147,3 +147,34 @@ jobs:
               :kaboom:
               Production smoke tests for the GOV.UK Account manager have failed
               Failed build: http://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
+
+  - name: deploy-app-production
+    serial: true
+    plan:
+      - get: git-master
+        trigger: true
+        passed: [ping-test]
+      - task: deploy-to-paas
+        file: git-master/concourse/tasks/deploy-to-govuk-paas.yml
+        params:
+          CF_ORG: govuk_development
+          CF_APP_NAME: govuk-account-manager
+          CF_SPACE: production
+          CF_STARTUP_TIMEOUT: 15 # minutes
+          APP_INSTANCES: 1
+          WORKER_INSTANCES: 1
+          HOSTNAME: govuk-account-manager
+          REQUIRE_BASIC_AUTH: "true"
+          BASIC_AUTH_USERNAME: ((basic-auth-username))
+          BASIC_AUTH_PASSWORD: ((basic-auth-password))
+          APP_DOMAIN: www.gov.uk
+          WEBSITE_ROOT: https://www.gov.uk
+          KEYCLOAK_ADMIN_PASSWORD: ((keycloak-admin-password))
+          KEYCLOAK_ADMIN_USER: ((keycloak-admin-user))
+          KEYCLOAK_CLIENT_ID: ((keycloak-client-id))
+          KEYCLOAK_CLIENT_SECRET: ((keycloak-client-secret))
+          KEYCLOAK_REALM_ID: master
+          KEYCLOAK_SERVER_URL: https://govuk-keycloak.cloudapps.digital/auth
+          KEYCLOAK_REDIRECT_BASE_URL: https://((keycloak-redirect-base-url))
+          NOTIFY_API_KEY: ((notify-api-key))
+          NOTIFY_TEMPLATE_ID: 6074fdc2-03b3-4bb6-83fe-31220779c13b


### PR DESCRIPTION
This will deploy the application to staging and production spaces in the GOV.UK PaaS, rather than the sandbox space as at the moment.

I've left the number of app and worker instances at 1 for now.  This will reduce the hosting cost prior to making this public facing, when the number of instances will need to be increased.

Once Keycloak has been deployed to staging and production, the URLs in `pipeline.yml` will need updating to reflect any changes in the route and credentials for staging.

Not to be merged until the `govuk-account-manager` app in `sandbox` is deleted and the `govuk-account-manager.cloudapps.digital` route becomes available again.

Trello card: https://trello.com/c/TBgzi9MY