### PR TITLE
Add a table for email subscription details

### DIFF
--- a/app/models/email_subscription.rb
+++ b/app/models/email_subscription.rb
@@ -1,0 +1,3 @@
+class EmailSubscription < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,6 +28,9 @@ class User < ApplicationRecord
   has_many :activities,
            dependent: :delete_all
 
+  has_many :email_subscriptions,
+           dependent: :delete_all
+
   after_commit :update_remote_user_info, on: %i[create update]
 
   # this has to happen before the record is actually destroyed because

--- a/db/migrate/20201012135851_create_email_subscription.rb
+++ b/db/migrate/20201012135851_create_email_subscription.rb
@@ -1,0 +1,11 @@
+class CreateEmailSubscription < ActiveRecord::Migration[6.0]
+  def change
+    create_table :email_subscriptions do |t|
+      t.references :user,       null: false
+      t.string     :topic_slug, null: false
+      t.string     :subscription_id
+    end
+
+    add_foreign_key :email_subscriptions, :users, column: :user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_18_160201) do
+ActiveRecord::Schema.define(version: 2020_10_12_135851) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,6 +31,13 @@ ActiveRecord::Schema.define(version: 2020_09_18_160201) do
     t.uuid "key_id", null: false
     t.string "pem", null: false
     t.index ["application_uid"], name: "index_application_keys_on_application_uid"
+  end
+
+  create_table "email_subscriptions", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "topic_slug", null: false
+    t.string "subscription_id"
+    t.index ["user_id"], name: "index_email_subscriptions_on_user_id"
   end
 
   create_table "oauth_access_grants", force: :cascade do |t|
@@ -116,6 +123,7 @@ ActiveRecord::Schema.define(version: 2020_09_18_160201) do
 
   add_foreign_key "activities", "oauth_applications"
   add_foreign_key "activities", "users"
+  add_foreign_key "email_subscriptions", "users"
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_grants", "users", column: "resource_owner_id"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"


### PR DESCRIPTION
This is used by a few of the email trello cards, so having it implemented first lets us work on those in parallel.

The schema is described [in this card](https://trello.com/c/5ZuuW1j7/430-store-email-topic-id-in-account-manager-database).