### PR TITLE
Do not show an error about a missing password on first page load

### DIFF
--- a/app/controllers/devise_registration_controller.rb
+++ b/app/controllers/devise_registration_controller.rb
@@ -23,6 +23,8 @@ class DeviseRegistrationController < Devise::RegistrationsController
 
     redirect_to url_for_state and return unless registration_state.state == "start"
 
+    return if request.get?
+
     password = params.dig(:user, :password) # pragma: allowlist secret
     password_confirmation = params.dig(:user, :password_confirmation)
     password_format_ok = User::PASSWORD_REGEX.match? password


### PR DESCRIPTION
This bug was introduced by splitting apart the registration & login
URLs.  There is already a similar check in
devise_sessions_controller.rb, so that doesn't need changing.