### PR TITLE
Consent page

### DIFF
--- a/app/controllers/devise_registration_controller.rb
+++ b/app/controllers/devise_registration_controller.rb
@@ -108,18 +108,47 @@ class DeviseRegistrationController < Devise::RegistrationsController
 
   def your_information
     redirect_to url_for_state unless registration_state.state == "your_information"
+    @consents = {}
   end
 
   def your_information_post
     redirect_to url_for_state unless registration_state.state == "your_information"
 
-    email_topic_slug = registration_state.jwt_payload&.dig("attributes", "transition_checker_state", "email_topic_slug")
-    if email_topic_slug
-      registration_state.update!(state: :transition_emails)
-      redirect_to new_user_registration_transition_emails_path(registration_state_id: @registration_state_id)
+    cookie_consent_decision = params.dig(:cookie_consent)
+    cookie_consent_decision_format_ok = %w[yes no].include? cookie_consent_decision
+
+    feedback_consent_decision = params.dig(:feedback_consent)
+    feedback_consent_decision_format_ok = %w[yes no].include? feedback_consent_decision
+
+    @resource_error_messages = {}
+    @consents = {}
+
+    if cookie_consent_decision_format_ok
+      registration_state.update!(cookie_consent: cookie_consent_decision == "yes")
+      @consents[:cookie_consent_decision] = cookie_consent_decision
     else
-      redirect_to new_user_registration_finish_path(registration_state_id: @registration_state_id)
+      @resource_error_messages[:cookie_consent] = [I18n.t("activerecord.errors.models.user.attributes.cookie_consent_decision.invalid")]
     end
+
+    if feedback_consent_decision_format_ok
+      registration_state.update!(feedback_consent: feedback_consent_decision == "yes")
+      @consents[:feedback_consent_decision] = feedback_consent_decision
+    else
+      @resource_error_messages[:feedback_consent] = [I18n.t("activerecord.errors.models.user.attributes.feedback_consent_decision.invalid")]
+    end
+
+    if !registration_state.cookie_consent.nil? && !registration_state.feedback_consent.nil?
+      email_topic_slug = registration_state.jwt_payload&.dig("attributes", "transition_checker_state", "email_topic_slug")
+      if email_topic_slug
+        registration_state.update!(state: :transition_emails)
+        redirect_to new_user_registration_transition_emails_path(registration_state_id: @registration_state_id)
+      else
+        redirect_to new_user_registration_finish_path(registration_state_id: @registration_state_id)
+      end
+      return
+    end
+
+    render :your_information
   end
 
   def transition_emails

--- a/app/views/devise/registrations/your_information.html.erb
+++ b/app/views/devise/registrations/your_information.html.erb
@@ -3,12 +3,59 @@
     <%= render "govuk_publishing_components/components/heading", {
       text: t("devise.registrations.your_information.heading"),
       heading_level: 1,
-      margin_top: 0,
       margin_bottom: 3,
     } %>
 
+    <%= sanitize(t("devise.registrations.your_information.description")) %>
+
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("devise.registrations.your_information.data_choice_heading"),
+      heading_level: 2,
+      font_size: "m",
+      margin_bottom: 3,
+    } %>
+
+    <%= sanitize(t("devise.registrations.your_information.data_choice_description")) %>
+
     <%= form_with(url: new_user_registration_your_information_path(registration_state_id: @registration_state_id), method: :post) do %>
-      <p class="govuk-body">When we have the final terms & conditions text, it will go here.</p>
+
+      <%= render "govuk_publishing_components/components/radio", {
+        name: "cookie_consent",
+        heading: t("devise.registrations.your_information.fields.cookie_consent.heading"),
+        heading_size: "s",
+        error_message: devise_error_items(:cookie_consent, @resource_error_messages),
+        items: [
+          {
+            value: "yes",
+            text: t("devise.registrations.your_information.fields.cookie_consent.yes"),
+            checked: @consents.fetch(:cookie_consent_decision, nil) == "yes"
+          },
+          {
+            value: "no",
+            text: t("devise.registrations.your_information.fields.cookie_consent.no"),
+            checked: @consents.fetch(:cookie_consent_decision, nil) == "no"
+          }
+        ]
+      } %>
+
+      <%= render "govuk_publishing_components/components/radio", {
+        name: "feedback_consent",
+        heading: t("devise.registrations.your_information.fields.feedback_consent.heading"),
+        heading_size: "s",
+        error_message: devise_error_items(:feedback_consent, @resource_error_messages),
+        items: [
+          {
+            value: "yes",
+            text: t("devise.registrations.your_information.fields.feedback_consent.yes"),
+            checked: @consents.fetch(:feedback_consent_decision, nil) == "yes"
+          },
+          {
+            value: "no",
+            text: t("devise.registrations.your_information.fields.feedback_consent.no"),
+            checked: @consents.fetch(:feedback_consent_decision, nil) == "no"
+          }
+        ]
+      } %>
 
       <%= render "govuk_publishing_components/components/button", {
         text: t("devise.registrations.your_information.fields.submit.label"),

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -132,7 +132,30 @@ en:
             label: Continue
       your_information:
         heading: Control how we use information about you
+        description: |
+          <p class="govuk-body">Your GOV.UK account will only store the information you’ve chosen to provide about yourself. You can access, update or permanently delete your account and all the information stored in it at any time.</p>
+          <p class="govuk-body">We will never:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>sell or rent your information to third parties</li>
+            <li>share your information with third parties for marketing purposes</li>
+          </ul>
+          <p class="govuk-body">As we add new features to your account, we may ask if we can share your information with other parts of government to help us provide more efficient online services that are relevant to you. We will always ask your permission beforehand.</p>
+          <p class="govuk-body">You can read the <a href="https://gov.uk/help/privacy-notice" class="govuk-link">full privacy notice</a> for more detail on how your information is stored, shared and used.</p>
+        data_choice_heading: Data about how you use GOV.UK
+        data_choice_description: |
+          <p class="govuk-body">We’d like to use cookies to collect anonymised analytics about how you use GOV.UK, for example what pages you visit and what you click on.</p>
+          <p class="govuk-body">This data shows us what is and isn’t working, and helps us understand where we can male improvements to GOV.UK.</p>
         fields:
+          cookie_consent:
+            heading: Can we use cookies to learn about how you use GOV.UK while you’re signed in to your account?
+            hint: You’ll be able to update this later in your privacy settings if you’re not sure or you change your mind.
+            "yes": "Yes"
+            "no": "No"
+          feedback_consent:
+            heading: Can we email you to ask for feedback about your account?
+            hint: You can update this later in your privacy settings if you’re not sure or you change your mind.
+            "yes": "Yes"
+            "no": "No"
           submit:
             label: Continue
       transition_emails:
@@ -220,5 +243,9 @@ en:
               too_short: "Enter a valid password"
             password_confirmation:
               confirmation: "Passwords do not match"
+            cookie_consent_decision:
+              invalid: "Please select an option"
+            feedback_consent_decision:
+              invalid: "Please select an option"
             email_decision:
               invalid: "Please select one option"

--- a/db/migrate/20201020131956_add_consent_to_registration_state.rb
+++ b/db/migrate/20201020131956_add_consent_to_registration_state.rb
@@ -1,0 +1,6 @@
+class AddConsentToRegistrationState < ActiveRecord::Migration[6.0]
+  def change
+    add_column :registration_states, :cookie_consent, :boolean
+    add_column :registration_states, :feedback_consent, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_20_102250) do
+ActiveRecord::Schema.define(version: 2020_10_20_131956) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -115,6 +115,8 @@ ActiveRecord::Schema.define(version: 2020_10_20_102250) do
     t.string "phone_code"
     t.datetime "phone_code_generated_at"
     t.integer "mfa_attempts"
+    t.boolean "cookie_consent"
+    t.boolean "feedback_consent"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/feature/registration_from_another_application_spec.rb
+++ b/spec/feature/registration_from_another_application_spec.rb
@@ -162,6 +162,12 @@ RSpec.feature "Registration (coming from another application)" do
     fill_in "phone_code", with: phone_code
     click_on I18n.t("mfa.phone.code.fields.submit.label")
 
+    i_consent_my_information_being_used
+  end
+
+  def i_consent_my_information_being_used
+    within(".govuk-form-group:first-of-type") { choose "Yes" }
+    within(".govuk-form-group:last-of-type") { choose "Yes" }
     click_on I18n.t("devise.registrations.your_information.fields.submit.label")
   end
 

--- a/spec/feature/registration_spec.rb
+++ b/spec/feature/registration_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "Registration" do
     enter_password_and_confirmation
     enter_phone_number
     enter_mfa
-    accept_terms
+    provide_consent
 
     expect(page).to have_text(I18n.t("post_registration.heading"))
 
@@ -30,7 +30,7 @@ RSpec.feature "Registration" do
     enter_password_and_confirmation
     enter_phone_number
     enter_mfa
-    accept_terms
+    provide_consent
 
     assert_enqueued_jobs 1, only: NotifyDeliveryJob
   end
@@ -187,7 +187,7 @@ RSpec.feature "Registration" do
     it "skips over the MFA screens" do
       enter_email_address
       enter_password_and_confirmation
-      accept_terms
+      provide_consent
 
       expect(page).to have_text(I18n.t("post_registration.heading"))
 
@@ -231,7 +231,9 @@ RSpec.feature "Registration" do
     click_on I18n.t("mfa.phone.code.fields.submit.label")
   end
 
-  def accept_terms
+  def provide_consent
+    within(".govuk-form-group:first-of-type") { choose "Yes" }
+    within(".govuk-form-group:last-of-type") { choose "No" }
     click_on I18n.t("devise.registrations.your_information.fields.submit.label")
   end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/H3qUS4dO/346-manage-your-account-screens)

## What
- Adds registration page content
- Adds radio button choice for cookie consent (must be yes/no)
- Adds radio button choice for feedback consent (must be yes/no)
- Adjusts existing specs for new registration flow

## Looks like
![consent_page_feature](https://user-images.githubusercontent.com/3694062/96627798-49e04500-1309-11eb-9bf5-e959e45a2867.gif)
