### PR TITLE
Don't allow registering without completing the transition checker

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -155,7 +155,7 @@
         "hashed_secret": "c725f5d5486bdf839cce75a8b7b043b88214ccba",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 219,
+        "line_number": 223,
         "type": "Secret Keyword"
       }
     ],

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -13,8 +13,12 @@ class WelcomeController < ApplicationController
           login_state = create_login_state(payload, @email)
           redirect_to user_session_path(login_state_id: login_state.id)
         elsif Rails.configuration.enable_registration
-          registration_state = create_registration_state(payload, @email)
-          redirect_to new_user_registration_start_path(registration_state_id: registration_state.id)
+          if payload || !Rails.configuration.force_jwt_at_registration
+            registration_state = create_registration_state(payload, @email)
+            redirect_to new_user_registration_start_path(registration_state_id: registration_state.id)
+          else
+            render "devise/registrations/transition_checker"
+          end
         else
           render "devise/registrations/closed"
         end

--- a/app/views/devise/registrations/transition_checker.html.erb
+++ b/app/views/devise/registrations/transition_checker.html.erb
@@ -1,0 +1,11 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("devise.registrations.transition_checker.heading"),
+      heading_level: 1,
+      margin_bottom: 3,
+    } %>
+
+    <p class="govuk-body"><%= sanitize(t("devise.registrations.transition_checker.message", link: "#{transition_checker_path}/questions")) %></p>
+  </div>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -63,6 +63,10 @@ module GovukAccountManagerPrototype
 
     config.enable_registration = ENV["ENABLE_REGISTRATION"] != "false"
 
+    # show a page prompting the user to complete the transition
+    # checker if they try to register without a JWT
+    config.force_jwt_at_registration = true
+
     config.feature_flag_mfa = ENV["FEATURE_FLAG_MFA"] == "enabled"
   end
 end

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -148,6 +148,10 @@ en:
       update_needs_confirmation: "You updated your account successfully, but we need to confirm your new email address. Please check your email and follow the confirmation link to confirm your new email address."
       updated: "Your account has been updated successfully."
       updated_but_not_signed_in: "Your account has been updated successfully, but since your password was changed, you need to sign in again"
+      transition_checker:
+        heading: This email address does not have a GOV.UK account
+        message: |
+          To create an account, you need to <a class="govuk-link" href="%{link}">answer a few questions in the UK transition checker</a> and subscribe to email updates.
       closed:
         heading: Registrations are closed
         message:

--- a/spec/feature/registration_spec.rb
+++ b/spec/feature/registration_spec.rb
@@ -4,9 +4,11 @@ RSpec.feature "Registration" do
 
   before { allow(Rails.configuration).to receive(:feature_flag_mfa).and_return(mfa_enabled) }
   before { allow(Rails.configuration).to receive(:enable_registration).and_return(registration_enabled) }
+  before { allow(Rails.configuration).to receive(:force_jwt_at_registration).and_return(force_jwt) }
 
   let(:mfa_enabled) { true }
   let(:registration_enabled) { true }
+  let(:force_jwt) { false }
   let(:email) { "email@example.com" }
   # https://www.ofcom.org.uk/phones-telecoms-and-internet/information-for-industry/numbering/numbers-for-drama
   let(:phone_number) { "01234567890" }
@@ -195,6 +197,16 @@ RSpec.feature "Registration" do
       enter_email_address
 
       expect(page).to have_text(I18n.t("devise.registrations.closed.heading"))
+    end
+  end
+
+  context "a JWT is required" do
+    let(:force_jwt) { true }
+
+    it "shows an error message" do
+      enter_email_address
+
+      expect(page).to have_text(I18n.t("devise.registrations.transition_checker.heading"))
     end
   end
 

--- a/spec/requests/welcome_spec.rb
+++ b/spec/requests/welcome_spec.rb
@@ -1,8 +1,4 @@
 RSpec.describe "welcome" do
-  include ActiveJob::TestHelper
-
-  let(:actual_reset_password_token) { user.send_reset_password_instructions }
-
   describe "GET" do
     it "renders the email address form" do
       get new_user_session_url
@@ -23,6 +19,8 @@ RSpec.describe "welcome" do
       end
 
       context "the user doesn't exist" do
+        before { allow(Rails.configuration).to receive(:force_jwt_at_registration).and_return(false) }
+
         it "redirects to the registration form" do
           get new_user_session_url(user: { email: "no-such-user@domain.tld" })
           follow_redirect!


### PR DESCRIPTION

<img width="801" alt="Screenshot 2020-10-30 at 09 49 07" src="https://user-images.githubusercontent.com/75235/97692292-82191d80-1a97-11eb-98fc-14e74b6e954b.png">


For our first experiment the accounts system is tightly coupled with
the transition checker, so we don't want users to be able to register
without completing the checker.

---
[Trello card](https://trello.com/c/ICDC0esK/368-accounts-snag-list-%F0%9F%8C%AD)