### PR TITLE
Implement a restrictive content security policy

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,10 +23,9 @@
 </head>
 
 <body class="govuk-template__body ">
-  <script>
+  <%= javascript_tag nonce: true do -%>
     document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
-
-  </script>
+  <% end -%>
 
   <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 

--- a/app/views/layouts/doorkeeper/application.html.erb
+++ b/app/views/layouts/doorkeeper/application.html.erb
@@ -23,10 +23,9 @@
 </head>
 
 <body class="govuk-template__body ">
-  <script>
+  <%= javascript_tag nonce: true do -%>
     document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
-
-  </script>
+  <% end -%>
 
   <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -48,5 +48,9 @@ module GovukAccountManagerPrototype
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    # Match the content security policy by disabling framing
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
+    config.action_dispatch.default_headers["X-Frame-Options"] = "DENY"
   end
 end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,27 +1,32 @@
 # frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Define an application-wide content security policy
 # For further information see the following documentation
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
-# Rails.application.config.content_security_policy do |policy|
-#   policy.default_src :self, :https
-#   policy.font_src    :self, :https, :data
-#   policy.img_src     :self, :https, :data
-#   policy.object_src  :none
-#   policy.script_src  :self, :https
-#   policy.style_src   :self, :https
+Rails.application.config.content_security_policy do |policy|
+  policy.default_src     :self
 
-#   # Specify URI for violation reports
-#   # policy.report_uri "/csp-violation-report-endpoint"
-# end
+  policy.base_uri        :none
+  policy.frame_ancestors :none
+  policy.frame_src       :none
+  policy.object_src      :none
+
+  # we're also setting a nonce, which will cause browsers which
+  # support nonces to ignore the :unsafe_inline directive.
+  policy.script_src      :self, :unsafe_inline
+
+  # Specify URI for violation reports
+  # policy.report_uri "/csp-violation-report-endpoint"
+end
 
 # If you are using UJS then enable automatic nonce generation
-# Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }
+Rails.application.config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
 
 # Set the nonce only to specific directives
-# Rails.application.config.content_security_policy_nonce_directives = %w(script-src)
+Rails.application.config.content_security_policy_nonce_directives = %w[script-src]
 
 # Report CSP violations to a specified URI
 # For further information see the following documentation:


### PR DESCRIPTION
An example of the header generated is (the nonce is unique to the request):

```
default-src 'self'; base-uri 'none'; frame-ancestors 'none'; frame-src 'none'; object-src 'none'; script-src 'self' 'unsafe-inline' 'nonce-ly0NVpdRJC7gEsqKP2ialQ=='
```

Only sources from the same origin are allowed; the `<applet>`, `<base>`, `<embed>`, `<iframe>`, `<object>`, tags are forbidden; embedding the app in an iframe is forbidden; and `<script>` tags must have nonces (if the browser supports that).

This gets a good score on this [CSP Evaluator](https://csp-evaluator.withgoogle.com/), with the only suggestions being:

- `script-src 'self'` is problematic if we have some types of dynamic or user-uploaded scripts, which we don't.
- `require-trusted-types-for` is missing, but `policy.require_trusted_types_for` isn't a thing.

The [default Rails security headers](https://guides.rubyonrails.org/security.html#default-headers) seem good as they are, other than `X-Frame-Options`, which I changed to `DENY` to match the CSP.

---

[Trello card](https://trello.com/c/CB3QyV68/182-set-up-content-security-policy)