### PR TITLE
Lowercase "o" on sign out

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -55,7 +55,7 @@ en:
           <p class="govuk-body">You can <a class="govuk-link" href="%{register}">sign up for a new account</a> if this is your first visit.</p>
   navigation:
     user_root_path: Account
-    destroy_user_session: Sign Out
+    destroy_user_session: Sign out
     menu_bar:
       account:
         link_text: Your account


### PR DESCRIPTION
## What
Renames "Sign Out" to "Sign out" on the header navigation in the account manager.

## Why
To line up with our content guidance.

## Visual changes
### Before
![Screenshot 2020-10-29 at 18 21 18](https://user-images.githubusercontent.com/64783893/97615700-91568780-1a13-11eb-892e-4a0084f5f8c0.png)

### After
![Screenshot 2020-10-29 at 18 20 50](https://user-images.githubusercontent.com/64783893/97615715-961b3b80-1a13-11eb-9681-dcc18fc2877f.png)