### PR TITLE
Make app container attachable for binding.pry

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ version: '3.7'
 
 services:
   app:
+    tty: true
+    stdin_open: true
     build: .
     command: bash -c "rm -f tmp/pids/server.pid && bundle && bundle exec rails s -p 3000 -b '0.0.0.0'"
     environment:


### PR DESCRIPTION
If you drop binding.pry into the app currently docker-compose just glosses over it and carrys on. Not ideal if you want to explore or debug. This setting lets you spin up as normal eg: 'docker-compose up -d' and then run something like 'docker-compose attach app_1' at which point it will pause at a binding.pry and let you debug :tada:

it works:
![image](https://user-images.githubusercontent.com/3694062/85529904-6db6a700-b605-11ea-8258-eea5fc847070.png)
