### PR TITLE
Sign out of all sessions

### DIFF
--- a/app/controllers/devise_sessions_controller.rb
+++ b/app/controllers/devise_sessions_controller.rb
@@ -53,6 +53,11 @@ class DeviseSessionsController < Devise::SessionsController
 
   def phone_resend; end
 
+  def destroy
+    current_user.invalidate_all_sessions!
+    super
+  end
+
 protected
 
   def check_login_state

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -61,6 +61,14 @@ class User < ApplicationRecord
     ActivateEmailSubscriptionsJob.perform_later id
   end
 
+  def authenticatable_salt
+    "#{super}#{session_token}"
+  end
+
+  def invalidate_all_sessions!
+    update!(session_token: SecureRandom.hex)
+  end
+
   def needs_mfa?
     !phone.nil?
   end

--- a/db/migrate/20201027112254_add_session_token_to_user.rb
+++ b/db/migrate/20201027112254_add_session_token_to_user.rb
@@ -1,0 +1,5 @@
+class AddSessionTokenToUser < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :session_token, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_23_154821) do
+ActiveRecord::Schema.define(version: 2020_10_27_112254) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -158,6 +158,7 @@ ActiveRecord::Schema.define(version: 2020_10_23_154821) do
     t.string "unconfirmed_phone"
     t.boolean "feedback_consent", default: false, null: false
     t.boolean "cookie_consent", default: false, null: false
+    t.string "session_token"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/spec/requests/logout_spec.rb
+++ b/spec/requests/logout_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe "logout" do
+  include ActiveJob::TestHelper
+
+  let(:user) { FactoryBot.create(:user) }
+
+  before { sign_in(user) }
+
+  describe "GET" do
+    it "refreshes the salt" do
+      old_salt = user.authenticatable_salt
+      get destroy_user_session_path
+      expect(user.reload.authenticatable_salt).to_not eq(old_salt)
+    end
+  end
+end


### PR DESCRIPTION
Devise uses a salted cookie to keep a user logged in.  By default,
this salt is just the hashed password, so the only way to sign out of
other sessions is to change your password.

This commit adds a random value to the salt, which is refreshed on log
out, to prevent session reuse.  This change doesn't prevent concurrent
sessions, and if a session times out others will be unaffected; but if
the user logs out of one session, all the others will be terminated
too.

We could extend this to prevent multiple sessions by also refreshing
the salt on login.

---

[Trello card](https://trello.com/c/dNbs2hap/380-get-results-of-pen-test-and-respond-accordingly)