### PR TITLE
Add right-hand margin to sidebar navigation on desktop

### DIFF
--- a/app/assets/stylesheets/accounts.scss
+++ b/app/assets/stylesheets/accounts.scss
@@ -9,6 +9,7 @@
 
   @include govuk-media-query($from: desktop) {
     display: block;
+    margin-right: govuk-spacing(4)
   }
 }
 


### PR DESCRIPTION
## What
Adds 20px of right-hand margin to the sidebar nav on the account manager on desktop.

## Why
This is implemented as part of Conor's visual snag recommendations to increase space between the sidebar navigation and the main content of those pages.

## Visual changes
### Before
![Screenshot 2020-10-30 at 14 03 23](https://user-images.githubusercontent.com/64783893/97714150-b3561580-1ab8-11eb-9e60-3d48085cb554.png)

### After
![Screenshot 2020-10-30 at 14 02 56](https://user-images.githubusercontent.com/64783893/97714161-b7823300-1ab8-11eb-879a-a67dd7ab50bf.png)
