### PR TITLE
Reset confirmtaion screen

### DIFF
--- a/app/controllers/devise_registration_controller.rb
+++ b/app/controllers/devise_registration_controller.rb
@@ -27,6 +27,10 @@ class DeviseRegistrationController < Devise::RegistrationsController
 
 protected
 
+  def after_update_path_for(_resource)
+    account_confirmation_email_sent_path
+  end
+
   def after_sign_up_path_for(_resource)
     new_user_after_sign_up_path
   end

--- a/app/views/devise/registrations/confirmation_email_sent.html.erb
+++ b/app/views/devise/registrations/confirmation_email_sent.html.erb
@@ -1,0 +1,11 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("update_registration.title"),
+      heading_level: 1,
+      margin_top: 0,
+      margin_bottom: 3,
+    } %>
+
+    <%= sanitize(t("update_registration.instructions", account_link: user_root_path)) %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,6 +72,12 @@ en:
         label: "Create a GOV.UK account"
       action: |
         <p class="govuk-body"><a class="govuk-link" href="%{link}">Sign in to GOV.UK</a> if you already have an account.</p>
+  update_registration:
+    title: "Check your email"
+    instructions: |
+      <p class="govuk-body">We’ve sent you an email to confirm these changes.</p>
+      <p class="govuk-body">You will need to click on the confirmation link in the email to finish updating your account.</p>
+      <p class="govuk-body"><a class="govuk-link" href="%{account_link}">Go to your GOV.UK account</a>
   post_registration:
     title: "Confirm your email address"
     instructions: |

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,8 @@ Rails.application.routes.draw do
     put    "/account", to: "devise_registration#update"
     delete "/account", to: "devise_registration#destroy"
 
+    get "/account/confirmation-email-sent", to: "devise_registration#confirmation_email_sent"
+
     get  "/account/confirmation/new", to: "devise/confirmations#new", as: :new_user_confirmation
     get  "/account/confirmation", to: "devise/confirmations#show", as: :user_confirmation
     post "/account/confirmation", to: "devise/confirmations#create"


### PR DESCRIPTION
- Relates to: https://trello.com/c/iNy60wrg/167-show-confirmation-screens-for-password-resets

# What

Updates to password and emails just send the user back to the account screen with no confirmation.
This could leave users unsure if the change has taken effect.

If the update is successful, this PR changes the redirect to go to a confirmation screen with some text.

## What does it look like

[See gif in slack](https://gds.slack.com/archives/C011Y5SAY3U/p1595436489050400)
