### PR TITLE
Add email and deanonymise_tokens to scopes

### DIFF
--- a/config/locales/doorkeeper_openid_connect.en.yml
+++ b/config/locales/doorkeeper_openid_connect.en.yml
@@ -2,6 +2,7 @@ en:
   doorkeeper:
     scopes:
       openid: 'Authenticate your account'
+      email: 'View your email address'
     errors:
       messages:
         login_required: 'The authorization server requires end-user authentication'

--- a/config/scopes.yml
+++ b/config/scopes.yml
@@ -4,3 +4,4 @@ optional_scopes:
   - openid
   - account_manager_access
   - deanonymise_tokens
+  - email


### PR DESCRIPTION
I've discovered that we do need `deanonymise_tokens` there, as we've configured Doorkeeper to throw an error when creating an application with an unknown scope.

The `email` scope comes from https://github.com/alphagov/govuk-attribute-service-prototype/pull/11

---

[Trello card](https://trello.com/c/8qr9M2VL/197-store-email-address-in-the-attribute-service)