### PR TITLE
Split subject lines for changing email address

### DIFF
--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -1,0 +1,9 @@
+class DeviseMailer < Devise::Mailer
+  def email_changed(record, opts = {})
+    if record.try(:unconfirmed_email?)
+      devise_mail(record, :email_changing, opts)
+    else
+      devise_mail(record, :email_changed, opts)
+    end
+  end
+end

--- a/app/views/devise/mailer/email_changed.text.erb
+++ b/app/views/devise/mailer/email_changed.text.erb
@@ -1,13 +1,5 @@
-<% if @resource.try(:unconfirmed_email?) %>
-  <%= t("devise.mailer.email_changed.is_being_changed.body",
-      email: @email,
-      new_address: @resource.unconfirmed_email,
-      feedback_link: feedback_form_url,
-  ) %>
-<% else %>
-  <%= t("devise.mailer.email_changed.has_been_changed.body",
-      email: @email,
-      new_address: @resource.email,
-      govuk_account_link: new_user_session_url,
-  ) %>
-<% end %>
+<%= t("devise.mailer.email_changed.body",
+    email: @email,
+    new_address: @resource.email,
+    govuk_account_link: new_user_session_url,
+) %>

--- a/app/views/devise/mailer/email_changing.text.erb
+++ b/app/views/devise/mailer/email_changing.text.erb
@@ -1,0 +1,5 @@
+<%= t("devise.mailer.email_changing.body",
+    email: @email,
+    new_address: @resource.unconfirmed_email,
+    feedback_link: feedback_form_url,
+) %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -27,7 +27,7 @@ Devise.setup do |config|
   config.mailer_sender = "please-change-me-at-config-initializers-devise@example.com"
 
   # Configure the class responsible to send e-mails.
-  # config.mailer = 'Devise::Mailer'
+  config.mailer = "DeviseMailer"
 
   # Configure the parent class responsible to send e-mails.
   config.parent_mailer = "ApplicationMailer"

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -56,31 +56,31 @@ en:
           -----
 
           This is an automated email, please do not reply as we do not monitor responses.
-      email_changed:
+      email_changing:
         subject: "Updating the email address for your GOV.UK account"
-        is_being_changed:
-          body: |
-            Hello,
+        body: |
+          Hello,
 
-            You said you want to update the email address for your GOV.UK account.
+          You said you want to update the email address for your GOV.UK account.
 
-            We sent a confirmation link to %{new_address}. The email address for your account will not be updated until you click that link.
+          We sent a confirmation link to %{new_address}. The email address for your account will not be updated until you click that link.
 
-            If this was not you, contact us (%{feedback_link}).
-            -----
+          If this was not you, contact us (%{feedback_link}).
+          -----
 
-            This is an automated email, please do not reply as we do not monitor responses.
-        has_been_changed:
-          body: |
-            Hello,
+          This is an automated email, please do not reply as we do not monitor responses.
+      email_changed:
+        subject: "You’ve updated the email address for your GOV.UK account"
+        body: |
+          Hello,
 
-            You’ve successfully updated the email address for your GOV.UK account.
+          You’ve successfully updated the email address for your GOV.UK account.
 
-            Go to your GOV.UK account (%{govuk_account_link})
+          Go to your GOV.UK account (%{govuk_account_link})
 
-            -----
+          -----
 
-            This is an automated email, please do not reply as we do not monitor responses.
+          This is an automated email, please do not reply as we do not monitor responses.
       password_change:
         subject: You’ve updated the password for your GOV.UK account"
         body: |


### PR DESCRIPTION
We want to send emails with different subject lines for the two events associated with changing an email (i.e. a request has been made, and the change has been performed).

Trello card: https://trello.com/c/ICDC0esK