### PR TITLE
Use a service account when administering Keycloak

### DIFF
--- a/config/initializers/keycloak.rb
+++ b/config/initializers/keycloak.rb
@@ -1,11 +1,9 @@
 KeycloakAdmin.configure do |config|
-  config.use_service_account = false
+  config.use_service_account = true
   config.server_url          = ENV["KEYCLOAK_SERVER_URL"]
   config.server_domain       = ENV["KEYCLOAK_SERVER_DOMAIN"]
   config.client_id           = ENV["KEYCLOAK_ADMIN_CLIENT_ID"]
   config.client_realm_name   = ENV["KEYCLOAK_REALM_ID"]
-  config.username            = ENV["KEYCLOAK_ADMIN_USER"]
-  config.password            = ENV["KEYCLOAK_ADMIN_PASSWORD"]
   config.client_id           = ENV["KEYCLOAK_CLIENT_ID"]
   config.client_secret       = ENV["KEYCLOAK_CLIENT_SECRET"]
   config.logger              = Rails.logger


### PR DESCRIPTION
This will remove the need for a user account (with username and password) to be set up for the account manager app to use in order to administer Keycloak.  Instead the client's default service account will be used.

It requires the service account to be configured in Keycloak before this can be deployed.

Trello card: https://trello.com/c/TBgzi9MY