### PR TITLE
Fix reset password log

### DIFF
--- a/app/controllers/devise_passwords_controller.rb
+++ b/app/controllers/devise_passwords_controller.rb
@@ -7,7 +7,6 @@ class DevisePasswordsController < Devise::PasswordsController
     if successfully_sent?(resource)
       respond_with({}, location: after_sending_reset_password_instructions_path_for(resource.email))
     else
-      SecurityActivity.change_password!(resource, request.remote_ip)
       respond_with(resource)
     end
   end
@@ -27,6 +26,7 @@ class DevisePasswordsController < Devise::PasswordsController
       else
         set_flash_message!(:notice, :updated_not_active)
       end
+      SecurityActivity.change_password!(resource, request.remote_ip)
       respond_with resource, location: after_resetting_password_path_for(resource)
     else
       set_minimum_password_length


### PR DESCRIPTION
This was implemented in https://github.com/alphagov/govuk-account-manager-prototype/pull/313 but never being triggered because the password reset is a PUT request, rather than POST.

Trello card: https://trello.com/c/ICDC0esK