### PR TITLE
Update change email link to edit email instead of create new account

### DIFF
--- a/app/views/post_registration/show.html.erb
+++ b/app/views/post_registration/show.html.erb
@@ -38,6 +38,6 @@
       font_size: 19,
     } %>
 
-    <%= sanitize(t("post_registration.re_register_instructions", resend_confirmation_link: new_user_confirmation_path, register_link: new_user_session_path)) %>
+    <%= sanitize(t("post_registration.re_register_instructions", resend_confirmation_link: new_user_confirmation_path, retry_link: edit_user_registration_email_path)) %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -240,7 +240,7 @@ en:
     re_register_subtitle: "If you did not get the email or want to use a different address"
     re_register_instructions: |
       <p class="govuk-body">We can <a class="govuk-link" href="%{resend_confirmation_link}" data-module="gem-track-click" data-track-category="account-create" data-track-action="confirm-email" data-track-label="resend-email">send the confirmation email again</a> if you did not get it.</a>
-      <p class="govuk-body">You can <a class="govuk-link" href="%{register_link}" data-module="gem-track-click" data-track-category="account-create" data-track-action="confirm-email" data-track-label="different-email">use a different email address</a> if your email address is not correct.</p>
+      <p class="govuk-body">You can <a class="govuk-link" href="%{retry_link}" data-module="gem-track-click" data-track-category="account-create" data-track-action="confirm-email" data-track-label="different-email">use a different email address</a> if your email address is not correct.</p>
   change_password:
     heading: Change your password
     content: |


### PR DESCRIPTION
At the moment we are forcing users through a new registration if they want to change their email address immediately after registering.  This should instead link to the change email address in their account.

Trello card: https://trello.com/c/ICDC0esK