### PR TITLE
Show error summary on registration consent view

### DIFF
--- a/app/controllers/devise_registration_controller.rb
+++ b/app/controllers/devise_registration_controller.rb
@@ -108,21 +108,21 @@ class DeviseRegistrationController < Devise::RegistrationsController
     feedback_consent_decision = params.dig(:feedback_consent)
     feedback_consent_decision_format_ok = %w[yes no].include? feedback_consent_decision
 
-    @resource_error_messages = {}
+    @error_items = []
     @consents = {}
 
     if cookie_consent_decision_format_ok
       registration_state.update!(cookie_consent: cookie_consent_decision == "yes")
       @consents[:cookie_consent_decision] = cookie_consent_decision
     else
-      @resource_error_messages[:cookie_consent] = [I18n.t("activerecord.errors.models.user.attributes.cookie_consent_decision.invalid")]
+      @error_items << { field: "cookie_consent", href: "#cookie_consent", text: I18n.t("activerecord.errors.models.user.attributes.cookie_consent_decision.invalid") }
     end
 
     if feedback_consent_decision_format_ok
       registration_state.update!(feedback_consent: feedback_consent_decision == "yes")
       @consents[:feedback_consent_decision] = feedback_consent_decision
     else
-      @resource_error_messages[:feedback_consent] = [I18n.t("activerecord.errors.models.user.attributes.feedback_consent_decision.invalid")]
+      @error_items << { field: "feedback_consent", href: "#feedback_consent", text: I18n.t("activerecord.errors.models.user.attributes.feedback_consent_decision.invalid") }
     end
 
     if !registration_state.cookie_consent.nil? && !registration_state.feedback_consent.nil?

--- a/app/views/devise/registrations/your_information.html.erb
+++ b/app/views/devise/registrations/your_information.html.erb
@@ -7,6 +7,14 @@
       margin_bottom: 3,
     } %>
 
+    <% if defined?(@error_items) %>
+      <%= render "govuk_publishing_components/components/error_summary", {
+        id: "error-summary",
+        title: t("feedback.show.errors.summary"),
+        items: @error_items
+      } %>
+    <% end %>
+
     <%= sanitize(t("devise.registrations.your_information.description")) %>
 
     <%= render "govuk_publishing_components/components/heading", {
@@ -30,9 +38,10 @@
     <div class="js-cookie-consent">
       <%= render "govuk_publishing_components/components/radio", {
         name: "cookie_consent",
+        id: "cookie_consent",
         heading: t("devise.registrations.your_information.fields.cookie_consent.heading"),
         heading_size: "s",
-        error_message: devise_error_items(:cookie_consent, @resource_error_messages),
+        error_message: error_items("cookie_consent", @error_items),
         hint: t("devise.registrations.your_information.fields.cookie_consent.hint"),
         items: [
           {
@@ -68,9 +77,10 @@
 
       <%= render "govuk_publishing_components/components/radio", {
         name: "feedback_consent",
+        id: "feedback_consent",
         heading: t("devise.registrations.your_information.fields.feedback_consent.heading"),
         heading_size: "s",
-        error_message: devise_error_items(:feedback_consent, @resource_error_messages),
+        error_message: error_items("feedback_consent", @error_items),
         hint: t("devise.registrations.your_information.fields.feedback_consent.hint"),
         items: [
           {


### PR DESCRIPTION
Shows an error summary on the consent page during the registration flow.

<img width="743" alt="Screenshot 2020-10-29 at 15 39 18" src="https://user-images.githubusercontent.com/6329861/97596897-21d59d80-19fd-11eb-9c3a-03dc1cbc3f4d.png">

Trello card: https://trello.com/c/ICDC0esK