### PR TITLE
Remove unused hint

### DIFF
--- a/app/views/devise/registrations/edit_email.html.erb
+++ b/app/views/devise/registrations/edit_email.html.erb
@@ -30,7 +30,6 @@
         label: {
           text: t("devise.registrations.edit.fields.current_password.label"),
         },
-        hint: t("devise.registrations.edit.fields.current_password.hint"),
         name: "user[current_password]",
         type: "password",
         id: "current__confirmation",


### PR DESCRIPTION
There is a hint added to the current password field, but nothing set in the locales file, so "Hint" gets rendered.