### PR TITLE
Gate dynamic client registration API behind an env var

### DIFF
--- a/app/controllers/api_register_client_controller.rb
+++ b/app/controllers/api_register_client_controller.rb
@@ -18,6 +18,13 @@ class ApiRegisterClientController < Doorkeeper::ApplicationController
   end
 
   def create
+    unless ENV["ENABLE_DYNAMIC_REGISTRATION"]
+      render status: :forbidden, json: {
+        error: "forbidden",
+        error_description: "Dynamic client registration API is disabled",
+      } and return
+    end
+
     if params["subject_type"].present? && params["subject_type"] != "pairwise"
       render status: :bad_request, json: {
         error: "unacceptable_subject_type",

--- a/spec/helpers/post_registration_helper_spec.rb
+++ b/spec/helpers/post_registration_helper_spec.rb
@@ -1,4 +1,8 @@
 RSpec.describe PostRegistrationHelper, type: :helper do
+  before do
+    ENV["ENABLE_DYNAMIC_REGISTRATION"] = "1"
+  end
+
   describe "#service_name_for" do
     let(:application) do
       FactoryBot.create(


### PR DESCRIPTION
We'll want to think about access control for this (does it play into
our mTLS ideas?).  For now just disable it unless an env var is set.