### PR TITLE
Run ping tests against staging and production

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -178,3 +178,27 @@ jobs:
           KEYCLOAK_REDIRECT_BASE_URL: https://((keycloak-redirect-base-url))
           NOTIFY_API_KEY: ((notify-api-key))
           NOTIFY_TEMPLATE_ID: 6074fdc2-03b3-4bb6-83fe-31220779c13b
+
+  - name: ping-test-production
+    serial: true
+    plan:
+      - get: git-master
+        trigger: true
+        passed: [deploy-app-production]
+      - task: ping-smoke-test
+        file: git-master/concourse/tasks/ping-smoke-test.yml
+        timeout: 5m
+        params:
+          URL: 'https://((basic-auth-username)):((basic-auth-password))@govuk-account-manager.cloudapps.digital/register'
+          MESSAGE: "Checks that the application deployed to production is not serving HTTP error codes. If this fails, you should investigate immediately."
+        on_failure:
+          put: govuk-slack
+          params:
+            channel: '#govuk-accounts-tech'
+            username: 'Concourse (GOV.UK Accounts)'
+            icon_emoji: ':concourse:'
+            silent: true
+            text: |
+              :kaboom:
+              Production smoke tests for the GOV.UK Account manager have failed
+              Failed build: http://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME


### PR DESCRIPTION
This updates the existing ping smoke test to run against staging, and adds a new ping smoke test against the production deployment.

Trello card: https://trello.com/c/TBgzi9MY