### PR TITLE
Don't show the account manager in the data exchange table

### DIFF
--- a/app/controllers/security_controller.rb
+++ b/app/controllers/security_controller.rb
@@ -15,6 +15,8 @@ class SecurityController < ApplicationController
 private
 
   def activity_to_exchange(activity)
+    return if activity.oauth_application == AccountManagerApplication.application
+
     scopes = activity.scopes.split(" ").map(&:to_sym) - ScopeDefinition.new.hidden_scopes
     return if scopes.empty?
 


### PR DESCRIPTION
There are a lot of these because of the RemoteUserInfo.  It also
doesn't make sense unless people understand things about our
microservice architecture, which we don't want.  The intent of this
list is to show when other services use your data, not when the
accounts system itself does.

---

[Trello card](https://trello.com/c/ICDC0esK/368-accounts-snag-list)