### PR TITLE
Pre-populate phone number when resending 2FA code

### DIFF
--- a/app/controllers/devise_registration_controller.rb
+++ b/app/controllers/devise_registration_controller.rb
@@ -106,6 +106,8 @@ class DeviseRegistrationController < Devise::RegistrationsController
 
   def phone_resend
     redirect_to url_for_state and return unless registration_state.state == "phone"
+
+    @phone = registration_state.phone
   end
 
   def your_information

--- a/app/views/devise/registrations/phone_resend.html.erb
+++ b/app/views/devise/registrations/phone_resend.html.erb
@@ -20,6 +20,7 @@
         <%= render "govuk_publishing_components/components/input", {
           label: { text: t("mfa.phone.resend.fields.phone.label") },
           name: "phone",
+          value: @phone,
         } %>
       <% end %>
 


### PR DESCRIPTION
If the user would like another 2FA code, we should prepopulate the phone number field so they don't have to type this again (and will let them check they typed the phone number correctly).

Trello card: https://trello.com/c/ICDC0esK