### PR TITLE
Use application uid in pairwise subject identifier generation

### DIFF
--- a/config/initializers/doorkeeper_openid_connect.rb
+++ b/config/initializers/doorkeeper_openid_connect.rb
@@ -32,7 +32,7 @@ Doorkeeper::OpenidConnect.configure do
   end
 
   subject do |resource_owner, application|
-    Digest::SHA256.hexdigest("#{resource_owner.id}#{URI.parse(application.redirect_uri).host}#{Rails.application.secrets.oidc_idp_pepper}")
+    Digest::SHA256.hexdigest("#{resource_owner.id}#{application.uid}#{Rails.application.secrets.oidc_idp_pepper}")
   end
 
   # Protocol to use when generating URIs for the discovery endpoint,


### PR DESCRIPTION
Currently we're using

    hash(user + application uri + pepper)

Which means that an application can't change its uri, as all the user
identifiers will change.  Instead, use

    hash(user + application id + pepper)

The application ID won't change, so this is a more sensible hash.

The OIDC spec doesnt define how a pairwise subject identifier should
be computed, it only provides examples, so changing our algorithm is
fine.