### PR TITLE
Set config.hosts so an attacker can't spoof X-Forwarded-Host

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -132,4 +132,8 @@ Rails.application.configure do
     .select { |range| range["service"] == "CLOUDFRONT" }
     .pluck("ip_prefix")
     .map { |proxy| IPAddr.new(proxy) }
+
+  config.hosts = [
+    ENV["REDIRECT_BASE_URL"].split("://")[1],
+  ]
 end


### PR DESCRIPTION
Rails uses config.host for generating redirect URLs, and by default
trusts the Host and X-Forwarded-Host headers.  Since we know what
domain we will be using, we should lock this down.