### PR TITLE
Add an endpoint to update an email subscription

### DIFF
--- a/app/models/email_subscription.rb
+++ b/app/models/email_subscription.rb
@@ -3,6 +3,19 @@ class EmailSubscription < ApplicationRecord
 
   before_destroy :deactivate_immediately
 
+  def activate_if_confirmed
+    return if subscription_id
+    return unless user.confirmed?
+
+    subscriber_list = Services.email_alert_api.get_subscriber_list(slug: topic_slug)
+
+    Services.email_alert_api.subscribe(
+      subscriber_list_id: subscriber_list.to_hash.dig("subscriber_list", "id"),
+      address: user.email,
+      frequency: "daily",
+    )
+  end
+
   def deactivate_immediately
     return unless subscription_id
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,6 +66,7 @@ Rails.application.routes.draw do
 
       scope "transition-checker", module: :transition_checker, as: :transition_checker do
         get "/email-subscription", to: "emails#show"
+        post "/email-subscription", to: "emails#update"
       end
     end
   end


### PR DESCRIPTION
If the user has confirmed their email address, this propagates the
change to email-alert-api immediately, otherwise it just updates the
slug stored in our database.

---

[Trello card](https://trello.com/c/u4bDlBsK/339-add-an-endpoint-to-account-manager-to-update-someones-email-subscription)