### PR TITLE
Redirect to account home after changing password

### DIFF
--- a/app/controllers/devise_registration_controller.rb
+++ b/app/controllers/devise_registration_controller.rb
@@ -204,7 +204,7 @@ class DeviseRegistrationController < Devise::RegistrationsController
         respond_with resource, location: confirmation_email_sent_path
       elsif params.dig(:user, :password)
         flash[:notice] = I18n.t("devise.registrations.edit.success")
-        render :edit_password
+        redirect_to :user_root
       end
     else
       clean_up_passwords resource

--- a/app/views/account/show.html.erb
+++ b/app/views/account/show.html.erb
@@ -13,7 +13,7 @@
       margin_bottom: 4,
     } %>
 
-    <% if flash[:notice] == t("devise.confirmations.confirmed") %>
+    <% if flash[:notice] %>
       <%= render "govuk_publishing_components/components/success_alert", { message: flash[:notice] } %>
     <% end %>
 

--- a/app/views/devise/registrations/edit_password.html.erb
+++ b/app/views/devise/registrations/edit_password.html.erb
@@ -16,10 +16,6 @@
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do %>
     <%= render "devise/shared/error_messages", resource: resource %>
 
-    <% if flash[:notice] %>
-      <%= render "govuk_publishing_components/components/success_alert", { message: flash[:notice] } %>
-    <% end %>
-
       <%= render "govuk_publishing_components/components/input", {
         label: {
           text: t("devise.registrations.edit.fields.current_password.label"),


### PR DESCRIPTION
Shows the flash notice on the account home rather than on the change password view.

<img width="1049" alt="Screenshot 2020-10-29 at 14 47 16" src="https://user-images.githubusercontent.com/6329861/97589747-d075e000-19f5-11eb-9978-25d23f5a207a.png">

Trello card: https://trello.com/c/ICDC0esK