### PR TITLE
Remove type coercion from attribute manager response

### DIFF
--- a/app/lib/remote_user_info.rb
+++ b/app/lib/remote_user_info.rb
@@ -12,17 +12,7 @@ class RemoteUserInfo
   def user_info
     uri = "#{ENV['ATTRIBUTE_SERVICE_URL']}/oidc/user_info"
     response = RestClient.get uri, { accept: :json, authorization: "Bearer #{token.token}" }
-    JSON.parse(response.body).deep_symbolize_keys.transform_values do |v|
-      # TODO: think about types & schemas in the Attribute Service
-      case v
-      when "true"
-        true
-      when "false"
-        false
-      else
-        v
-      end
-    end
+    JSON.parse(response.body).deep_symbolize_keys
   rescue StandardError => e
     Raven.capture_exception(e)
     nil


### PR DESCRIPTION
We are now storing boolean values as booleans in the attribute service, so no longer need to coerce the type in the account manager.

Not to be merged until https://github.com/alphagov/govuk-attribute-service-prototype/pull/16 is merged and deployed.

Trello card: https://trello.com/c/fMBLbcHw