### PR TITLE
Add Precommit hooks with detect-secrets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/Yelp/detect-secrets
+    rev: v0.14.3
+    hooks:
+    -   id: detect-secrets
+        args: ['--baseline', '.secrets.baseline']
+        exclude: .*/spec/.*

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,333 @@
+{
+  "custom_plugin_paths": [],
+  "exclude": {
+    "files": null,
+    "lines": null
+  },
+  "generated_at": "2020-09-23T14:42:15Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    ".env.example": [
+      {
+        "hashed_secret": "745233cd45eaa8b050f60165b863ac973a2152e6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 6,
+        "type": "Secret Keyword"
+      }
+    ],
+    ".github/workflows/ci.yml": [
+      {
+        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 12,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 39,
+        "type": "Basic Auth Credentials"
+      }
+    ],
+    "README.md": [
+      {
+        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 43,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 49,
+        "type": "Basic Auth Credentials"
+      },
+      {
+        "hashed_secret": "491c5414edf678e36506389b7cdcd1d35dae8918",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 106,
+        "type": "Secret Keyword"
+      }
+    ],
+    "app/controllers/api/v1/register_client_controller.rb": [
+      {
+        "hashed_secret": "ce6725bf461f91d10258d9d1a33230348da3b094",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 47,
+        "type": "Secret Keyword"
+      }
+    ],
+    "app/models/activity.rb": [
+      {
+        "hashed_secret": "6f667d3e9627f5549ffeb1055ff294c34430b837",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 4,
+        "type": "Secret Keyword"
+      }
+    ],
+    "app/views/devise/sessions/new.html.erb": [
+      {
+        "hashed_secret": "06062101a81dd812ca9902fdf5f27ed472079d75",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 52,
+        "type": "Secret Keyword"
+      }
+    ],
+    "concourse/pipeline.yml": [
+      {
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 94,
+        "type": "Basic Auth Credentials"
+      }
+    ],
+    "concourse/tasks/deploy-to-govuk-paas.yml": [
+      {
+        "hashed_secret": "47748b1fd1747e8bff5493fa6c3bcf16d6449969",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 6,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "config/initializers/devise.rb": [
+      {
+        "hashed_secret": "6d6a768983c2fe5e02f811224549d0e34f9d5c02",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 17,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "config/initializers/mailer.rb": [
+      {
+        "hashed_secret": "26f3da68911137c980b40d6fc1542764f11cb3a7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2,
+        "type": "Secret Keyword"
+      }
+    ],
+    "config/locales/devise.en.yml": [
+      {
+        "hashed_secret": "6dbfd69451fe511cd7b5c20998b3f2fe99129c99",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 39,
+        "type": "Secret Keyword"
+      }
+    ],
+    "config/locales/en.yml": [
+      {
+        "hashed_secret": "3eb416223e9e69e6bb8ee19793911ad1ad2027d8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 37,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "c725f5d5486bdf839cce75a8b7b043b88214ccba",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 60,
+        "type": "Secret Keyword"
+      }
+    ],
+    "config/secrets.yml": [
+      {
+        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 41,
+        "type": "Private Key"
+      },
+      {
+        "hashed_secret": "3eb416223e9e69e6bb8ee19793911ad1ad2027d8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 75,
+        "type": "Secret Keyword"
+      }
+    ],
+    "db/seeds.rb": [
+      {
+        "hashed_secret": "22c547722fcb22f9bf489303a97e479842695d21",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 24,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "b73c8ebdf0468a1f646f78bca03a902f803b81a3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 32,
+        "type": "Secret Keyword"
+      }
+    ],
+    "spec/requests/api/v1/deanonymise_token_spec.rb": [
+      {
+        "hashed_secret": "b20a988cb8f956ff7b5a010966eaf211ca04609d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 6,
+        "type": "Secret Keyword"
+      }
+    ],
+    "spec/requests/api/v1/register_client_spec.rb": [
+      {
+        "hashed_secret": "5f5d7ce96eeee7d3f9fbb1bde381d9410d729603",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 145,
+        "type": "Secret Keyword"
+      }
+    ],
+    "spec/requests/data_exchange_spec.rb": [
+      {
+        "hashed_secret": "b20a988cb8f956ff7b5a010966eaf211ca04609d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 8,
+        "type": "Secret Keyword"
+      }
+    ],
+    "spec/requests/edit_password_spec.rb": [
+      {
+        "hashed_secret": "b20a988cb8f956ff7b5a010966eaf211ca04609d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 8,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "99a678500a26fd2bebc89925cd6298e4297c7933",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 38,
+        "type": "Secret Keyword"
+      }
+    ],
+    "spec/requests/new_password_spec.rb": [
+      {
+        "hashed_secret": "b20a988cb8f956ff7b5a010966eaf211ca04609d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 23,
+        "type": "Secret Keyword"
+      }
+    ],
+    "spec/requests/oauth_authorization_spec.rb": [
+      {
+        "hashed_secret": "b20a988cb8f956ff7b5a010966eaf211ca04609d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 8,
+        "type": "Secret Keyword"
+      }
+    ],
+    "spec/requests/welcome_spec.rb": [
+      {
+        "hashed_secret": "b20a988cb8f956ff7b5a010966eaf211ca04609d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 19,
+        "type": "Secret Keyword"
+      }
+    ],
+    "spec/unit/account_manager_application_spec.rb": [
+      {
+        "hashed_secret": "b20a988cb8f956ff7b5a010966eaf211ca04609d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 16,
+        "type": "Secret Keyword"
+      }
+    ],
+    "spec/unit/application_key_spec.rb": [
+      {
+        "hashed_secret": "53ea3a0ab90ec62ae79c6fc177c5e62c20ec68b3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 90,
+        "type": "Secret Keyword"
+      }
+    ],
+    "spec/unit/remote_user_info_spec.rb": [
+      {
+        "hashed_secret": "b20a988cb8f956ff7b5a010966eaf211ca04609d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 8,
+        "type": "Secret Keyword"
+      }
+    ]
+  },
+  "version": "0.14.3",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}

--- a/README.md
+++ b/README.md
@@ -6,6 +6,18 @@ A Prototype to explore how users might authenticate, authorise their data to be 
 
 Use [govuk-accounts-docker](https://github.com/alphagov/govuk-accounts-docker) to run this app together with the Attribute Service.
 
+### Pre-commit hooks & Detect Secrets
+
+This repo uses pre-commit hooks (https://pre-commit.com/) and the plugin detect-secrets (https://github.com/Yelp/detect-secrets) to prevent developers deploying secrets.
+Developers working with this repo should ensure they have pre-commit installed on their system before they attempt to commit and push changes.
+
+The [pre-commit project page](https://pre-commit.com/) has instructions on the many ways the tool can be installed.
+If you are using Brew on Mac or linuxbrew, an easy way is to:
+
+```
+brew install pre-commit
+```
+
 ### Sending emails locally
 
 You'll need to pass a GOV.UK Notify API key as an environment variable


### PR DESCRIPTION
Up until now this repo has been private and we've been careful about not committing secrets

However given the potential risk to users once a live prototype is deployed or beyond we want to avoid the risk of human errors with commits

This adds a .secrets.baseline file that contains a record of previous scans by precommit hooks (https://pre-commit.com/) and the detect-secrets plugin (https://github.com/Yelp/detect-secrets). The file contains a record of false-positives previously flagged by the tool, to prevent lots of boring repetition  for future devs just looking to commit their code.