### PR TITLE
Don't check if a nil previous_url is on ignore list

### DIFF
--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -16,7 +16,7 @@ resource_errors = raw_errors.map { |field, errors| errors.map { |error| { field:
 <% end %>
 
 <% if flash[:alert] %>
-  <% if previous_url_is_on_ignore_list(params[:previous_url]) %>
+  <% if params[:previous_url] && previous_url_is_on_ignore_list(params[:previous_url]) %>
       <% remove_flash_alert %>
   <% else %>
     <%= render "govuk_publishing_components/components/error_summary", {


### PR DESCRIPTION
If there's a flash alert on a page which doesn't take a
previous_url (like the reset password page),
previous_url_is_on_ignore_list will throw an error.