### PR TITLE
Reduce widths of MFA registration journey input fields

### DIFF
--- a/app/views/devise/registrations/phone_code.html.erb
+++ b/app/views/devise/registrations/phone_code.html.erb
@@ -17,7 +17,8 @@
         name: "phone_code",
         maxlength: 6,
         type: "number",
-        error_message: @phone_code_error_message
+        error_message: @phone_code_error_message,
+        width: 5,
       } %>
 
       <%= render "govuk_publishing_components/components/button", {

--- a/app/views/devise/registrations/phone_resend.html.erb
+++ b/app/views/devise/registrations/phone_resend.html.erb
@@ -21,6 +21,8 @@
           label: { text: t("mfa.phone.resend.fields.phone.label") },
           name: "phone",
           value: @phone,
+          width: 10,
+          autocomplete: "tel",
         } %>
       <% end %>
 


### PR DESCRIPTION
## What
Applies the width attribute to input fields within the MFA registration journey, specifically the security code and phone number re-entry fields. Additionally adds `autocomplete="tel"` to the phone re-entry field.

## Why
This is based on a previous recommendation from Conor re: the initial phone number field page to keep the width of the input field inline with what we're asking. In this case because phone numbers and our 6 digit security code are much shorter than the default length of the govuk input component.

The autocomplete attribute is to ensure that the input field follows WCAG accessibility standards to cater to users with motor issues. This attribute will ensure that the browser prompts the user to autofill the field with their phone number if they've entered it previously in other forms online.

## Visual changes
### Before
![Screenshot 2020-10-26 at 10 30 56](https://user-images.githubusercontent.com/64783893/97164105-8c76a700-1779-11eb-845b-24164d2f696c.png)

### After
![Screenshot 2020-10-26 at 10 36 51](https://user-images.githubusercontent.com/64783893/97164125-94364b80-1779-11eb-81eb-32d4d59486cf.png)
