### PR TITLE
Include Rails default trusted proxies in our proxy list

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -127,7 +127,7 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: ENV["REDIRECT_BASE_URL"] }
 
   # Add all AWS IP ranges to TRUSTED_PROXIES
-  config.action_dispatch.trusted_proxies = AwsIp.new
+  config.action_dispatch.trusted_proxies = ActionDispatch::RemoteIp::TRUSTED_PROXIES + AwsIp.new
     .all_ranges
     .select { |range| range["service"] == "CLOUDFRONT" }
     .pluck("ip_prefix")


### PR DESCRIPTION
The [Rails code for trusting proxies](https://github.com/rails/rails/blob/25bc1c013472eb95120a5912345ea25c3cbf6f89/actionpack/lib/action_dispatch/middleware/remote_ip.rb#L62-L72) ignores the Rails defaults if we provide an absolute list of IPs as an array.  Therefore we need to add the defaults back in, otherwise the internal CDN IP will be logged as the user's IP.

Trello card: https://trello.com/c/ICDC0esK