### PR TITLE
Enable email notifications on email address change

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -129,7 +129,7 @@ Devise.setup do |config|
   config.pepper = Rails.application.secrets.password_pepper
 
   # Send a notification to the original email when the user's email is changed.
-  # config.send_email_changed_notification = false
+  config.send_email_changed_notification = true
 
   # Send a notification email when the user's password is changed.
   # config.send_password_change_notification = false


### PR DESCRIPTION
When a user changes their email address, we should alert their old email address as a security measure.

Trello card: https://trello.com/c/ICDC0esK