### PR TITLE
Serve the OIDC UserInfo endpoint from the Attribute Service

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -123,6 +123,7 @@ jobs:
           NOTIFY_TEMPLATE_ID: 6074fdc2-03b3-4bb6-83fe-31220779c13b
           OIDC_SIGNING_KEY: ((oidc-signing-key-staging))
           OIDC_SALT: ((oidc-salt-staging))
+          ATTRIBUTE_SERVICE_URL: https://govuk-attribute-service-staging.london.cloudapps.digital
 
   - name: ping-test-staging
     serial: true
@@ -173,6 +174,7 @@ jobs:
           NOTIFY_TEMPLATE_ID: 6074fdc2-03b3-4bb6-83fe-31220779c13b
           OIDC_SIGNING_KEY: ((oidc-signing-key-production))
           OIDC_SALT: ((oidc-salt-production))
+          ATTRIBUTE_SERVICE_URL: https://govuk-attribute-service.london.cloudapps.digital
 
   - name: ping-test-production
     serial: true

--- a/concourse/tasks/deploy-to-govuk-paas.yml
+++ b/concourse/tasks/deploy-to-govuk-paas.yml
@@ -49,6 +49,8 @@ run:
       cf set-env $CF_APP_NAME OIDC_IDP_PRIVATE_KEY "$OIDC_SIGNING_KEY"
       cf set-env $CF_APP_NAME OIDC_IDP_SALT "$OIDC_SALT"
 
+      cf set-env $CF_APP_NAME ATTRIBUTE_SERVICE_URL "$ATTRIBUTE_SERVICE_URL"
+
       cf v3-zdt-push $CF_APP_NAME --wait-for-deploy-complete --no-route
       cf map-route $CF_APP_NAME london.cloudapps.digital --hostname "$HOSTNAME"
 

--- a/config/initializers/doorkeeper_openid_connect.rb
+++ b/config/initializers/doorkeeper_openid_connect.rb
@@ -48,3 +48,9 @@ Doorkeeper::OpenidConnect.configure do
   claims do
   end
 end
+
+module Doorkeeper::OpenidConnect::Helpers::Controller
+  def oauth_userinfo_url(*)
+    "#{ENV['ATTRIBUTE_SERVICE_URL']}/oidc/user_info"
+  end
+end

--- a/spec/requests/discovery_spec.rb
+++ b/spec/requests/discovery_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe "Doorkeeper::OpenidConnect::DiscoveryController", type: :request do
+  let(:attribute_service_url) { "https://attribute-service" }
+
+  before do
+    ENV["ATTRIBUTE_SERVICE_URL"] = attribute_service_url
+  end
+
+  it "includes the custom attribute service URL" do
+    get "/.well-known/openid-configuration"
+    expect(JSON.parse(response.body)).to include("userinfo_endpoint" => "#{attribute_service_url}/oidc/user_info")
+  end
+end


### PR DESCRIPTION
Serve this on a different domain by overriding the URL helper method which the controller in doorkeeper-openid_connect uses: https://github.com/doorkeeper-gem/doorkeeper-openid_connect/blob/b88fdda8469c2634833a56e47fe3b78da5fcd803/app/controllers/doorkeeper/openid_connect/discovery_controller.rb#L33