### PR TITLE
Change from allowing scopes to denying them

### DIFF
--- a/app/controllers/data_exchange_controller.rb
+++ b/app/controllers/data_exchange_controller.rb
@@ -1,7 +1,9 @@
 class DataExchangeController < ApplicationController
   before_action :authenticate_user!
 
-  SCOPES = [].freeze
+  DENYLIST_SCOPES = [
+    :openid,
+  ].freeze
 
   def show
     @data_exchanges = current_user
@@ -14,7 +16,7 @@ class DataExchangeController < ApplicationController
 private
 
   def grant_to_exchange(grant)
-    scopes = grant.scopes.map(&:to_sym) & SCOPES
+    scopes = grant.scopes.map(&:to_sym) - DENYLIST_SCOPES
     return if scopes.empty?
 
     {


### PR DESCRIPTION
Small tweaks ahead of prototyping pulling subscriptions as a scoped attributes:

We're likely to have many more scopes that we want to allow than deny (possibly just :openid that should be denied !). So it makes sense to switch this from an allow list to a deny list

This work has cropped up as I'm experimenting with adding some scopes along the lines of :'emailsubscriptions.read_only' and :'emailsubscriptions.write_only'. I'm alreadying having to add that in my factories, and in /config/initalizers/doorkeeper.rb. It would be nice to not have another place to maintain these!