### PR TITLE
[WIP] Authenticate Email Subscription list transfers

### DIFF
--- a/spec/factories/doorkeeper.rb
+++ b/spec/factories/doorkeeper.rb
@@ -1,5 +1,15 @@
 FactoryBot.define do
   factory :oauth_application, class: Doorkeeper::Application do
+    id            { 1 }
+    uid           { "8AGx4q2ltTBJU0KPlbOzjdWsmm3k80VVNkKjwGkcS1U" }
+    secret        { "SlRdBYZV7TB7PbktkQnHibXvyv2g2uNj3XeQjSa0gJA" }
+    confidential  { true }
+
+    factory :email_alert_api, class: Doorkeeper::Application do
+      name          { "Email Alert API" }
+      redirect_uri  { "http://localhost:3000/auth/email-subscriptions/callback" }
+      scopes        { :"emailsubscriptions.read_only" }
+    end
   end
 
   factory :oauth_access_token, class: Doorkeeper::AccessToken do


### PR DESCRIPTION
## What are we doing

We want to be able to allow the Email Alert API to authenticate against the `govuk-account-manager-prototype` to share subscription lists via a scope.

We should then be able to retrieve this subscripton list from the `govuk-attribute-service-prototype`.

NB This is just an exploritory test, we're not convinced at the moment that email subscriptions are best off in the attribute store, and there may be good reasons not to do so! But for now, we just want to find out how easy it is to do this!

## How does this PR contribute
- Builds off #84 and #82 
- Creates a factory

## TODO
- Finish defining a feature test to prove we can authorise against this scope. 
- Adds two new optional scopes that account manager can authorise (these will also need to be added to the `govuk-attribute-service-prototype` (WIP need to merge #84 first!):
  - `:"emailsubscriptions.read_only"`, and
  - `:"emailsubscriptions.read_write"`
- Write a test to prove the server can respond properly to a request with this scope.
- Copy this work across to attribute store