### PR TITLE
Remove email placeholder from password reset confirmation

### DIFF
--- a/app/views/reset_password/submit.html.erb
+++ b/app/views/reset_password/submit.html.erb
@@ -7,7 +7,7 @@
       margin_bottom: 3,
     } %>
 
-    <p class="govuk-body"><%= sanitize(t("reset_password.sent.summary")) %></p>
+    <p class="govuk-body"><%= sanitize(t("reset_password.sent.summary", email: @email)) %></p>
 
 
     <%= render "govuk_publishing_components/components/heading", {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -104,7 +104,7 @@ en:
     no_such_user: "There is no such user"
     sent:
       title: "Password change request sent"
-      summary: "We’ve sent an email to name@example.com with instructions for changing your password."
+      summary: "We’ve sent an email to %{email} with instructions for changing your password."
       sub_heading: "If you did not get the email"
       resend_instructions: "We can <a class=\"govuk-link\" href=\"/reset-password\">send the password reset email again</a> if you did not get it."
   new_password:


### PR DESCRIPTION
There was a placeholder here rather than the user's correct email address.