### PR TITLE
Update a user's email subscriptions after all confirmation actions

### DIFF
--- a/app/jobs/activate_email_subscriptions_job.rb
+++ b/app/jobs/activate_email_subscriptions_job.rb
@@ -2,6 +2,6 @@ class ActivateEmailSubscriptionsJob < ApplicationJob
   queue_as :default
 
   def perform(user_id)
-    User.find(user_id).email_subscriptions.find_each(&:activate_if_confirmed)
+    User.find(user_id).email_subscriptions.find_each(&:reactivate_if_confirmed)
   end
 end

--- a/app/models/email_subscription.rb
+++ b/app/models/email_subscription.rb
@@ -3,9 +3,10 @@ class EmailSubscription < ApplicationRecord
 
   before_destroy :deactivate_immediately
 
-  def activate_if_confirmed
-    return if subscription_id
+  def reactivate_if_confirmed
     return unless user.confirmed?
+
+    deactivate_immediately
 
     subscriber_list = Services.email_alert_api.get_subscriber_list(slug: topic_slug)
 

--- a/spec/jobs/activate_email_subscriptions_job_spec.rb
+++ b/spec/jobs/activate_email_subscriptions_job_spec.rb
@@ -19,8 +19,11 @@ RSpec.describe ActivateEmailSubscriptionsJob, type: :job do
         :email_subscription,
         user_id: user.id,
         topic_slug: "emails",
+        subscription_id: email_alert_api_subscription_id,
       )
     end
+
+    let(:email_alert_api_subscription_id) { nil }
 
     it "calls email-alert-api to create the subscription" do
       stub_subscriber_list = stub_email_alert_api_has_subscriber_list_by_slug(slug: subscription.topic_slug, returned_attributes: { id: "list-id" })
@@ -31,6 +34,23 @@ RSpec.describe ActivateEmailSubscriptionsJob, type: :job do
       expect(user.reload.email_subscriptions&.first&.subscription_id).to_not be_nil
       expect(stub_subscriber_list).to have_been_made
       expect(stub_activate).to have_been_made
+    end
+
+    context "the email subscription is already active" do
+      let(:email_alert_api_subscription_id) { "an-old-subscription" }
+
+      it "recreates the subscription" do
+        stub_subscriber_list = stub_email_alert_api_has_subscriber_list_by_slug(slug: subscription.topic_slug, returned_attributes: { id: "list-id" })
+        stub_activate = stub_email_alert_api_creates_a_subscription("list-id", user.email, "daily", "subscription-id")
+        stub_deactivate = stub_email_alert_api_unsubscribes_a_subscription(subscription.subscription_id)
+
+        described_class.perform_now user.id
+
+        expect(user.reload.email_subscriptions&.first&.subscription_id).to_not be_nil
+        expect(stub_subscriber_list).to have_been_made
+        expect(stub_activate).to have_been_made
+        expect(stub_deactivate).to have_been_made
+      end
     end
   end
 end


### PR DESCRIPTION
A user will confirm their email address in two cases:

1. They have just created their account, in which case any email
   subscriptions they have are not yet active.

2. They have just updated their email address, in which case any
   email subscriptions they have must be recreated.

This commit replaces the :activate_if_confirmed method with one which
does this delete-and-create in one go.

---

[Trello card](https://trello.com/c/ZAO9zsx2/342-change-the-email-address-of-the-linked-subscription-when-someone-confirms-a-new-email-address)