### PR TITLE
Include an empty string when identifying the base URL

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -120,7 +120,7 @@ Rails.application.configure do
   end
 
   config.redirect_base_url = if ENV["VCAP_APPLICATION"].present?
-                               "https://" + JSON.parse(ENV.fetch("VCAP_APPLICATION")).to_h.fetch("uris", []).first
+                               "https://" + JSON.parse(ENV.fetch("VCAP_APPLICATION")).to_h.fetch("uris", [""]).first
                              else
                                ENV["REDIRECT_BASE_URL"]
                              end


### PR DESCRIPTION
For the worker process, we don't have (or need) a route so should just use an empty string as the default in this case since the current code causes the worker to fail to start.

I previously thought the link was constructed by the worker (rather than the web app), but I think I'm wrong.

Trello card: https://trello.com/c/TBgzi9MY