### PR TITLE
Send a 204 response for a valid email subscription

### DIFF
--- a/app/controllers/api/v1/transition_checker/emails_controller.rb
+++ b/app/controllers/api/v1/transition_checker/emails_controller.rb
@@ -12,12 +12,12 @@ class Api::V1::TransitionChecker::EmailsController < Doorkeeper::ApplicationCont
     subscription = user.email_subscriptions.first
 
     head 404 and return unless subscription
-    head 200 and return unless subscription.subscription_id
+    head 204 and return unless subscription.subscription_id
 
     begin
       state = Services.email_alert_api.get_subscription(subscription.subscription_id)
       has_ended = state.to_hash.dig("subscription", "ended_reason")
-      head has_ended ? 410 : 200
+      head has_ended ? 410 : 204
     rescue GdsApi::HTTPGone, GdsApi::HTTPNotFound
       head 410
     end

--- a/spec/requests/api/v1/transition_checker/emails_spec.rb
+++ b/spec/requests/api/v1/transition_checker/emails_spec.rb
@@ -61,9 +61,9 @@ RSpec.describe "/api/v1/transition-checker/*" do
         )
       end
 
-      it "returns a 200" do
+      it "returns a 204" do
         get api_v1_transition_checker_email_subscription_path, headers: headers
-        expect(response).to have_http_status(200)
+        expect(response).to have_http_status(204)
       end
 
       context "the subscription is disabled" do
@@ -78,9 +78,9 @@ RSpec.describe "/api/v1/transition-checker/*" do
       context "the subscription hasn't been activated" do
         let(:email_alert_api_subscription_id) { nil }
 
-        it "returns a 200" do
+        it "returns a 204" do
           get api_v1_transition_checker_email_subscription_path, headers: headers
-          expect(response).to have_http_status(200)
+          expect(response).to have_http_status(204)
         end
       end
     end


### PR DESCRIPTION
Rails converts the 200 into a 204 because there's no content, so
instead be explicit about it here.

---

[Trello card](https://trello.com/c/9UxDwIhI/340-in-the-update-flow-create-or-update-email-subscriptions)