### PR TITLE
Pass along JWT and previous_url from registrations#start

### DIFF
--- a/app/views/devise/registrations/start.html.erb
+++ b/app/views/devise/registrations/start.html.erb
@@ -13,6 +13,13 @@
         <%= render "devise/shared/error_messages", resource: resource, resource_error_messages: @resource_error_messages %>
       <% end %>
 
+      <% if params[:previous_url] %>
+        <%= hidden_field_tag :previous_url, params[:previous_url] %>
+      <% end %>
+      <% if params[:jwt] %>
+        <%= hidden_field_tag :jwt, params[:jwt] %>
+      <% end %>
+
       <% if params.dig(:user, :email) %><%= hidden_field_tag :"user[email]", params.dig(:user, :email) %><% end %>
 
       <%= render "govuk_publishing_components/components/input", {


### PR DESCRIPTION
This is needed because this template can be rendered by the welcome
controller, which doesn't create the RegistrationState, so the
parameters were being lost by the time we got to the
DeviseRegistrationsController.

This bug was likely introduced with the stateful registration PR.