### PR TITLE
Run pre-commit as a Github Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 on: [push, pull_request]
 
 jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - uses: pre-commit/action@v2.0.0
   test:
     runs-on: ubuntu-latest
 

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -4,7 +4,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-09-23T14:42:15Z",
+  "generated_at": "2020-09-24T10:37:50Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -73,14 +73,14 @@
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 12,
+        "line_number": 18,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 39,
+        "line_number": 45,
         "type": "Basic Auth Credentials"
       }
     ],


### PR DESCRIPTION
This will run our pre-commit configuration when pushing any branch to Github, and on creating a pull request.

By doing this, we will cover scenarios where developers do not have pre-commit installed and therefore have not run these checks before pushing their code.

The commit will be marked with a red X in Github and this will prevent a PR from being merged (provided the relevant branch protection rules have been configured):
![Screenshot 2020-09-24 at 11 40 08](https://user-images.githubusercontent.com/6329861/94135020-c000a180-fe5a-11ea-8372-eb5145d3667b.png)

PR for branch protection rules update: https://github.com/alphagov/govuk-saas-config/pull/60

Trello card: https://trello.com/c/OZH2YUIg