### PR TITLE
Scale worker process after doing push to PaaS

### DIFF
--- a/concourse/tasks/deploy-to-govuk-paas.yml
+++ b/concourse/tasks/deploy-to-govuk-paas.yml
@@ -28,7 +28,6 @@ run:
       cf set-env $CF_APP_NAME CF_STARTUP_TIMEOUT "$CF_STARTUP_TIMEOUT"
 
       cf scale -i "$APP_INSTANCES" $CF_APP_NAME
-      cf v3-scale --process worker -i "$WORKER_INSTANCES" $CF_APP_NAME
 
       if [[ "${REQUIRE_BASIC_AUTH:-}" = "true" ]]; then
         cf set-env $CF_APP_NAME REQUIRE_BASIC_AUTH "$REQUIRE_BASIC_AUTH"
@@ -48,3 +47,5 @@ run:
 
       cf v3-zdt-push $CF_APP_NAME --wait-for-deploy-complete --no-route
       cf map-route $CF_APP_NAME london.cloudapps.digital --hostname "$HOSTNAME"
+
+      cf v3-scale --process worker -i "$WORKER_INSTANCES" $CF_APP_NAME


### PR DESCRIPTION
We are attempting to scale the worker process before pushing the application.  The scaling step fails since the worker process does not exist.

Therefore moving the scaling to occur after the application is pushed.

Trello card: https://trello.com/c/2JmH1gtVZ