### PR TITLE
Show password changed message after changing password

### DIFF
--- a/app/controllers/devise_registration_controller.rb
+++ b/app/controllers/devise_registration_controller.rb
@@ -201,7 +201,12 @@ class DeviseRegistrationController < Devise::RegistrationsController
       set_flash_message_for_update(resource, prev_unconfirmed_email)
       bypass_sign_in resource, scope: resource_name if sign_in_after_change_password?
 
-      respond_with resource, location: after_update_path_for(resource)
+      if params.dig(:user, :email)
+        respond_with resource, location: confirmation_email_sent_path
+      elsif params.dig(:user, :password)
+        flash[:notice] = I18n.t("devise.registrations.edit.success")
+        render :edit_password
+      end
     else
       clean_up_passwords resource
       set_minimum_password_length
@@ -223,10 +228,6 @@ class DeviseRegistrationController < Devise::RegistrationsController
   def edit_password; end
 
 protected
-
-  def after_update_path_for(_resource)
-    confirmation_email_sent_path
-  end
 
   def after_sign_up_path_for(resource)
     new_user_after_sign_up_path(previous_url: @previous_url, email: resource.email)

--- a/app/views/devise/registrations/edit_password.html.erb
+++ b/app/views/devise/registrations/edit_password.html.erb
@@ -14,6 +14,10 @@
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do %>
     <%= render "devise/shared/error_messages", resource: resource %>
 
+    <% if flash[:notice] %>
+      <%= render "govuk_publishing_components/components/success_alert", { message: flash[:notice] } %>
+    <% end %>
+
       <%= render "govuk_publishing_components/components/input", {
         label: {
           text: t("devise.registrations.edit.fields.current_password.label"),

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -200,6 +200,7 @@ en:
         heading_password: "Change your password"
         heading_email: "Change your email address"
         unconfirmed: "Currently waiting confirmation for: %{email}"
+        success: "Your password has been changed"
         fields:
           email:
             label: "Enter a new email address"


### PR DESCRIPTION
Previously we were redirecting to an email saying to check your emails and that the account email had changed when the user changed their password.

Instead we are now showing an alert that the password has been changed.

![Screenshot 2020-10-28 at 16 28 19](https://user-images.githubusercontent.com/6329861/97466131-ac08fd80-193a-11eb-99dd-548d69f7bae1.png)

Trello card: https://trello.com/c/ICDC0esK