### PR TITLE
Add heading level attribute for create account inputs without a h1

### DIFF
--- a/app/views/devise/registrations/phone.html.erb
+++ b/app/views/devise/registrations/phone.html.erb
@@ -6,6 +6,7 @@
         hint: t("mfa.phone.create.fields.phone.hint"),
         name: "phone",
         heading_size: "l",
+        heading_level: 1,
         error_message: @phone_error_message,
         width: 10,
         autocomplete: "tel",

--- a/app/views/welcome/show.html.erb
+++ b/app/views/welcome/show.html.erb
@@ -16,6 +16,7 @@
 
       <%= render "govuk_publishing_components/components/input", {
         heading_size: "l",
+        heading_level: 1,
         label: {
           text: t("welcome.show.fields.email.label"),
         },


### PR DESCRIPTION
## What
Applies the new `heading_level` attribute to pages throughout the account creation flow that didn't already have a `h1` so that they now have a `h1` in the form of the question label.

## Why
This allows screen reader users to navigate pages via headings as well as through usual means.

No visual changes.