### PR TITLE
Add .cfignore file

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,3 @@
+.git
+log
+tmp


### PR DESCRIPTION
This ignores files that we won't want to push to the PaaS:
- .git - this is large and not needed since we won't use version control in the deployed app
- log - these are local logs from the development environment
- tmp - this contains temporary files (including the pid file that stops the remote server from starting)