### PR TITLE
Reduce maximum length for MFA code to 5-digits

### DIFF
--- a/app/views/devise/registrations/phone_code.html.erb
+++ b/app/views/devise/registrations/phone_code.html.erb
@@ -16,7 +16,7 @@
       <%= render "govuk_publishing_components/components/input", {
         label: { text: t("mfa.phone.code.fields.phone_code.label") },
         name: "phone_code",
-        maxlength: 6,
+        maxlength: 5,
         type: "number",
         error_message: @phone_code_error_message,
         width: 5,

--- a/app/views/devise/sessions/phone_code.html.erb
+++ b/app/views/devise/sessions/phone_code.html.erb
@@ -16,7 +16,7 @@
       <%= render "govuk_publishing_components/components/input", {
         label: { text: t("mfa.phone.code.fields.phone_code.label") },
         name: "phone_code",
-        maxlength: 6,
+        maxlength: 5,
         type: "number",
         error_message: @phone_code_error_message,
         width: 5,


### PR DESCRIPTION
We have previously reduced the MFA code length to 5-digits in #239, so we should also adjust the maximum number of digits that can be typed into that field.

Trello card: https://trello.com/c/ICDC0esK