### PR TITLE
Update how analytics is called

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,7 +139,7 @@ GEM
       sentry-raven (~> 3.1.1)
       statsd-ruby (~> 1.4.0)
       unicorn (>= 5.4, < 5.8)
-    govuk_publishing_components (23.1.0)
+    govuk_publishing_components (23.2.0)
       govuk_app_config
       kramdown
       plek

--- a/app/assets/javascripts/analytics.js
+++ b/app/assets/javascripts/analytics.js
@@ -1,10 +1,12 @@
 //= require govuk_publishing_components/analytics
 
+var gaProperty = "UA-26179049-28"
+var gaPropertyCrossDomain = "UA-145652997-1"
 var linkedDomains = ['www.gov.uk']
 
 $(document).ready(function() {
   if (typeof window.GOVUK.analyticsInit !== 'undefined') {
-    window.GOVUK.analyticsInit(linkedDomains)
+    window.GOVUK.analyticsInit(gaProperty, gaPropertyCrossDomain, linkedDomains)
 
     if (window.GOVUK.cookie('cookies_preferences_set') && window.GOVUK.cookie('cookies_policy')) {
       var currentConsentCookie = JSON.parse(window.GOVUK.cookie('cookies_policy'))
@@ -21,7 +23,7 @@ $(document).ready(function() {
       if (response === 'yes') {
         window.GOVUK.approveAllCookieTypes()
         window.GOVUK.cookie('cookies_preferences_set', 'true', { days: 365 })
-        window.GOVUK.analyticsInit(linkedDomains)
+        window.GOVUK.analyticsInit(gaProperty, gaPropertyCrossDomain, linkedDomains)
       }
 
       else {


### PR DESCRIPTION
## What
- we now pass the GA properties, rather than them being hardcoded in the analytics code in the gem

## Why
- because we are using a different GA property to GOV.UK

## Visual changes
None.