### PR TITLE
Avoid use of URI.join

### DIFF
--- a/app/controllers/devise_sessions_controller.rb
+++ b/app/controllers/devise_sessions_controller.rb
@@ -59,12 +59,12 @@ class DeviseSessionsController < Devise::SessionsController
     if params[:continue]
       current_user.invalidate_all_sessions!
       Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name)
-      redirect_to URI.join(transition_checker_path, "logout", "?done=1")
+      redirect_to "#{transition_checker_path}/logout?done=1"
     elsif params[:done]
       current_user.invalidate_all_sessions!
       super
     else
-      redirect_to URI.join(transition_checker_path, "logout", "?continue=1")
+      redirect_to "#{transition_checker_path}/logout?continue=1"
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -39,7 +39,6 @@ module ApplicationHelper
 
   def transition_checker_path
     base_url = Rails.env.development? ? Plek.find("finder-frontend") : Plek.new.website_root
-    base_path = "/transition-check"
-    URI.join(base_url, base_path)
+    URI("#{base_url}/transition-check")
   end
 end


### PR DESCRIPTION
Its path / endpoint distinction is confusing and causes errors.

---

[Trello card](https://trello.com/c/RIfEPXbc/387-make-sign-out-in-the-experiment-navigation-bar-apply-to-the-account-manager-transition-and-the-checker)