### PR TITLE
Adjust manage page delete section

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -4,7 +4,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2020-10-28T09:24:35Z",
+  "generated_at": "2020-10-28T09:43:07Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -178,7 +178,7 @@
         "hashed_secret": "d841b7c2d6839c79a70094ebfd9ea28508141646",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 118,
+        "line_number": 119,
         "type": "Secret Keyword"
       }
     ],

--- a/app/views/manage/show.html.erb
+++ b/app/views/manage/show.html.erb
@@ -40,7 +40,15 @@
       ]
     } %>
 
-    <p class="govuk-body"><a href="<%= account_delete_path %>" class="govuk-link"><%= t("account.manage.delete.link") %></a></p>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("account.manage.delete.heading"),
+      heading_level: 2,
+      font_size: "m",
+      margin_bottom: 4,
+    } %>
+
     <p class="govuk-body"><%= t("account.manage.delete.description") %></p>
+
+    <p class="govuk-body"><a href="<%= account_delete_path %>" class="govuk-link"><%= t("account.manage.delete.link") %></a></p>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,8 +82,9 @@ en:
         email_question: Can GOV.UK email you to ask for feedback about your account?
         email_description: For example when new features are added to your account
       delete:
+        heading: Delete your account
+        description: You can permanently delete this account and all the information stored in it.
         link: Delete this GOV.UK account
-        description: You can permanently delete your account and all the information stored in it.
         button: Cancel my account
         confirm: Are you sure?
       security:


### PR DESCRIPTION
[Trello](https://trello.com/c/ICDC0esK/368-accounts-snag-list-%F0%9F%8C%AD)
[As requested here](https://docs.google.com/document/d/1qAzgq4NTWCggD7zmiCk8cQVfjpgCZM5cSdpz3uuHTEU/edit?disco=AAAAKlyIw_M)

Adds it under it's own heading

## What it looks like
![image](https://user-images.githubusercontent.com/3694062/97343040-eb721400-187e-11eb-916b-13f35a389af3.png)
