### PR TITLE
Fix .env.example syntax

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,14 +1,14 @@
-KEYCLOAK_ADMIN_USER: govuk
-KEYCLOAK_ADMIN_PASSWORD: mypassword
+KEYCLOAK_ADMIN_USER=govuk
+KEYCLOAK_ADMIN_PASSWORD=mypassword
 
-KEYCLOAK_REALM_ID: master
-KEYCLOAK_SERVER_URL: http://keycloak:8080/auth
-KEYCLOAK_CLIENT_ID: admin-cli
-KEYCLOAK_CLIENT_SECRET: dc06e777-1985-422b-85cd-15979fc7ab77
+KEYCLOAK_REALM_ID=master
+KEYCLOAK_SERVER_URL=http://keycloak:8080/auth
+KEYCLOAK_CLIENT_ID=admin-cli
+KEYCLOAK_CLIENT_SECRET=dc06e777-1985-422b-85cd-15979fc7ab77
 
-REDIRECT_BASE_URL: http://localhost:3000
+REDIRECT_BASE_URL=http://localhost:3000
 
-REDIS_URL: redis://localhost:6379/0
+REDIS_URL=redis://localhost:6379/0
 
-GOVUK_NOTIFY_TEMPLATE_ID: aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
-NOTIFY_API_KEY: foobarbazbatquxquux
+GOVUK_NOTIFY_TEMPLATE_ID=aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
+NOTIFY_API_KEY=foobarbazbatquxquux


### PR DESCRIPTION
This file is most useful as something you can copy paste, remove .example and have dotenv populate for a local dev setup.

The syntax for these files is KEY=value, instead of KEY: value.

This can be seen in dotenv's README on usage: 'https://github.com/bkeepers/dotenv#usage'