### PR TITLE
Add a few tests around user tokens being expired or revoked

### DIFF
--- a/app/lib/account_manager_application.rb
+++ b/app/lib/account_manager_application.rb
@@ -13,7 +13,7 @@ class AccountManagerApplication
   def self.user_token(user_id)
     Doorkeeper::AccessToken.transaction do
       token = find_token(user_id)
-      token.nil? ? create_token(user_id) : token
+      token.nil? || token&.expired? ? create_token(user_id) : token
     end
   end
 


### PR DESCRIPTION
We don't currently expire or revoke the tokens used for communicating
with the Attribute Service, but I imagine we might like to one day:

1. If there's a bug which leaks access tokens, we'd want to revoke them
   all to issue new tokens.

2. To mitigate 1, we might want to set an expiry time on tokens.

So I thought there should be some tests making sure we correctly issue
new tokens when old ones are no longer valid.  This revealed a bug: if
only expired tokens exist, we wouldn't create a new one.