### PR TITLE
Update content for MFA phone number create

### DIFF
--- a/app/assets/stylesheets/accounts.scss
+++ b/app/assets/stylesheets/accounts.scss
@@ -50,3 +50,7 @@
   padding: govuk-spacing(8) 0;
   background: govuk-colour("light-grey");
 }
+
+.mfa-phone-create {
+  margin-bottom: govuk-spacing(4);
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -22,4 +22,18 @@ module ApplicationHelper
       []
     end
   end
+
+  def has_criteria_keys?(registration_state)
+    return false if registration_state.blank?
+
+    registration_state.jwt_payload&.dig("attributes", "transition_checker_state", "criteria_keys").present?
+  end
+
+  def email_alerts_only_path(registration_state)
+    checker_results = registration_state.jwt_payload&.dig("attributes", "transition_checker_state", "criteria_keys")
+    email_signup_path = "/transition-check/email-signup"
+    checker_results = "?c[]=" + checker_results.join('.join("&c[]=")')
+    base_url = Rails.env.development? ? Plek.find("finder-frontend") : Plek.website_root
+    URI.join(base_url, email_signup_path, checker_results)
+  end
 end

--- a/app/views/devise/registrations/phone.html.erb
+++ b/app/views/devise/registrations/phone.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with(url: new_user_registration_phone_code_path(registration_state_id: @registration_state_id), method: :post) do %>
+    <%= form_with(url: new_user_registration_phone_code_path(registration_state_id: @registration_state_id), method: :post, class: "mfa-phone-create") do %>
       <%= render "govuk_publishing_components/components/input", {
         label: { text: t("mfa.phone.create.fields.phone.label") },
         hint: t("mfa.phone.create.fields.phone.hint"),
@@ -15,5 +15,11 @@
         text: t("mfa.phone.create.fields.submit.label"),
       } %>
     <% end %>
+
+    <p class="govuk-body">
+      <% if has_criteria_keys?(@registration_state) %>
+        <%= sanitize(t("mfa.phone.create.email_only_alternative", email_link: email_alerts_only_path(@registration_state))) %>
+      <% end %>
+    </p>
   </div>
 </div>

--- a/config/locales/mfa.en.yml
+++ b/config/locales/mfa.en.yml
@@ -5,9 +5,10 @@ en:
         fields:
           phone:
             label: Enter your mobile number
-            hint: We’ll send you a security code by text message. Security codes help keep your account secure.
+            hint: We’ll send you a security code by text message. You’ll need the security code to finish creating your account. Security codes help keep your account secure.
           submit:
             label: Continue
+        email_only_alternative: If you do not have a mobile phone, you can still <a class="govuk-link" href="%{email_link}">get email alerts and a link to your results</a>.
       update:
         start:
           heading: Change your phone number


### PR DESCRIPTION
Requires a new bottom link that allows the user to bail out and get back
to the email alerts only path. As this is a complex URL and needs to be
plucked out of the JWT I've put this in a helper.

Also added a new class to the form and put a margin-bottom on.