### PR TITLE
Use `head` instead of `render nothing` for fallback error pages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,7 +27,7 @@ protected
         @error = :internal_server_error
         render status: :internal_server_error, template: "standard_errors/generic"
       end
-      format.all { render status: :internal_server_error, nothing: true }
+      format.all { head :internal_server_error }
     end
   end
 end

--- a/app/controllers/standard_errors_controller.rb
+++ b/app/controllers/standard_errors_controller.rb
@@ -7,7 +7,7 @@ class StandardErrorsController < ApplicationController
         @error = :not_found
         render status: :not_found, template: "standard_errors/generic"
       end
-      format.all { render status: :not_found, nothing: true }
+      format.all { head :not_found }
     end
   end
 
@@ -17,7 +17,7 @@ class StandardErrorsController < ApplicationController
         @error = :unprocessable_entity
         render status: :unprocessable_entity, template: "standard_errors/generic"
       end
-      format.all { render status: :unprocessable_entity, nothing: true }
+      format.all { head :unprocessable_entity }
     end
   end
 


### PR DESCRIPTION
It seems this has been the preferred method since Rails 4, and the old
way doesn't seem to be working at all with Rails 6.