### PR TITLE
Append https:// to base redirect URL

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -120,7 +120,7 @@ Rails.application.configure do
   end
 
   config.redirect_base_url = if ENV["VCAP_APPLICATION"].present?
-                               JSON.parse(ENV.fetch("VCAP_APPLICATION")).to_h.fetch("uris", []).first
+                               "https://" + JSON.parse(ENV.fetch("VCAP_APPLICATION")).to_h.fetch("uris", []).first
                              else
                                ENV["REDIRECT_BASE_URL"]
                              end


### PR DESCRIPTION
This was lost since PaaS gives us the hostname without protocol, therefore redirects were failing since the protocol was not being specified.

Trello card: https://trello.com/c/TBgzi9MY