### PR TITLE
Remove the requirement for a password to have a number

### DIFF
--- a/app/controllers/devise_registration_controller.rb
+++ b/app/controllers/devise_registration_controller.rb
@@ -25,11 +25,10 @@ class DeviseRegistrationController < Devise::RegistrationsController
 
     password = params.dig(:user, :password) # pragma: allowlist secret
     password_confirmation = params.dig(:user, :password_confirmation)
-    password_format_ok = User::PASSWORD_REGEX.match? password
     password_length_ok = Devise.password_length.include? password&.length
     password_confirmation_ok = password == password_confirmation
 
-    if password_format_ok && password_length_ok && password_confirmation_ok
+    if password_length_ok && password_confirmation_ok
       registration_state.update!(
         state: MultiFactorAuth.is_enabled? ? :phone : :your_information,
         password: password,
@@ -38,7 +37,6 @@ class DeviseRegistrationController < Devise::RegistrationsController
     else
       @resource_error_messages = {
         password: [ # pragma: allowlist secret
-          password_format_ok ? nil : I18n.t("activerecord.errors.models.user.attributes.password.invalid"),
           password_length_ok ? nil : I18n.t("activerecord.errors.models.user.attributes.password.too_short"),
         ].uniq,
         password_confirmation: [

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,4 @@
 class User < ApplicationRecord
-  # any string with at least one digit in it
-  PASSWORD_REGEX = /\A.*[0-9].*\z/.freeze
-
   def send_devise_notification(notification, *args)
     devise_mailer.send(notification, self, *args).deliver_later
   end
@@ -14,8 +11,6 @@ class User < ApplicationRecord
          :timeoutable,
          :trackable,
          :validatable
-
-  validates :password, format: { with: PASSWORD_REGEX }, allow_blank: true
 
   has_many :access_grants,
            class_name: "Doorkeeper::AccessGrant",

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -98,7 +98,7 @@ en:
         heading: "Change your password"
         password:
           label: "Create a new password"
-          hint: "It needs to be at least 8 characters long and must include at least one number."
+          hint: "It needs to be at least 8 characters long."
         password_confirm:
           label: "Retype password"
         submit:
@@ -130,7 +130,7 @@ en:
             label: Enter your email address
           password:
             label: Create a new password
-            hint: It needs to be at least 8 characters long and must include at least one number.
+            hint: It needs to be at least 8 characters long.
           password_confirm:
             label: Retype password
           submit:
@@ -189,7 +189,7 @@ en:
             label: "Enter a new email address"
           password:
             label: "Create a new password"
-            hint: "It needs to be at least 8 characters long and must include at least one number. Leave blank if you don’t want to change it."
+            hint: "It needs to be at least 8 characters long. Leave blank if you don’t want to change it."
           password_confirm:
             label: "Retype password"
           current_password:

--- a/spec/feature/registration_spec.rb
+++ b/spec/feature/registration_spec.rb
@@ -117,17 +117,6 @@ RSpec.feature "Registration" do
     end
   end
 
-  context "when the password does not contain a number" do
-    let(:password) { "qwertyui" }
-
-    it "returns an error" do
-      enter_email_address
-      enter_password_and_confirmation
-
-      expect(page).to have_text(I18n.t("activerecord.errors.models.user.attributes.password.invalid"))
-    end
-  end
-
   context "when the phone number is invalid" do
     it "returns an error" do
       enter_email_address

--- a/spec/requests/edit_password_spec.rb
+++ b/spec/requests/edit_password_spec.rb
@@ -87,15 +87,5 @@ RSpec.describe "edit-password" do
         expect(response.body).to have_content(I18n.t("activerecord.errors.models.user.attributes.password.too_short"))
       end
     end
-
-    context "when the password does not contain a number" do
-      let(:password) { "qwertyui" }
-
-      it "returns an error" do
-        post user_password_path, params: params
-
-        expect(response.body).to have_content(I18n.t("activerecord.errors.models.user.attributes.password.invalid"))
-      end
-    end
   end
 end


### PR DESCRIPTION
NCSC guidance is to have a minimum length but no other complexity
requirements.

---

[Trello card](https://trello.com/c/ICDC0esK/368-accounts-snag-list)