### PR TITLE
Lock users out for too many incorrect password attempts

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -194,7 +194,7 @@ Devise.setup do |config|
   # Defines which strategy will be used to lock an account.
   # :failed_attempts = Locks an account after a number of failed attempts to sign in.
   # :none            = No lock strategy. You should handle locking by yourself.
-  # config.lock_strategy = :failed_attempts
+  config.lock_strategy = :failed_attempts
 
   # Defines which key will be used when locking and unlocking an account
   # config.unlock_keys = [:email]
@@ -204,14 +204,14 @@ Devise.setup do |config|
   # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
   # :both  = Enables both strategies
   # :none  = No unlock strategy. You should handle unlocking by yourself.
-  # config.unlock_strategy = :both
+  config.unlock_strategy = :both
 
   # Number of authentication tries before locking an account if lock_strategy
   # is failed attempts.
-  # config.maximum_attempts = 20
+  config.maximum_attempts = 6
 
   # Time interval to unlock the account if :time is enabled as unlock_strategy.
-  # config.unlock_in = 1.hour
+  config.unlock_in = 1.hour
 
   # Warn on the last attempt before the account is locked.
   # config.last_attempt_warning = true


### PR DESCRIPTION
Lock someone out after 6 failed attempts, sending them an email with a
link to unlock the account.  Also unlock the account after 1 hour.

These settings are copied from Signon, so they should be pretty good.

---

[Trello card](https://trello.com/c/W9kTO3FQ/286-compare-account-security-settings-with-signon)