### PR TITLE
Reduce MFA code length to five digits

### DIFF
--- a/lib/multi_factor_auth.rb
+++ b/lib/multi_factor_auth.rb
@@ -40,7 +40,7 @@ module MultiFactorAuth
     end
   end
 
-  def self.send_phone_mfa(phone_number, digits: 6)
+  def self.send_phone_mfa(phone_number, digits: 5)
     raise Disabled unless is_enabled?
 
     phone_code = (1..digits).map { |_| SecureRandom.random_number(10).to_s }.join("")


### PR DESCRIPTION
Guidance suggests 5-digits for the SMS MFA code is more suitable.

Trello card: https://trello.com/c/ICDC0esK