### PR TITLE
Keep user on correct form on email or password change error

### DIFF
--- a/app/controllers/devise_registration_controller.rb
+++ b/app/controllers/devise_registration_controller.rb
@@ -204,7 +204,11 @@ class DeviseRegistrationController < Devise::RegistrationsController
     else
       clean_up_passwords resource
       set_minimum_password_length
-      respond_with resource
+      if params.dig(:user, :email)
+        render :edit_email
+      elsif params.dig(:user, :password)
+        render :edit_password
+      end
     end
   end
 

--- a/app/views/devise/registrations/edit_password.html.erb
+++ b/app/views/devise/registrations/edit_password.html.erb
@@ -12,6 +12,8 @@
     } %>
 
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do %>
+    <%= render "devise/shared/error_messages", resource: resource %>
+
       <%= render "govuk_publishing_components/components/input", {
         label: {
           text: t("devise.registrations.edit.fields.current_password.label"),


### PR DESCRIPTION
We are using separate views for changing the email and password, whereas devise has a single view for both.

By default, we are directing users to the combined form when an error occurs rather than keeping them on the correct form. This overrides that behaviour to ensure users remain on the same form, but with the error message showing.

Trello card: https://trello.com/c/ICDC0esK