### PR TITLE
Add bearer token for email-alert-api

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -119,6 +119,7 @@ jobs:
           BASIC_AUTH_PASSWORD: ((basic-auth-password))
           APP_DOMAIN: www.gov.uk
           WEBSITE_ROOT: https://www.gov.uk
+          EMAIL_ALERT_API_BEARER_TOKEN: ((email-alert-api-bearer-token))
           NOTIFY_API_KEY: ((notify-api-key))
           NOTIFY_TEMPLATE_ID: 6074fdc2-03b3-4bb6-83fe-31220779c13b
           NOTIFY_SMS_TEMPLATE_ID: 51f0410b-0367-4e24-bf4d-17019791b77d
@@ -175,6 +176,7 @@ jobs:
           BASIC_AUTH_PASSWORD: ((basic-auth-password))
           APP_DOMAIN: www.gov.uk
           WEBSITE_ROOT: https://www.gov.uk
+          EMAIL_ALERT_API_BEARER_TOKEN: ((email-alert-api-bearer-token))
           NOTIFY_API_KEY: ((notify-api-key))
           NOTIFY_TEMPLATE_ID: 6074fdc2-03b3-4bb6-83fe-31220779c13b
           NOTIFY_SMS_TEMPLATE_ID: 51f0410b-0367-4e24-bf4d-17019791b77d

--- a/concourse/tasks/deploy-to-govuk-paas.yml
+++ b/concourse/tasks/deploy-to-govuk-paas.yml
@@ -44,6 +44,8 @@ run:
       cf set-env $CF_APP_NAME FEATURE_FLAG_MFA "$FEATURE_FLAG_MFA"
       cf set-env $CF_APP_NAME REDIRECT_BASE_URL "https://${HOSTNAME}.london.cloudapps.digital"
 
+      cf set-env $CP_APP_NAME EMAIL_ALERT_API_BEARER_TOKEN "$EMAIL_ALERT_API_BEARER_TOKEN"
+
       cf set-env $CF_APP_NAME SENTRY_DSN "$SENTRY_DSN"
       cf set-env $CF_APP_NAME SENTRY_CURRENT_ENV "$CF_SPACE"
 


### PR DESCRIPTION
This will allow the account manager to communicate with email-alert-api.

The account manager has been registered as an [API user with the correct permissions](https://signon.publishing.service.gov.uk/api_users/18179/edit) and the bearer token deposited in Concourse secrets.

Trello card: https://trello.com/c/U0P11cQc