### PR TITLE
Pass cookie consent back to the transition checker

### DIFF
--- a/app/helpers/post_registration_helper.rb
+++ b/app/helpers/post_registration_helper.rb
@@ -1,7 +1,7 @@
 require "cgi"
 
 module PostRegistrationHelper
-  def service_name_for(previous_url)
+  def service_for(previous_url, current_user)
     return unless previous_url&.start_with? oauth_authorization_path
 
     bits = previous_url.split("?")
@@ -13,6 +13,16 @@ module PostRegistrationHelper
     app = Doorkeeper::Application.by_uid(querystring["client_id"].first)
     return unless app
 
-    app.name
+    url =
+      if current_user.cookie_consent && previous_url.end_with?("%3A%2Ftransition-check%2Fsaved-results")
+        "#{previous_url}%3Acookies-yes"
+      else
+        previous_url
+      end
+
+    {
+      name: app.name,
+      url: url,
+    }
   end
 end

--- a/app/views/post_registration/show.html.erb
+++ b/app/views/post_registration/show.html.erb
@@ -1,4 +1,4 @@
-<% service_name = service_name_for(params[:previous_url]) %>
+<% service = service_for(params[:previous_url], current_user) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -25,8 +25,8 @@
       <%= t("post_registration.delay_consequence") %>
     </p>
 
-    <% if service_name %>
-      <%= sanitize(t("post_registration.continue_to_service", service_name: service_name, service_link: params[:previous_url])) %>
+    <% if service %>
+      <%= sanitize(t("post_registration.continue_to_service", service_name: service[:name], service_link: service[:url])) %>
     <% else %>
       <%= sanitize(t("post_registration.continue_to_account", account_link: user_root_path)) %>
     <% end %>

--- a/spec/helpers/post_registration_helper_spec.rb
+++ b/spec/helpers/post_registration_helper_spec.rb
@@ -1,5 +1,7 @@
 RSpec.describe PostRegistrationHelper, type: :helper do
-  describe "#service_name_for" do
+  describe "#service_for" do
+    let(:user) { FactoryBot.create(:user) }
+
     let(:application) do
       FactoryBot.create(
         :oauth_application,
@@ -11,18 +13,18 @@ RSpec.describe PostRegistrationHelper, type: :helper do
 
     it "extracts the service name using the client_id parameter" do
       url = oauth_authorization_path + "?" + Rack::Utils.build_nested_query(client_id: application.uid)
-      expect(service_name_for(url)).to eq(application.name)
+      expect(service_for(url, user)[:name]).to eq(application.name)
     end
 
     it "only produces a service name if the link looks like an OAuth content URL" do
       url = "//nefarious-attempt-to-embed-an-arbitrary-link?" + Rack::Utils.build_nested_query(client_id: application.uid)
-      expect(service_name_for(url)).to be_nil
+      expect(service_for(url, user)).to be_nil
     end
 
     context "the client_id doesn't match an application" do
       it "returns nil" do
         url = oauth_authorization_path + "?" + Rack::Utils.build_nested_query(client_id: "breadbread")
-        expect(service_name_for(url)).to be_nil
+        expect(service_for(url, user)).to be_nil
       end
     end
   end


### PR DESCRIPTION
This is a hacky solution which works for now but which we will want to
revisit soon: if the user has consented to cookies *and* the
previous_url takes them back to the transition checker, append
something to the state.

This is not good because it couples us to the representation of the
transition checker state, and will also break if the query params get
re-ordered.

A better solution would be storing cookie consent as an attribute, but
currently we only want to implement per-session consent, not
per-account consent, so that doesn't work.

---

[Trello card](https://trello.com/c/YB2MRHmh/362-change-link-in-the-confirmation-page-to-update-user-cookie-preference)