### PR TITLE
Do not attempt to set REDIRECT_BASE_URL env var

### DIFF
--- a/concourse/tasks/deploy-to-govuk-paas.yml
+++ b/concourse/tasks/deploy-to-govuk-paas.yml
@@ -46,7 +46,6 @@ run:
       cf set-env $CF_APP_NAME KEYCLOAK_SERVER_URL "$KEYCLOAK_SERVER_URL"
       cf set-env $CF_APP_NAME NOTIFY_API_KEY "$NOTIFY_API_KEY"
       cf set-env $CF_APP_NAME GOVUK_NOTIFY_TEMPLATE_ID "$NOTIFY_TEMPLATE_ID"
-      cf set-env $CF_APP_NAME REDIRECT_BASE_URL "$KEYCLOAK_REDIRECT_BASE_URL"
 
       cf v3-zdt-push $CF_APP_NAME --wait-for-deploy-complete --no-route
       cf map-route $CF_APP_NAME cloudapps.digital --hostname "$HOSTNAME"


### PR DESCRIPTION
This env var was removed from the deployment in a previous commit, but hadn't been removed from the deploy to PaaS task, therefore deployment was failing.

Trello card: https://trello.com/c/TBgzi9MY