### PR TITLE
Show an error if new email is the same as the current email

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -4,7 +4,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2020-10-26T09:22:39Z",
+  "generated_at": "2020-10-26T15:42:12Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -155,7 +155,7 @@
         "hashed_secret": "6dbfd69451fe511cd7b5c20998b3f2fe99129c99",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 39,
+        "line_number": 40,
         "type": "Secret Keyword"
       }
     ],

--- a/app/controllers/devise_registration_controller.rb
+++ b/app/controllers/devise_registration_controller.rb
@@ -184,6 +184,11 @@ class DeviseRegistrationController < Devise::RegistrationsController
     self.resource = resource_class.to_adapter.get!(send(:"current_#{resource_name}").to_key)
     prev_unconfirmed_email = resource.unconfirmed_email if resource.respond_to?(:unconfirmed_email)
 
+    if params.dig(:user, :email) && params.dig(:user, :email) == resource.email
+      redirect_to edit_user_registration_email_path, flash: { alert: I18n.t("devise.failure.same_email") }
+      return
+    end
+
     resource_updated = update_resource(resource, account_update_params)
     yield resource if block_given?
     if resource_updated

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -20,6 +20,7 @@ en:
       timeout: "Your session expired. Please sign in again to continue."
       unauthenticated: "You need to sign in or sign up before continuing."
       unconfirmed: "You have to confirm your email address before continuing."
+      same_email: "Your new email address is the same as your current email address."
     mailer:
       confirmation_instructions:
         subject: "GOV.UK Accounts: confirm your email address"


### PR DESCRIPTION
If a user attempts to change their email address to the one they are already using, we should show an error message as this would be a pointless change on their account.

![Screenshot 2020-10-26 at 15 44 08](https://user-images.githubusercontent.com/6329861/97194491-1c304b80-17a2-11eb-8b89-2948290c6448.png)

Trello card: https://trello.com/c/ICDC0esK