### PR TITLE
Make login button return you to /account

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -7,7 +7,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
     client_secret: Rails.application.secrets.keycloak_client_secret,
     idp_base_uri: "#{ENV['KEYCLOAK_SERVER_URL']}/realms/#{ENV['KEYCLOAK_REALM_ID']}",
     redirect_uri: "#{ENV['REDIRECT_BASE_URL']}/auth/keycloak/callback",
-    return_to_prefix: "/account/",
-    return_to_default: "/account/manage",
+    return_to_prefix: "/account",
+    return_to_default: "/account",
   }
 end


### PR DESCRIPTION
The return_to_prefix is "/account/", but the login button sends you to
"/account/", which rails reports as "/account".  "/account/" is not a
prefix of "/account", so we were being sent to the default page, the
manage page.