### PR TITLE
Redirect a logged in user from / to /account 

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -4,7 +4,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-09-25T10:41:31Z",
+  "generated_at": "2020-10-05T14:28:57Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -302,7 +302,7 @@
         "hashed_secret": "b20a988cb8f956ff7b5a010966eaf211ca04609d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 19,
+        "line_number": 46,
         "type": "Secret Keyword"
       }
     ],

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -2,6 +2,11 @@ class WelcomeController < ApplicationController
   skip_before_action :verify_authenticity_token, only: [:show]
 
   def show
+    if current_user
+      redirect_to user_root_path
+      return
+    end
+
     ApplicationKey.validate_jwt!(params[:jwt]) if params[:jwt]
 
     @email = params.dig(:user, :email)

--- a/spec/requests/welcome_spec.rb
+++ b/spec/requests/welcome_spec.rb
@@ -37,4 +37,25 @@ RSpec.describe "welcome" do
       end
     end
   end
+
+  context "the user is logged in" do
+    let(:user) do
+      FactoryBot.create(
+        :user,
+        email: "user@domain.tld",
+        password: "breadbread1",
+        password_confirmation: "breadbread1",
+      )
+    end
+
+    before do
+      sign_in(user)
+    end
+
+    it "redirects the user to the account page" do
+      get new_user_session_url
+
+      expect(response).to redirect_to(user_root_path)
+    end
+  end
 end


### PR DESCRIPTION
Previously, visiting / while logged in would give you the email
address form.  Entering your email address would take you to the login
form (because the account exists), which would then redirect you to
the accounts page (because you have a valid session).

This is a bit confusing, as it looks like you're logging in without
entering a password.

So this commit pushes the redirect to the / page directly.