### PR TITLE
Set the cookies_preferences_set cookie on sign in and update

### DIFF
--- a/app/controllers/devise_sessions_controller.rb
+++ b/app/controllers/devise_sessions_controller.rb
@@ -74,6 +74,14 @@ protected
   end
 
   def do_sign_in
+    cookies[:cookies_preferences_set] = "true"
+    cookies[:cookies_policy] = {
+      essential: true,
+      settings: false,
+      usage: login_state.user.cookie_consent.to_s,
+      campaigns: false,
+    }.to_json
+
     set_flash_message!(:notice, :signed_in)
     sign_in(resource_name, login_state.user)
     redirect_to login_state.redirect_path

--- a/app/controllers/edit_consent_controller.rb
+++ b/app/controllers/edit_consent_controller.rb
@@ -4,7 +4,17 @@ class EditConsentController < ApplicationController
   def cookie; end
 
   def cookie_send
-    current_user.update!(cookie_consent: params[:cookie_consent] == "yes")
+    cookie_consent = params[:cookie_consent] == "yes"
+    current_user.update!(cookie_consent: cookie_consent)
+
+    cookies[:cookies_preferences_set] = "true"
+    cookies[:cookies_policy] = {
+      essential: true,
+      settings: false,
+      usage: cookie_consent.to_s,
+      campaigns: false,
+    }.to_json
+
     redirect_to(account_manage_path)
   end
 


### PR DESCRIPTION
We don't need the cookie banner for signed in users, because we
already know whether they have consented or not.

---

[Trello card](https://trello.com/c/ICDC0esK/368-accounts-snag-list-%F0%9F%8C%AD-not-showstoppers)