### PR TITLE
Return pairwise and true subject ids in deanonymised response

### DIFF
--- a/app/controllers/api_deanonymise_token_controller.rb
+++ b/app/controllers/api_deanonymise_token_controller.rb
@@ -13,7 +13,11 @@ class ApiDeanonymiseTokenController < ApplicationController
     elsif token.expired?
       head 410
     else
-      respond_with token.as_json
+      render json: {
+        true_subject_identifier: token.resource_owner_id,
+        pairwise_subject_identifier: Doorkeeper::OpenidConnect::UserInfo.new(token).claims[:sub],
+        scopes: token.scopes.to_a,
+      }
     end
   end
 

--- a/spec/requests/api_deanonymise_token_spec.rb
+++ b/spec/requests/api_deanonymise_token_spec.rb
@@ -55,7 +55,11 @@ RSpec.describe "/api/v1/deanonymise-token" do
     it "can deanonymise tokens" do
       get deanonymise_token_path, params: params, headers: headers
       expect(response).to be_successful
-      expect(JSON.parse(response.body).deep_symbolize_keys).to eq(check_token.as_json.merge(scope: check_token.scopes.to_a))
+      expect(JSON.parse(response.body).deep_symbolize_keys).to eq({
+        pairwise_subject_identifier: Doorkeeper::OpenidConnect::UserInfo.new(check_token).claims[:sub],
+        scopes: check_token.scopes.to_a,
+        true_subject_identifier: user.id,
+      })
     end
 
     context "with an expired check token" do


### PR DESCRIPTION
The OIDC spec requires the UserInfo response to include the subject
identifier (s. 5.3.2).  So if we want the attribute service to serve
that endpoint, it needs to know what the pairwise identifier is.  It
still needs to know the true identifier, for storing attributes.

---

[Trello card](https://trello.com/c/hV6UTrKV/179-implement-oauth-oidc-flows-for-attribute-service)