### PR TITLE
Add page asking if users want email notifications

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -4,7 +4,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2020-10-09T15:35:39Z",
+  "generated_at": "2020-10-13T08:59:32Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -300,7 +300,7 @@
         "hashed_secret": "53ea3a0ab90ec62ae79c6fc177c5e62c20ec68b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 14,
+        "line_number": 16,
         "type": "Secret Keyword"
       }
     ],

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -15,6 +15,7 @@ class WelcomeController < ApplicationController
         if User.exists?(email: @email)
           render "devise/sessions/new"
         else
+          @state = :needs_password
           render "devise/registrations/new"
         end
       else

--- a/app/helpers/error_items_helper.rb
+++ b/app/helpers/error_items_helper.rb
@@ -8,10 +8,11 @@ module ErrorItemsHelper
     end
   end
 
-  def devise_error_items(field)
-    return nil unless resource
+  def devise_error_items(field, resource_error_messages = nil)
+    raw_errors = resource ? resource.errors.messages : resource_error_messages
+    return nil unless raw_errors
 
-    all_errors = resource.errors.messages.map do |id, errors|
+    all_errors = raw_errors.map do |id, errors|
       errors.map do |error|
         { field: id, error: error }
       end

--- a/app/lib/registration_state_machine.rb
+++ b/app/lib/registration_state_machine.rb
@@ -1,0 +1,50 @@
+module RegistrationStateMachine
+  def self.call(params, jwt_payload)
+    state = nil
+    resource_error_messages = nil
+
+    password = params.dig(:user, :password) # pragma: allowlist secret
+    password_confirmation = params.dig(:user, :password_confirmation)
+    if password
+      password_format_ok = User::PASSWORD_REGEX.match? password
+      password_length_ok = Devise.password_length.include? password.length
+      password_confirmation_ok = password == password_confirmation
+
+      if password_format_ok && password_length_ok && password_confirmation_ok
+        email_topic_slug = (jwt_payload || {}).dig(:attributes, :transition_checker_state, "email_topic_slug")
+
+        if email_topic_slug
+          email_decision = params.dig(:email_decision)
+          email_decision_format_ok = %w[yes no].include? email_decision
+
+          if email_decision && email_decision_format_ok
+            state = :finish
+          else
+            state = :needs_email_decision
+            resource_error_messages = {
+              email_decision: email_decision ? [I18n.t("activerecord.errors.models.user.attributes.email_decision.invalid")] : nil,
+            }.compact
+          end
+        else
+          state = :finish
+        end
+      else
+        state = :needs_password
+        resource_error_messages = {
+          password: [ # pragma: allowlist secret
+            password_format_ok ? nil : I18n.t("activerecord.errors.models.user.attributes.password.invalid"),
+            password_length_ok ? nil : I18n.t("activerecord.errors.models.user.attributes.password.too_short"),
+          ],
+          password_confirmation: password_confirmation_ok ? nil : [I18n.t("activerecord.errors.models.user.attributes.password_confirmation.confirmation")],
+        }.compact
+      end
+    else
+      state = :needs_password
+    end
+
+    {
+      state: state,
+      resource_error_messages: resource_error_messages,
+    }
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,7 @@
 class User < ApplicationRecord
+  # any string with at least one digit in it
+  PASSWORD_REGEX = /\A.*[0-9].*\z/.freeze
+
   def send_devise_notification(notification, *args)
     devise_mailer.send(notification, self, *args).deliver_later
   end
@@ -13,7 +16,7 @@ class User < ApplicationRecord
          :trackable,
          :validatable
 
-  validates :password, format: { with: /\A.*[0-9].*\z/ }, allow_blank: true
+  validates :password, format: { with: PASSWORD_REGEX }, allow_blank: true
 
   has_many :access_grants,
            class_name: "Doorkeeper::AccessGrant",

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,49 +1,73 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/heading", {
-      text: t("devise.registrations.new.heading"),
+      text: t("devise.registrations.new.#{@state}.heading"),
       heading_level: 1,
       margin_top: 0,
       margin_bottom: 3,
     } %>
 
     <%= form_with(url: new_user_registration_post_path) do %>
-      <% if resource %>
-        <%= render "devise/shared/error_messages", resource: resource %>
-      <% end %>
-
-      <% if params[:previous_url] %>
-        <%= hidden_field_tag :previous_url, params[:previous_url] %>
-      <% end %>
-      <% if params[:jwt] %>
-        <%= hidden_field_tag :jwt, params[:jwt] %>
-      <% end %>
-
+      <% if params[:previous_url] %><%= hidden_field_tag :previous_url, params[:previous_url] %><% end %>
+      <% if params[:jwt] %><%= hidden_field_tag :jwt, params[:jwt] %><% end %>
       <%= hidden_field_tag :"user[email]", params.dig(:user, :email) %>
 
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: t("devise.registrations.new.fields.password.label"),
-        },
-        hint: t("devise.registrations.new.fields.password.hint"),
-        name: "user[password]",
-        type: "password",
-        id: "password",
-        error_message: devise_error_items(:password),
-      } %>
+      <% if @state == :needs_email_decision %>
+        <%= hidden_field_tag :"user[password]", params.dig(:user, :password) %>
+        <%= hidden_field_tag :"user[password_confirmation]", params.dig(:user, :password_confirmation) %>
 
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: t("devise.registrations.new.fields.password_confirm.label"),
-        },
-        name: "user[password_confirmation]",
-        type: "password",
-        id: "password_confirmation",
-        error_message: devise_error_items(:password_confirmation),
-      } %>
+        <%= sanitize(t("devise.registrations.new.needs_email_decision.description")) %>
+
+        <%= render "govuk_publishing_components/components/radio", {
+          name: "email_decision",
+          heading: t("devise.registrations.new.needs_email_decision.fields.emailsignup.heading"),
+          heading_size: "s",
+          error_message: devise_error_items(:email_decision, @resource_error_messages),
+          items: [
+            {
+              value: "yes",
+              text: t("devise.registrations.new.needs_email_decision.fields.emailsignup.yes")
+            },
+            {
+              value: "no",
+              text: t("devise.registrations.new.needs_email_decision.fields.emailsignup.no")
+            }
+          ]
+        } %>
+
+       <%= render "govuk_publishing_components/components/inset_text", {
+         text: t("devise.registrations.new.needs_email_decision.unsubscribe")
+       } %>
+
+      <% else %>
+        <% if resource || @resource_error_messages %>
+          <%= render "devise/shared/error_messages", resource: resource, resource_error_messages: @resource_error_messages %>
+        <% end %>
+
+        <%= render "govuk_publishing_components/components/input", {
+          label: {
+            text: t("devise.registrations.new.needs_password.fields.password.label"),
+          },
+          hint: t("devise.registrations.new.needs_password.fields.password.hint"),
+          name: "user[password]",
+          type: "password",
+          id: "password",
+          error_message: devise_error_items(:password, @resource_error_messages),
+        } %>
+
+        <%= render "govuk_publishing_components/components/input", {
+          label: {
+            text: t("devise.registrations.new.needs_password.fields.password_confirm.label"),
+          },
+          name: "user[password_confirmation]",
+          type: "password",
+          id: "password_confirmation",
+          error_message: devise_error_items(:password_confirmation, @resource_error_messages),
+        } %>
+      <% end %>
 
       <%= render "govuk_publishing_components/components/button", {
-        text: t("devise.registrations.new.fields.submit.label"),
+        text: t("devise.registrations.new.#{@state}.fields.submit.label"),
       } %>
     <% end %>
   </div>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,6 +1,9 @@
-<% resource_errors = resource.errors.messages.map { |field, errors| errors.map { |error| { field: field, error: error } } }.flatten %>
+<%
+raw_errors = resource ? resource.errors.messages : resource_error_messages
+resource_errors = raw_errors.map { |field, errors| errors.map { |error| { field: field, error: error } } }.flatten
+%>
 
-<% if resource.errors.any? %>
+<% if resource_errors.any? %>
   <%= render "govuk_publishing_components/components/error_summary", {
     title: I18n.t("errors.messages.headline"),
     items: resource_errors.map { |item|
@@ -13,7 +16,7 @@
 <% end %>
 
 <% if flash[:alert] %>
-  <% if previous_url_is_on_ignore_list(previous_url) %>
+  <% if previous_url_is_on_ignore_list(params[:previous_url]) %>
       <% remove_flash_alert %>
   <% else %>
     <%= render "govuk_publishing_components/components/error_summary", {

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -119,17 +119,36 @@ en:
       updated: "Your account has been updated successfully."
       updated_but_not_signed_in: "Your account has been updated successfully, but since your password was changed, you need to sign in again"
       new:
-        heading: "Create password"
-        fields:
-          email:
-            label: "Enter your email address"
-          password:
-            label: "Create a new password"
-            hint: "It needs to be at least 8 characters long and must include at least one number."
-          password_confirm:
-            label: "Retype password"
-          submit:
-            label: "Continue"
+        needs_password:
+          heading: "Create password"
+          fields:
+            email:
+              label: "Enter your email address"
+            password:
+              label: "Create a new password"
+              hint: "It needs to be at least 8 characters long and must include at least one number."
+            password_confirm:
+              label: "Retype password"
+            submit:
+              label: "Continue"
+        needs_email_decision:
+          heading: "Do you want to receive emails about the UK transition?"
+          description: |
+            <p class="govuk-body">The emails will tell you what you, your family, or your business should do to prepare for new rules from 1 January 2021.</p>
+            <p class="govuk-body">You will only get updates if:</p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>there are changes to your results</li>
+              <li>questions or results are added which may affect you</li>
+            </ul>
+            <p class="govuk-body">You’ll never get more than one email a day. The email will include all the updates made that day.</p>
+          unsubscribe: You can unsubscribe from emails or change your subscription at any time.
+          fields:
+            emailsignup:
+              heading: Do you want to receive emails about the UK transition?
+              yes: "Yes"
+              no: "No, I just want to save my results"
+            submit:
+              label: "Continue"
         sign_in: |
           <a class="govuk-link" href="%{login_url}>Sign in to GOV.UK</a> if you already have an account.
       edit:
@@ -199,3 +218,5 @@ en:
               too_short: "Enter a valid password"
             password_confirmation:
               confirmation: "Passwords do not match"
+            email_decision:
+              invalid: "Please select one option"

--- a/spec/requests/welcome_spec.rb
+++ b/spec/requests/welcome_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "welcome" do
         it "shows the registration form" do
           get new_user_session_url(user: { email: "no-such-user@domain.tld" })
 
-          expect(response.body).to have_content(I18n.t("devise.registrations.new.heading"))
+          expect(response.body).to have_content(I18n.t("devise.registrations.new.needs_password.heading"))
         end
       end
     end


### PR DESCRIPTION

<img width="760" alt="Screenshot 2020-10-13 at 09 41 00" src="https://user-images.githubusercontent.com/75235/95837447-88d62f80-0d38-11eb-830b-84340ae431c8.png">


This works by implementing a small state machine in the devise
registrations controller, deciding which page to show when the #create
endpoint is hit.

This is a bit complicated, but I'm not sure what a better solution
would be: we could create the account but in some sort of
"deactivated" state, and store the JWT alongside it, and then make it
so that trying to use a deactivated account sends you to the T&C page
and then the email alert consent form, but that introduces problems:

- can we even store the user's email address and attributes before
  they see the T&Cs?
- the login needs additional logic
- we'd have to stop devise from sending its confirmation email until
  the user has finished the registration process

So this complicated state machine may be a lesser evil for now.

---

[Trello card](https://trello.com/c/lpbvODc0/332-in-the-registration-flow-ask-whether-the-user-wants-email-alerts-if-a-topic-slug-is-given-in-the-jwt)