### PR TITLE
Update content to email sent page

### DIFF
--- a/app/views/devise/registrations/confirmation_email_sent.html.erb
+++ b/app/views/devise/registrations/confirmation_email_sent.html.erb
@@ -3,10 +3,30 @@
     <%= render "govuk_publishing_components/components/heading", {
       text: t("update_registration.heading"),
       heading_level: 1,
-      margin_top: 0,
       margin_bottom: 3,
     } %>
 
-    <%= sanitize(t("update_registration.instructions", account_link: user_root_path)) %>
+    <p class="govuk-body">
+      <%= t("update_registration.instruction_one", new_email: current_user.unconfirmed_email) %>
+    </p>
+
+    <p class="govuk-body">
+      <%= t("update_registration.instruction_two") %>
+    </p>
+
+    <%= sanitize(t("update_registration.instruction_list")) %>
+
+
+    <%= sanitize(t("update_registration.back_link", user_root_path: user_root_path)) %>
+
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("update_registration.alternative_actions.heading"),
+      heading_level: 2,
+      margin_bottom: 3,
+      heading_size: "s",
+    } %>
+
+    <%= sanitize(t("update_registration.alternative_actions.retry", retry_link: edit_user_registration_email_path, new_email: current_user.unconfirmed_email)) %>
+
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -193,11 +193,19 @@ en:
         <p class="govuk-body">Your feedback has been sent to the GOV.UK Accounts team.</p>
         <p class="govuk-body"><a href="/account" class="govuk-link">Go to your account</a></p>
   update_registration:
-    heading: "Check your email"
-    instructions: |
-      <p class="govuk-body">We’ve sent you an email to confirm these changes.</p>
-      <p class="govuk-body">You will need to click on the confirmation link in the email to finish updating your account.</p>
-      <p class="govuk-body"><a class="govuk-link" href="%{account_link}">Go to your GOV.UK account</a>
+    heading: "Confirm your new email address"
+    instruction_one: "We’ve sent an email to %{new_email}."
+    instruction_two: "You need to click on the confirmation link in the email to:"
+    instruction_list: |
+      <ul class="govuk-list govuk-list--bullet">
+        <li>finish updating the email address for your account</li>
+        <li>get email updates about the UK transition sent to your new email address</li>
+      </ul>
+    back_link: <p class="govuk-body"><a class="govuk-link" href="%{user_root_path}">Go to your GOV.UK account</a></p>
+    alternative_actions:
+      heading: If you did not get the email or want to use a different address
+      resend: <p class="govuk-body">We can <a class="govuk-link" href="%{resend_link}">send the confirmation email again</a> if you did not get it.</p>
+      retry: <p class="govuk-body">You can <a class="govuk-link" href="%{retry_link}">use a different email address</a> if %{new_email} is not correct.</p>
   post_registration:
     heading: "Confirm your email address"
     instruction_one: We’ve sent an email to


### PR DESCRIPTION
## What it looks like

![image](https://user-images.githubusercontent.com/3694062/97298042-c5cb1780-184a-11eb-9039-b478f64b15e5.png)

## Note

Also adds content for a resend email link, however we've not got a route for that, so I'll add it to the snag list and do that separately.

All we'd need to do is put the following in the view then:
```
    <%= sanitize(t("update_registration.alternative_actions.resend", retry_link: edit_user_registration_email_resend_path)) %>

```

[Requested here](https://docs.google.com/document/d/1qAzgq4NTWCggD7zmiCk8cQVfjpgCZM5cSdpz3uuHTEU/edit?disco=AAAAKj5SizQ)