### PR TITLE
Use separate URLs for logging in and registering

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -112,7 +112,7 @@
         "hashed_secret": "06062101a81dd812ca9902fdf5f27ed472079d75",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 52,
+        "line_number": 45,
         "type": "Secret Keyword"
       }
     ],

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,4 +23,13 @@ protected
       format.all { head :internal_server_error }
     end
   end
+
+  def after_sign_in_path_for(_resource)
+    target = params.fetch(:previous_url, user_root_path)
+    if target.start_with?("/account") || target.start_with?("/oauth")
+      target
+    else
+      user_root_path
+    end
+  end
 end

--- a/app/controllers/devise_registration_controller.rb
+++ b/app/controllers/devise_registration_controller.rb
@@ -5,6 +5,7 @@ class DeviseRegistrationController < Devise::RegistrationsController
   # rubocop:enable Rails/LexicallyScopedActionFilter
 
   before_action :check_registration_state, only: %i[
+    start
     phone
     phone_code
     phone_code_send
@@ -19,23 +20,6 @@ class DeviseRegistrationController < Devise::RegistrationsController
 
   def start
     render :closed and return unless Rails.configuration.enable_registration
-
-    @registration_state_id = params[:registration_state_id]
-    # if this is unset we've been sent here from the welcome form
-    unless @registration_state_id
-      redirect_to new_user_session_path and return unless params.dig(:user, :email)
-
-      jwt_payload = ApplicationKey.validate_jwt!(params[:jwt]) if params[:jwt]
-
-      @registration_state = RegistrationState.create!(
-        touched_at: Time.zone.now,
-        state: :start,
-        email: params[:user][:email],
-        previous_url: jwt_payload&.dig(:post_register_oauth).presence || params[:previous_url],
-        jwt_payload: jwt_payload,
-      )
-      @registration_state_id = registration_state.id
-    end
 
     redirect_to url_for_state and return unless registration_state.state == "start"
 

--- a/app/views/devise/registrations/start.html.erb
+++ b/app/views/devise/registrations/start.html.erb
@@ -7,20 +7,10 @@
       margin_bottom: 3,
     } %>
 
-    <% url = @registration_state_id ? new_user_registration_start_path(registration_state_id: @registration_state_id) : new_user_registration_start_path %>
-    <%= form_with(url: url, method: :post) do %>
+    <%= form_with(url: new_user_registration_start_path(registration_state_id: @registration_state_id), method: :post) do %>
       <% if resource || @resource_error_messages %>
         <%= render "devise/shared/error_messages", resource: resource, resource_error_messages: @resource_error_messages %>
       <% end %>
-
-      <% if params[:previous_url] %>
-        <%= hidden_field_tag :previous_url, params[:previous_url] %>
-      <% end %>
-      <% if params[:jwt] %>
-        <%= hidden_field_tag :jwt, params[:jwt] %>
-      <% end %>
-
-      <% if params.dig(:user, :email) %><%= hidden_field_tag :"user[email]", params.dig(:user, :email) %><% end %>
 
       <%= render "govuk_publishing_components/components/input", {
         label: {

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -7,19 +7,12 @@
       margin_bottom: 3,
     } %>
 
-    <%= form_with(url: user_session_path) do %>
+    <%= form_with(url: user_session_path(login_state_id: @login_state_id)) do %>
       <% if resource %>
         <%= render "devise/shared/error_messages", resource: resource %>
       <% end %>
 
-      <% if params[:previous_url] %>
-        <%= hidden_field_tag :previous_url, params[:previous_url] %>
-      <% end %>
-      <% if params[:jwt] %>
-        <%= hidden_field_tag :jwt, params[:jwt] %>
-      <% end %>
-
-      <%= hidden_field_tag :"user[email]", params.dig(:user, :email) %>
+      <%= hidden_field_tag :"user[email]", @login_state.user.email %>
 
       <%= render "govuk_publishing_components/components/input", {
         label: {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,8 @@ Rails.application.routes.draw do
     post "/feedback", to: "feedback#submit", as: :feedback_form_submitted
 
     scope "/login" do
-      post "/", to: "devise_sessions#create", as: :user_session
+      get  "/", to: "devise_sessions#create", as: :user_session
+      post "/", to: "devise_sessions#create"
       get  "/phone/code", to: "devise_sessions#phone_code", as: :user_session_phone_code
       post "/phone/code", to: "devise_sessions#phone_code_send"
       post "/phone/verify", to: "devise_sessions#phone_verify", as: :user_session_phone_verify
@@ -75,7 +76,8 @@ Rails.application.routes.draw do
     end
 
     scope "/new-account" do
-      post "/", to: "devise_registration#start", as: :new_user_registration_start
+      get  "/", to: "devise_registration#start", as: :new_user_registration_start
+      post "/", to: "devise_registration#start"
       get  "/phone", to: "devise_registration#phone", as: :new_user_registration_phone
       get  "/phone/code", to: "devise_registration#phone_code", as: :new_user_registration_phone_code
       post "/phone/code", to: "devise_registration#phone_code_send"

--- a/spec/feature/registration_from_another_application_spec.rb
+++ b/spec/feature/registration_from_another_application_spec.rb
@@ -148,12 +148,14 @@ RSpec.feature "Registration (coming from another application)" do
   end
 
   def start_journey
-    Capybara.current_session.driver.submit :post, new_user_registration_start_path, {
+    Capybara.current_session.driver.submit :post, "/", {
       "user[email]" => email,
-      "user[password]" => password,
-      "user[password_confirmation]" => password,
       "jwt" => jwt,
     }.compact
+
+    fill_in "password", with: password
+    fill_in "password_confirmation", with: password
+    click_on I18n.t("devise.registrations.start.fields.submit.label")
 
     fill_in "phone", with: "01234567890"
     click_on I18n.t("mfa.phone.create.fields.submit.label")

--- a/spec/requests/jwt_login_spec.rb
+++ b/spec/requests/jwt_login_spec.rb
@@ -40,16 +40,9 @@ RSpec.describe "JWT log in" do
 
   let!(:user) { FactoryBot.create(:user) }
 
-  let(:params) do
-    {
-      "user[email]" => user.email,
-      "user[password]" => user.password,
-      "jwt" => jwt,
-    }
-  end
-
   it "redirects the user to the OAuth consent flow" do
-    post user_session_path, params: params
+    post new_user_session_path, params: { "user[email]" => user.email, "jwt" => jwt }
+    post response.redirect_url, params: { "user[email]" => user.email, "user[password]" => user.password }
     expect(response).to redirect_to(jwt_post_login_oauth.delete_prefix(Rails.application.config.redirect_base_url))
   end
 end

--- a/spec/requests/welcome_spec.rb
+++ b/spec/requests/welcome_spec.rb
@@ -14,16 +14,18 @@ RSpec.describe "welcome" do
       context "the user exists" do
         let!(:user) { FactoryBot.create(:user) }
 
-        it "shows the login form" do
+        it "redirects to the login form" do
           get new_user_session_url(user: { email: user.email })
+          follow_redirect!
 
           expect(response.body).to have_content(I18n.t("devise.sessions.new.heading"))
         end
       end
 
       context "the user doesn't exist" do
-        it "shows the registration form" do
+        it "redirects to the registration form" do
           get new_user_session_url(user: { email: "no-such-user@domain.tld" })
+          follow_redirect!
 
           expect(response.body).to have_content(I18n.t("devise.registrations.start.heading"))
         end


### PR DESCRIPTION
Rather than render the "enter password" / "create password" forms on
/, create the LoginState or RegistrationState and redirect to the
appropriate URL.

---

[Trello card](https://trello.com/c/ICDC0esK/368-accounts-snag-list)