### PR TITLE
Tell users when their email address has been confirmed

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,6 +17,7 @@
 @import "govuk_publishing_components/components/phase-banner";
 @import "govuk_publishing_components/components/radio";
 @import "govuk_publishing_components/components/search";
+@import "govuk_publishing_components/components/success-alert";
 @import "govuk_publishing_components/components/summary-list";
 @import "govuk_publishing_components/components/textarea";
 

--- a/app/views/account/show.html.erb
+++ b/app/views/account/show.html.erb
@@ -11,6 +11,10 @@
       margin_bottom: 4,
     } %>
 
+    <% if flash[:notice] == t("devise.confirmations.confirmed") %>
+      <%= render "govuk_publishing_components/components/success_alert", { message: flash[:notice] } %>
+    <% end %>
+
     <% if current_user.email %>
       <p class="govuk-body">
         <%= current_user.email %>

--- a/app/views/welcome/show.html.erb
+++ b/app/views/welcome/show.html.erb
@@ -8,6 +8,10 @@
         <%= hidden_field_tag :jwt, params[:jwt] %>
       <% end %>
 
+      <% if flash[:notice] == t("devise.confirmations.confirmed") %>
+        <%= render "govuk_publishing_components/components/success_alert", { message: flash[:notice] } %>
+      <% end %>
+
       <%= render "govuk_publishing_components/components/input", {
         heading_size: "l",
         label: {


### PR DESCRIPTION
When a user confirms their email address, we currently don't tell
them.  They have to look at their attributes and notice the
"(unconfirmed)" is gone.  Even worse, because we don't log a user in
when they confirm their address (which is desirable to avoid a
loophole where 2fa can be avoided), a user might end up on the login
screen with no indication that anything has happened, click the link
again, and be told that they've already confirmed their account!

This looks pretty bad on the login form currently, but that will be
resolved by adding a proper heading to the page, which we need to do
anyway.

---

<img width="784" alt="Screenshot 2020-10-23 at 13 33 21" src="https://user-images.githubusercontent.com/75235/97004081-64e2cd00-1534-11eb-9c65-0948407688fa.png">
<img width="822" alt="Screenshot 2020-10-23 at 13 33 30" src="https://user-images.githubusercontent.com/75235/97004085-657b6380-1534-11eb-925b-e41c1e460b25.png">

---

[Trello card](https://trello.com/c/ICDC0esK/368-accounts-snag-list)