### PR TITLE
Update link to trial privacy policy

### DIFF
--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -155,7 +155,7 @@ en:
             <li>share your information with third parties for marketing purposes</li>
           </ul>
           <p class="govuk-body">As we add new features to your account, we may ask if we can share your information with other parts of government to help us provide more efficient online services that are relevant to you. We will always ask your permission beforehand.</p>
-          <p class="govuk-body">You can read the <a href="https://gov.uk/help/privacy-notice" class="govuk-link">full privacy notice</a> for more detail on how your information is stored, shared and used.</p>
+          <p class="govuk-body">You can read the <a href="http://www.gov.uk/government/publications/govuk-accounts-trial-full-privacy-notice-and-accessibility-statement" class="govuk-link">full privacy notice</a> for more detail on how your information is stored, shared and used.</p>
         data_choice_heading: Data about how you use GOV.UK
         data_choice_description: |
           <p class="govuk-body">We’d like to use cookies to collect anonymised analytics about how you use GOV.UK, for example what pages you visit and what you click on.</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -120,7 +120,7 @@ en:
     security:
       heading: Security
       description: |
-        <p class="govuk-body">Read the <a class="govuk-link" href="https://gov.uk/help/privacy-notice" data-module="gem-track-click" data-track-category="account-manage" data-track-action="security" data-track-label="privacy-notice">full GOV.UK Accounts privacy notice</a> to find out how we collect, process and use information about you.</p>
+        <p class="govuk-body">Read the <a class="govuk-link" href="http://www.gov.uk/government/publications/govuk-accounts-trial-full-privacy-notice-and-accessibility-statement" data-module="gem-track-click" data-track-category="account-manage" data-track-action="security" data-track-label="privacy-notice">full GOV.UK Accounts privacy notice</a> to find out how we collect, process and use information about you.</p>
       account_use: Services that have used information about you
       activity: Sign-in attempts and changes to account details
       no_activity_found: There is no currently logged activity on your account. As you use your account to log in and interact with services you will be able to see a record of how it has been used here.


### PR DESCRIPTION
This is the likely URL for the new privacy policy. Held in draft until:
- Content have confirmed that is live
- Confirmed that this should be linked to on the following pages:
  - your information
  - security page