### PR TITLE
Disable CSRF protection for transition checker API endpoint

### DIFF
--- a/app/controllers/api/v1/transition_checker/emails_controller.rb
+++ b/app/controllers/api/v1/transition_checker/emails_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::TransitionChecker::EmailsController < Doorkeeper::ApplicationController
+  skip_before_action :verify_authenticity_token
+
   before_action -> { doorkeeper_authorize! :transition_checker }
 
   rescue_from ActionController::ParameterMissing do


### PR DESCRIPTION
This is an API endpoint so we explicitly want cross-site requests.