### PR TITLE
Use older version of cf-cli image

### DIFF
--- a/concourse/tasks/deploy-to-govuk-paas.yml
+++ b/concourse/tasks/deploy-to-govuk-paas.yml
@@ -3,7 +3,7 @@ image_resource:
   type: docker-image
   source:
     repository: governmentpaas/cf-cli
-    tag: latest
+    tag: 5b44bd954693937ddd07ee6c9e113923bc620aed
 inputs:
   - name: git-master
     path: src


### PR DESCRIPTION
This will fix deployments until we update the script.

Copied from: https://github.com/alphagov/govuk-coronavirus-find-support/pull/329/files