### PR TITLE
Reduce width of phone number input in registration flow

### DIFF
--- a/app/views/devise/registrations/phone.html.erb
+++ b/app/views/devise/registrations/phone.html.erb
@@ -8,6 +8,7 @@
         heading_size: "l",
         error_message: @phone_error_message,
         width: 10,
+        autocomplete: "tel",
       } %>
 
       <%= render "govuk_publishing_components/components/button", {


### PR DESCRIPTION
## What
Reduces the width of the input field on the phone number view for the signup flow as well as adding the `autocomplete="tel"` attribute to the input.

## Why
This is based on a recommendation from Conor to keep the width of the input field inline with what we're asking. In this case because phone numbers are typically much shorter than the default length of the govuk input component.

The autocomplete attribute is to ensure that the input field follows WCAG accessibility standards to cater to users with motor issues. This attribute will ensure that the browser prompts the user to autofill the field with their phone number if they've entered it previously in other forms online.

## Visual changes
### Before
![Screenshot 2020-10-23 at 15 45 02](https://user-images.githubusercontent.com/64783893/97019504-4edf0780-1548-11eb-9fba-dde3901f56bd.png)

### After
![Screenshot 2020-10-23 at 15 44 12](https://user-images.githubusercontent.com/64783893/97019629-73d37a80-1548-11eb-9f52-0d7736ef4c8e.png)