### PR TITLE
Do not get app URL from PaaS

### DIFF
--- a/concourse/tasks/deploy-to-govuk-paas.yml
+++ b/concourse/tasks/deploy-to-govuk-paas.yml
@@ -46,6 +46,7 @@ run:
       cf set-env $CF_APP_NAME KEYCLOAK_SERVER_URL "$KEYCLOAK_SERVER_URL"
       cf set-env $CF_APP_NAME NOTIFY_API_KEY "$NOTIFY_API_KEY"
       cf set-env $CF_APP_NAME GOVUK_NOTIFY_TEMPLATE_ID "$NOTIFY_TEMPLATE_ID"
+      cf set-env $CF_APP_NAME REDIRECT_BASE_URL "https://${HOSTNAME}.cloudapps.digital"
 
       cf v3-zdt-push $CF_APP_NAME --wait-for-deploy-complete --no-route
       cf map-route $CF_APP_NAME cloudapps.digital --hostname "$HOSTNAME"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -119,11 +119,7 @@ Rails.application.configure do
     end
   end
 
-  config.redirect_base_url = if ENV["VCAP_APPLICATION"].present?
-                               "https://" + JSON.parse(ENV.fetch("VCAP_APPLICATION", "{}")).to_h.fetch("uris", [""]).first
-                             else
-                               ENV["REDIRECT_BASE_URL"]
-                             end
+  config.redirect_base_url = ENV["REDIRECT_BASE_URL"]
 
   config.action_mailer.delivery_method = :notify
 end


### PR DESCRIPTION
We had attempted to get the app URL from the PaaS's auto environment variables, however this failed in the worker instance as that instance has no routes bound (see #32 and #33).

Therefore reverting back to using the hostname as specified in the concourse pipeline.

Reverts 98cf1d437155fd8fb1eddfbe2ab735a00baf5060

Trello card: https://trello.com/c/TBgzi9MY