### PR TITLE
Implement account-manager side of single-sign-out

### DIFF
--- a/app/controllers/devise_sessions_controller.rb
+++ b/app/controllers/devise_sessions_controller.rb
@@ -1,4 +1,6 @@
 class DeviseSessionsController < Devise::SessionsController
+  include ApplicationHelper
+
   before_action :check_login_state, only: %i[
     create
     phone_code
@@ -54,8 +56,16 @@ class DeviseSessionsController < Devise::SessionsController
   def phone_resend; end
 
   def destroy
-    current_user.invalidate_all_sessions!
-    super
+    if params[:continue]
+      current_user.invalidate_all_sessions!
+      Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name)
+      redirect_to URI.join(transition_checker_path, "logout", "?done=1")
+    elsif params[:done]
+      current_user.invalidate_all_sessions!
+      super
+    else
+      redirect_to URI.join(transition_checker_path, "logout", "?continue=1")
+    end
   end
 
 protected

--- a/spec/requests/logout_spec.rb
+++ b/spec/requests/logout_spec.rb
@@ -6,9 +6,15 @@ RSpec.describe "logout" do
   before { sign_in(user) }
 
   describe "GET" do
-    it "refreshes the salt" do
+    it "refreshes the salt on ?continue" do
       old_salt = user.authenticatable_salt
-      get destroy_user_session_path
+      get destroy_user_session_path(continue: 1)
+      expect(user.reload.authenticatable_salt).to_not eq(old_salt)
+    end
+
+    it "refreshes the salt on ?done" do
+      old_salt = user.authenticatable_salt
+      get destroy_user_session_path(done: 1)
       expect(user.reload.authenticatable_salt).to_not eq(old_salt)
     end
   end


### PR DESCRIPTION
We want signing out of account-manager to sign out of the
finder-frontend, and vice versa, for this initial experiment. This is
a bit unusual for a federated accounts system like this, but for now
we are presenting the GOV.UK account as more of a Transition Checker
account.  We will work on the larger design problem of making users
understand that the account is a distinct thing later.

Here's how it'll work. It works the same on both sides, so I'll just
call the two endpoints "logoutA" and "logoutB".

1. User visits logoutA
2. User is 302-redirected to logoutB?continue=1
3. User's B session cookie is deleted
4. User is redirected to logoutA?done=1
5. User's A session cookie is deleted
6. The post-logout screen or redirect is shown

Redirecting through every signed-in service won't scale beyond 1
service, but for this first experiment, we do only have 1.

---

[Trello card](https://trello.com/c/RIfEPXbc/387-make-sign-out-in-the-experiment-navigation-bar-apply-to-the-account-manager-transition-and-the-checker)