### PR TITLE
Add translations for activerecord errors

### DIFF
--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -181,3 +181,19 @@ en:
       not_saved:
         one: "1 error prohibited this %{resource} from being saved:"
         other: "%{count} errors prohibited this %{resource} from being saved:"
+  activerecord:
+    errors:
+      models:
+        user:
+          attributes:
+            reset_password_token:
+              invalid: "This password reset link is invalid"
+            email:
+              blank: "Please provide an email address"
+              invalid: "Please enter a valid email address"
+            password:
+              blank: "Enter a valid password"
+              invalid: "Enter a valid password"
+              too_short: "Enter a valid password"
+            password_confirmation:
+              confirmation: "Passwords do not match"

--- a/spec/requests/edit_password_spec.rb
+++ b/spec/requests/edit_password_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "edit-password" do
       it "returns an error" do
         post account_password_path, params: params
 
-        expect(response.body).to have_content("Reset password token is invalid")
+        expect(response.body).to have_content(I18n.t("activerecord.errors.models.user.attributes.reset_password_token.invalid"))
       end
     end
 
@@ -61,7 +61,7 @@ RSpec.describe "edit-password" do
       it "returns an error" do
         post account_password_path, params: params
 
-        expect(response.body).to have_content("Password can't be blank")
+        expect(response.body).to have_content(I18n.t("activerecord.errors.models.user.attributes.password.blank"))
       end
     end
 
@@ -71,7 +71,7 @@ RSpec.describe "edit-password" do
       it "returns an error" do
         post account_password_path, params: params
 
-        expect(response.body).to have_content("Password confirmation doesn't match Password")
+        expect(response.body).to have_content(I18n.t("activerecord.errors.models.user.attributes.password_confirmation.confirmation"))
       end
     end
 
@@ -81,7 +81,7 @@ RSpec.describe "edit-password" do
       it "returns an error" do
         post account_password_path, params: params
 
-        expect(response.body).to have_content("Password confirmation doesn't match Password")
+        expect(response.body).to have_content(I18n.t("activerecord.errors.models.user.attributes.password_confirmation.confirmation"))
       end
     end
 
@@ -91,7 +91,7 @@ RSpec.describe "edit-password" do
       it "returns an error" do
         post account_password_path, params: params
 
-        expect(response.body).to have_content("Password is too short (minimum is 8 characters)")
+        expect(response.body).to have_content(I18n.t("activerecord.errors.models.user.attributes.password.too_short"))
       end
     end
 
@@ -101,7 +101,7 @@ RSpec.describe "edit-password" do
       it "returns an error" do
         post account_password_path, params: params
 
-        expect(response.body).to have_content("Password is invalid")
+        expect(response.body).to have_content(I18n.t("activerecord.errors.models.user.attributes.password.invalid"))
       end
     end
   end

--- a/spec/requests/register_spec.rb
+++ b/spec/requests/register_spec.rb
@@ -51,7 +51,17 @@ RSpec.describe "register" do
       it "shows an error" do
         post new_user_registration_path, params: params
 
-        expect(response.body).to have_content("Email can't be blank")
+        expect(response.body).to have_content(I18n.t("activerecord.errors.models.user.attributes.email.blank"))
+      end
+    end
+
+    context "when the email is invalid" do
+      let(:email) { "foo" }
+
+      it "shows an error" do
+        post new_user_registration_path, params: params
+
+        expect(response.body).to have_content(I18n.t("activerecord.errors.models.user.attributes.email.invalid"))
       end
     end
 
@@ -61,7 +71,7 @@ RSpec.describe "register" do
       it "returns an error" do
         post new_user_registration_path, params: params
 
-        expect(response.body).to have_content("Password can't be blank")
+        expect(response.body).to have_content(I18n.t("activerecord.errors.models.user.attributes.password.blank"))
       end
     end
 
@@ -71,7 +81,7 @@ RSpec.describe "register" do
       it "returns an error" do
         post new_user_registration_path, params: params
 
-        expect(response.body).to have_content("Password confirmation doesn't match Password")
+        expect(response.body).to have_content(I18n.t("activerecord.errors.models.user.attributes.password_confirmation.confirmation"))
       end
     end
 
@@ -81,7 +91,7 @@ RSpec.describe "register" do
       it "returns an error" do
         post new_user_registration_path, params: params
 
-        expect(response.body).to have_content("Password confirmation doesn't match Password")
+        expect(response.body).to have_content(I18n.t("activerecord.errors.models.user.attributes.password_confirmation.confirmation"))
       end
     end
 
@@ -91,7 +101,7 @@ RSpec.describe "register" do
       it "returns an error" do
         post new_user_registration_path, params: params
 
-        expect(response.body).to have_content("Password is too short (minimum is 8 characters)")
+        expect(response.body).to have_content(I18n.t("activerecord.errors.models.user.attributes.password.too_short"))
       end
     end
 
@@ -101,7 +111,7 @@ RSpec.describe "register" do
       it "returns an error" do
         post new_user_registration_path, params: params
 
-        expect(response.body).to have_content("Password is invalid")
+        expect(response.body).to have_content(I18n.t("activerecord.errors.models.user.attributes.password.invalid"))
       end
     end
   end


### PR DESCRIPTION
These were copied from the old locale file.

---

[Trello card](https://trello.com/c/rYXwnGfe/170-ensure-all-error-messages-are-in-locale-files)