### PR TITLE
Include an empty JSON object as fallback when getting VCAP_APPLICATION

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -120,7 +120,7 @@ Rails.application.configure do
   end
 
   config.redirect_base_url = if ENV["VCAP_APPLICATION"].present?
-                               "https://" + JSON.parse(ENV.fetch("VCAP_APPLICATION")).to_h.fetch("uris", [""]).first
+                               "https://" + JSON.parse(ENV.fetch("VCAP_APPLICATION", "{}")).to_h.fetch("uris", [""]).first
                              else
                                ENV["REDIRECT_BASE_URL"]
                              end


### PR DESCRIPTION
For the worker process, we don't have (or need) a route so should just use an empty string as the default in this case.

The fix in #32 didn't work, and there's no way of getting a Rails console for the worker until we get the app running again.

Trello card: https://trello.com/c/TBgzi9MY