### PR TITLE
Allow logging in with an unconfirmed email address

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -143,7 +143,7 @@ Devise.setup do |config|
   # without confirming their account.
   # Default is 0.days, meaning the user cannot access the website without
   # confirming their account.
-  # config.allow_unconfirmed_access_for = 2.days
+  config.allow_unconfirmed_access_for = 7.days
 
   # A period that the user is allowed to confirm their account before their
   # token becomes invalid. For example, if set to 3.days, the user can confirm

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -91,7 +91,7 @@ en:
     title: "Confirm your email address"
     instructions: |
       <p class="govuk-body">We’ve sent you an email.</p>
-      <p class="govuk-body">You need to click on the confirmation link in the email to activate your GOV.UK account.</p>
+      <p class="govuk-body">You need to click on the confirmation link in the email to activate your GOV.UK account in the next 7 days.</p>
       <p class="govuk-body"><a class="govuk-link" href="%{account_link}">Go to your GOV.UK account</a>
     re_register_subtitle: "If you did not get the email or want to use a different address"
     re_register_instructions: |


### PR DESCRIPTION
This will be useful for creating an account while using a service, as
it doesn't interrupt the user journey to make them go check their
emails.

I picked 7 days somewhat arbitrarily.