### PR TITLE
Add Zendesk group ID

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -132,6 +132,7 @@ jobs:
           PASSWORD_PEPPER: ((password-pepper-staging))
           ZENDESK_CLIENT_USERNAME: ((zendesk-api-username))
           ZENDESK_CLIENT_TOKEN: ((zendesk-api-key))
+          ZENDESK_GROUP_ID: 360005155059
         on_failure:
           put: govuk-slack
           params:
@@ -202,6 +203,7 @@ jobs:
           PASSWORD_PEPPER: ((password-pepper-production))
           ZENDESK_CLIENT_USERNAME: ((zendesk-api-username))
           ZENDESK_CLIENT_TOKEN: ((zendesk-api-key))
+          ZENDESK_GROUP_ID: 360005155059
         on_failure:
           put: govuk-slack
           params:

--- a/config/initializers/gds_zendesk.rb
+++ b/config/initializers/gds_zendesk.rb
@@ -2,6 +2,8 @@ require "yaml"
 require "gds_zendesk/client"
 require "gds_zendesk/dummy_client"
 
+ZENDESK_GROUP_ID = ENV["ZENDESK_GROUP_ID"] || "123"
+
 GDS_ZENDESK_CLIENT = if Rails.env.development?
                        GDSZendesk::DummyClient.new(logger: Rails.logger)
                      else

--- a/lib/zendesk/ticket.rb
+++ b/lib/zendesk/ticket.rb
@@ -11,6 +11,7 @@ module Zendesk
         "subject" => @contact[:subject],
         "requester" => { "locale_id" => 1, "email" => @contact[:email], "name" => @contact[:name] },
         "comment" => { "body" => rendered_body },
+        "group_id" => ZENDESK_GROUP_ID,
       }
     end
 

--- a/spec/unit/zendesk_ticket_spec.rb
+++ b/spec/unit/zendesk_ticket_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Zendesk::Ticket, type: :unit do
         "comment" => {
           "body" => "[Details]\nThis site is awesome\n\n[Response Required]\nNo\n",
         },
+        "group_id" => "123",
       }
       expect(logger).to receive(:info).with("Zendesk ticket created: #{expected_attributes.inspect}")
 


### PR DESCRIPTION
This will put the feedback tickets into the "2nd Line -- GOV.UK Accounts" group in Zendesk.

Trello card: https://trello.com/c/ICDC0esK