### PR TITLE
Replace skip link with skip link component

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,7 +27,7 @@
     document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
   <% end -%>
 
-  <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
+  <%= render "govuk_publishing_components/components/skip_link" %>
 
   <%= render "govuk_publishing_components/components/layout_header", {
     environment: "public",


### PR DESCRIPTION
## What
Replaces the literal skip link markup with the skip link component from the publishing components gem.

## Why
To ensure that any changes to this component in the future are captured, general code tidiness.

No visual changes.