### PR TITLE
to_json attribute values on update

### DIFF
--- a/app/lib/remote_user_info.rb
+++ b/app/lib/remote_user_info.rb
@@ -31,12 +31,12 @@ class RemoteUserInfo
   def update_profile!
     RestClient.put(
       "#{ENV['ATTRIBUTE_SERVICE_URL']}/v1/attributes/email",
-      { value: @user.email },
+      { value: @user.email.to_json },
       { accept: :json, authorization: "Bearer #{token.token}" },
     )
     RestClient.put(
       "#{ENV['ATTRIBUTE_SERVICE_URL']}/v1/attributes/email_verified",
-      { value: @user.confirmed? },
+      { value: @user.confirmed?.to_json },
       { accept: :json, authorization: "Bearer #{token.token}" },
     )
   end

--- a/spec/unit/remote_user_info_spec.rb
+++ b/spec/unit/remote_user_info_spec.rb
@@ -78,10 +78,10 @@ RSpec.describe RemoteUserInfo, type: :unit do
       context "#update_profile!" do
         it "calls the attribute service to set the profile attributes" do
           email_stub = stub_request(:put, "#{attribute_service_url}/v1/attributes/email")
-            .with(headers: { accept: "application/json", authorization: "Bearer #{token.token}" }, body: { value: user.email })
+            .with(headers: { accept: "application/json", authorization: "Bearer #{token.token}" }, body: { value: user.email.to_json })
             .to_return(status: 200)
           email_verified_stub = stub_request(:put, "#{attribute_service_url}/v1/attributes/email_verified")
-            .with(headers: { accept: "application/json", authorization: "Bearer #{token.token}" }, body: { value: user.confirmed? })
+            .with(headers: { accept: "application/json", authorization: "Bearer #{token.token}" }, body: { value: user.confirmed?.to_json })
             .to_return(status: 200)
 
           described_class.new(user).update_profile!


### PR DESCRIPTION
This is needed for the email address (but it seems sensible to do it
for both fields), as an email address in itself isn't a valid JSON
string.

---

[Trello card](https://trello.com/c/fMBLbcHw/232-store-attribute-values-as-json)