### PR TITLE
Configure AWS CloudFront IP Addresses as trusted proxies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 ruby File.read(".ruby-version").strip
 
+gem "aws-ip"
 gem "bootsnap", ">= 1.4.2"
 gem "composite_primary_keys", "~> 12.0.0"
 gem "devise"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,8 @@ GEM
     aes_key_wrap (1.1.0)
     ast (2.4.1)
     awesome_print (1.8.0)
+    aws-ip (0.0.2)
+      ipaddress (~> 0.8.0)
     bcrypt (3.1.16)
     bindata (2.4.8)
     bootsnap (1.4.8)
@@ -153,6 +155,7 @@ GEM
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     inflection (1.0.0)
+    ipaddress (0.8.3)
     json-jwt (1.13.0)
       activesupport (>= 4.2)
       aes_key_wrap
@@ -381,6 +384,7 @@ PLATFORMS
 
 DEPENDENCIES
   awesome_print
+  aws-ip
   bootsnap (>= 1.4.2)
   byebug
   capybara

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "aws_ip"
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -123,4 +125,11 @@ Rails.application.configure do
 
   config.action_mailer.delivery_method = :notify
   config.action_mailer.default_url_options = { host: ENV["REDIRECT_BASE_URL"] }
+
+  # Add all AWS IP ranges to TRUSTED_PROXIES
+  config.action_dispatch.trusted_proxies = AwsIp.new
+    .all_ranges
+    .select { |range| range["service"] == "CLOUDFRONT" }
+    .pluck("ip_prefix")
+    .map { |proxy| IPAddr.new(proxy) }
 end


### PR DESCRIPTION
Inbound requests go through AWS CloudFront, which proxies IP addresses in the format: "Remote IP, CDN External IP, CDN Internal IP".

Rails automatically marks the internal IP as middleware, but does not know about the CDN External IP, so assumes this is the end user IP.  By registering a list of all CloudFront IP addresses, we will ensure the user's remote IP is actually logged.

Trello card: https://trello.com/c/ICDC0esK