### PR TITLE
Make Menu mobile header nav button work properly

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,5 +1,6 @@
 //= require govuk_publishing_components/dependencies
 //= require govuk_publishing_components/lib
+//= require govuk_publishing_components/components/header
 //= require govuk_publishing_components/components/button
 //= require govuk_publishing_components/components/checkboxes
 //= require govuk_publishing_components/components/error-summary


### PR DESCRIPTION
## What
Adds the js include for the govuk header script.

## Why
This js allows the mobile menu show/hide functionality to actually work properly. Users on mobile can now use the mobile navigation as expected.

No visual changes.