### PR TITLE
Validate user entered phone number only

### DIFF
--- a/app/controllers/devise_registration_controller.rb
+++ b/app/controllers/devise_registration_controller.rb
@@ -59,13 +59,13 @@ class DeviseRegistrationController < Devise::RegistrationsController
   def phone_code_send
     redirect_to url_for_state and return unless registration_state.state == "phone"
 
-    phone_number = params[:phone].presence || registration_state.phone
-
-    unless MultiFactorAuth.valid?(phone_number)
+    if params[:phone] && !MultiFactorAuth.valid?(params[:phone].presence)
       @phone_error_message = I18n.t("mfa.errors.phone.invalid")
       render :phone
       return
     end
+
+    phone_number = params[:phone].presence || registration_state.phone
 
     registration_state.transaction do
       registration_state.update!(phone: phone_number)


### PR DESCRIPTION
This resolves an issue where users could use their browser's back button, remove their phone number, click Continue then get another MFA code to their previously entered phone number.

https://trello.com/c/ICDC0esK