### PR TITLE
Bind Redis service to PaaS app

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -3,3 +3,5 @@ applications:
 - name: govuk-account-manager
   buildpack: ruby_buildpack
   memory: 2G
+  services:
+    - govuk-account-manager-redis


### PR DESCRIPTION
We had previously bound the Redis service to the PaaS app using the CF CLI.  This adds the binding to the manifest so the binding is done automatically for future deployments.

Trello card: https://trello.com/c/TBgzi9MY