### PR TITLE
Move application deployment to PaaS London region

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -102,7 +102,7 @@ jobs:
       - task: deploy-to-paas
         file: git-master/concourse/tasks/deploy-to-govuk-paas.yml
         params:
-          CF_ORG: govuk_development
+          CF_ORG: govuk-accounts
           CF_APP_NAME: govuk-account-manager
           CF_SPACE: staging
           CF_STARTUP_TIMEOUT: 15 # minutes
@@ -117,7 +117,7 @@ jobs:
           KEYCLOAK_CLIENT_ID: ((keycloak-client-id-staging))
           KEYCLOAK_CLIENT_SECRET: ((keycloak-client-secret-staging))
           KEYCLOAK_REALM_ID: master
-          KEYCLOAK_SERVER_URL: https://govuk-keycloak-staging.cloudapps.digital/auth
+          KEYCLOAK_SERVER_URL: https://govuk-keycloak-staging.london.cloudapps.digital/auth
           NOTIFY_API_KEY: ((notify-api-key))
           NOTIFY_TEMPLATE_ID: 6074fdc2-03b3-4bb6-83fe-31220779c13b
 
@@ -131,7 +131,7 @@ jobs:
         file: git-master/concourse/tasks/ping-smoke-test.yml
         timeout: 5m
         params:
-          URL: 'https://((basic-auth-username)):((basic-auth-password))@govuk-account-manager-staging.cloudapps.digital/register'
+          URL: 'https://((basic-auth-username)):((basic-auth-password))@govuk-account-manager-staging.london.cloudapps.digital/register'
           MESSAGE: "Checks that the application deployed to production is not serving HTTP error codes. If this fails, you should investigate immediately."
         on_failure:
           put: govuk-slack
@@ -154,7 +154,7 @@ jobs:
       - task: deploy-to-paas
         file: git-master/concourse/tasks/deploy-to-govuk-paas.yml
         params:
-          CF_ORG: govuk_development
+          CF_ORG: govuk-accounts
           CF_APP_NAME: govuk-account-manager
           CF_SPACE: production
           CF_STARTUP_TIMEOUT: 15 # minutes
@@ -169,7 +169,7 @@ jobs:
           KEYCLOAK_CLIENT_ID: ((keycloak-client-id))
           KEYCLOAK_CLIENT_SECRET: ((keycloak-client-secret))
           KEYCLOAK_REALM_ID: master
-          KEYCLOAK_SERVER_URL: https://govuk-keycloak.cloudapps.digital/auth
+          KEYCLOAK_SERVER_URL: https://govuk-keycloak.london.cloudapps.digital/auth
           NOTIFY_API_KEY: ((notify-api-key))
           NOTIFY_TEMPLATE_ID: 6074fdc2-03b3-4bb6-83fe-31220779c13b
 
@@ -183,7 +183,7 @@ jobs:
         file: git-master/concourse/tasks/ping-smoke-test.yml
         timeout: 5m
         params:
-          URL: 'https://((basic-auth-username)):((basic-auth-password))@govuk-account-manager.cloudapps.digital/register'
+          URL: 'https://((basic-auth-username)):((basic-auth-password))@govuk-account-manager.london.cloudapps.digital/register'
           MESSAGE: "Checks that the application deployed to production is not serving HTTP error codes. If this fails, you should investigate immediately."
         on_failure:
           put: govuk-slack

--- a/concourse/tasks/deploy-to-govuk-paas.yml
+++ b/concourse/tasks/deploy-to-govuk-paas.yml
@@ -8,7 +8,7 @@ inputs:
   - name: git-master
     path: src
 params:
-  CF_API: https://api.cloud.service.gov.uk
+  CF_API: https://api.london.cloud.service.gov.uk
   CF_USERNAME: ((paas-username))
   CF_PASSWORD: ((paas-password))
 
@@ -44,7 +44,7 @@ run:
       cf set-env $CF_APP_NAME KEYCLOAK_SERVER_URL "$KEYCLOAK_SERVER_URL"
       cf set-env $CF_APP_NAME NOTIFY_API_KEY "$NOTIFY_API_KEY"
       cf set-env $CF_APP_NAME GOVUK_NOTIFY_TEMPLATE_ID "$NOTIFY_TEMPLATE_ID"
-      cf set-env $CF_APP_NAME REDIRECT_BASE_URL "https://${HOSTNAME}.cloudapps.digital"
+      cf set-env $CF_APP_NAME REDIRECT_BASE_URL "https://${HOSTNAME}.london.cloudapps.digital"
 
       cf v3-zdt-push $CF_APP_NAME --wait-for-deploy-complete --no-route
-      cf map-route $CF_APP_NAME cloudapps.digital --hostname "$HOSTNAME"
+      cf map-route $CF_APP_NAME london.cloudapps.digital --hostname "$HOSTNAME"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -95,8 +95,8 @@ Rails.application.configure do
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 
-  # https://docs.cloud.service.gov.uk/deploying_services/redis
-  # https://docs.cloud.service.gov.uk/deploying_apps.html#system-provided-environment-variables
+  # https://docs.london.cloud.service.gov.uk/deploying_services/redis
+  # https://docs.london.cloud.service.gov.uk/deploying_apps.html#system-provided-environment-variables
   if ENV["VCAP_SERVICES"].present?
     redis = JSON.parse(ENV["VCAP_SERVICES"]).to_h.fetch("redis", [])
     instance = redis.first


### PR DESCRIPTION
GOV.UK Accounts now have a dedicated PaaS organisation in the London region.  Therefore updating the deployment pipeline to use this region instead of Ireland.

Trello card: https://trello.com/c/2JmH1gtVZ