### PR TITLE
Fix bad references to translations

### DIFF
--- a/app/views/delete/show.html.erb
+++ b/app/views/delete/show.html.erb
@@ -29,7 +29,7 @@
         inline_layout: true
       } %>
 
-      <a href="<%= account_manage_path %>" class="govuk-link"><%= t("account.general.cancel") %></a>
+      <a href="<%= account_manage_path %>" class="govuk-link"><%= t("general.cancel") %></a>
     <% end %>
   </div>
 </div>

--- a/app/views/manage/show.html.erb
+++ b/app/views/manage/show.html.erb
@@ -16,19 +16,19 @@
       heading_level: 2,
       items: [
         {
-          field: t("account.general.email"),
+          field: t("general.email"),
           value: current_user.email,
           edit: {
             href: edit_user_registration_email_url,
-            text: t("account.general.change"),
+            text: t("general.change"),
           }
         },
         {
-          field: t("account.general.password"),
+          field: t("general.password"),
           value: "********",
           edit: {
             href: edit_user_registration_password_url,
-            text: t("account.general.change"),
+            text: t("general.change"),
           }
         }
       ]
@@ -56,18 +56,18 @@
       items: [
         {
           field: t("account.manage.privacy.cookies_question") + t("account.manage.privacy.cookies_description"),
-          value: t("account.general.yes"),
+          value: t("general.yes"),
           edit: {
             href: "",
-            text: t("account.general.change"),
+            text: t("general.change"),
           }
         },
         {
           field: t("account.manage.privacy.email_question") + t("account.manage.privacy.email_description"),
-          value: t("account.general.yes"),
+          value: t("general.yes"),
           edit: {
             href: "",
-            text: t("account.general.change"),
+            text: t("general.change"),
           }
         }
       ]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,8 +32,8 @@
 en:
   general:
     change: Change
-    yes: Yes
-    no: No
+    "yes": "Yes"
+    "no": "No"
     email: Email
     password: Password
     cancel: Cancel


### PR DESCRIPTION
These entries are under `general`, not `account.general`.  The reason
this didn't show up in the views is because if the translation doesn't
exist, Rails defaults to the capitalised form of the last component of
the name, which was coincidentally correct.

Also `yes` and `no` are interpreted as booleans in YAML unless
quoted (even in key names).