### PR TITLE
Put a line break between privacy option descriptions

### DIFF
--- a/app/views/manage/show.html.erb
+++ b/app/views/manage/show.html.erb
@@ -22,7 +22,7 @@
       heading_level: 2,
       items: [
         {
-          field: t("account.manage.privacy.cookies_question") + t("account.manage.privacy.cookies_description"),
+          field: sanitize([t("account.manage.privacy.cookies_question"), t("account.manage.privacy.cookies_description")].join("<br>")),
           value: current_user.cookie_consent == true ? t("general.yes") : t("general.no"),
           edit: {
             href: edit_user_consent_cookie_path,
@@ -36,7 +36,7 @@
           }
         },
         {
-          field: t("account.manage.privacy.email_question") + t("account.manage.privacy.email_description"),
+          field: sanitize([t("account.manage.privacy.email_question"), t("account.manage.privacy.email_description")].join("<br>")),
           value: current_user.feedback_consent == true ? t("general.yes") : t("general.no"),
           edit: {
             href: edit_user_consent_feedback_path,


### PR DESCRIPTION
There was previously no spacing between the two string, which resulted into two words being joined together.

Trello card: https://trello.com/c/ICDC0esK