### PR TITLE
Disable basic auth for deanonymise_tokens endpoint

### DIFF
--- a/app/controllers/api_deanonymise_token_controller.rb
+++ b/app/controllers/api_deanonymise_token_controller.rb
@@ -1,4 +1,4 @@
-class ApiDeanonymiseTokenController < ApplicationController
+class ApiDeanonymiseTokenController < Doorkeeper::ApplicationController
   before_action -> { doorkeeper_authorize! :deanonymise_tokens }
 
   respond_to :json


### PR DESCRIPTION
We have no basic auth on any of the OAuth / OIDC endpoints, as
Doorkeeper's controllers don't inherit from ApplicationController by
default.  This one does, so it's an inconsistency.

Rather than make the Attribute Service able to handle HTTP Basic Auth
on this one API route, just make it consistent with the others.

---

[Trello card](https://trello.com/c/IDkONf5z/230-put-the-apply-for-a-barking-permit-app-on-the-paas)