### PR TITLE
Correctly handle confirmation emails

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -155,7 +155,7 @@
         "hashed_secret": "c725f5d5486bdf839cce75a8b7b043b88214ccba",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 245,
+        "line_number": 232,
         "type": "Secret Keyword"
       }
     ],

--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -1,18 +1,10 @@
 class DeviseMailer < Devise::Mailer
   def confirmation_instructions(record, token, opts = {})
     @token = token
-    if record.try(:unconfirmed_email?)
+    if record.confirmed? || record.unconfirmed_email?
       devise_mail(record, :change_confirmation_instructions, opts)
     else
       devise_mail(record, :confirmation_instructions, opts)
-    end
-  end
-
-  def email_changed(record, opts = {})
-    if record.try(:unconfirmed_email?)
-      devise_mail(record, :email_changing, opts)
-    else
-      devise_mail(record, :email_changed, opts)
     end
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -15,6 +15,18 @@ class UserMailer < ApplicationMailer
     mail(to: user.email, subject: I18n.t("mailer.change_phone.subject"))
   end
 
+  def change_email_to_email
+    user = params[:user]
+    @login_link = new_user_session_url
+    mail(to: user.email, subject: I18n.t("mailer.change_email_to.subject"))
+  end
+
+  def change_email_from_email
+    old_address = params[:old_address]
+    @login_link = new_user_session_url
+    mail(to: old_address, subject: I18n.t("mailer.change_email_from.subject"))
+  end
+
   def post_delete_email
     email = params[:email]
     @feedback_form_link = feedback_form_url

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -62,7 +62,12 @@ class User < ApplicationRecord
 
   # from devise
   def after_confirmation
-    unless has_received_onboarding_email
+    if email_before_last_save != email
+      UserMailer.with(old_address: email_before_last_save).change_email_from_email.deliver_later
+    end
+    if has_received_onboarding_email
+      UserMailer.with(user: self).change_email_to_email.deliver_later
+    else
       UserMailer.with(user: self).onboarding_email.deliver_later
       update!(has_received_onboarding_email: true)
     end

--- a/app/views/devise/mailer/email_changed.text.erb
+++ b/app/views/devise/mailer/email_changed.text.erb
@@ -1,5 +1,5 @@
 <%= t("devise.mailer.email_changed.body",
     email: @email,
-    new_address: @resource.email,
-    govuk_account_link: new_user_session_url,
+    new_address: @resource.unconfirmed_email,
+    feedback_link: feedback_form_url,
 ) %>

--- a/app/views/devise/mailer/email_changing.text.erb
+++ b/app/views/devise/mailer/email_changing.text.erb
@@ -1,5 +1,0 @@
-<%= t("devise.mailer.email_changing.body",
-    email: @email,
-    new_address: @resource.unconfirmed_email,
-    feedback_link: feedback_form_url,
-) %>

--- a/app/views/user_mailer/change_email_from_email.text.erb
+++ b/app/views/user_mailer/change_email_from_email.text.erb
@@ -1,0 +1,3 @@
+<%= t("mailer.change_email_from.body",
+    govuk_account_link: @login_link,
+) %>

--- a/app/views/user_mailer/change_email_to_email.text.erb
+++ b/app/views/user_mailer/change_email_to_email.text.erb
@@ -1,0 +1,3 @@
+<%= t("mailer.change_email_to.body",
+    govuk_account_link: @login_link,
+) %>

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -93,7 +93,7 @@ en:
           -----
 
           This is an automated email, please do not reply as we do not monitor responses.
-      email_changing:
+      email_changed:
         subject: "Updating the email address for your GOV.UK account"
         body: |
           Hello
@@ -104,19 +104,6 @@ en:
 
           If this was not you, contact us:
           %{feedback_link}.
-
-          -----
-
-          This is an automated email, please do not reply as we do not monitor responses.
-      email_changed:
-        subject: "You’ve updated the email address for your GOV.UK account"
-        body: |
-          Hello
-
-          You’ve successfully updated the email address for your GOV.UK account. You can no longer use this email address to sign in to your account.
-
-          Sign in to your GOV.UK account:
-          %{govuk_account_link}
 
           -----
 

--- a/config/locales/mailer.en.yml
+++ b/config/locales/mailer.en.yml
@@ -41,6 +41,32 @@ en:
         -----
 
         This is an automated email, please do not reply as we do not monitor responses.
+    change_email_to:
+      subject: You’ve updated the email address for your GOV.UK account
+      body: |
+        Hello
+
+        You’ve successfully updated the email address for your GOV.UK account.
+
+        Go to to your GOV.UK account:
+        %{govuk_account_link}
+
+        -----
+
+        This is an automated email, please do not reply as we do not monitor responses.
+    change_email_from:
+      subject: "You’ve updated the email address for your GOV.UK account"
+      body: |
+        Hello
+
+        You’ve successfully updated the email address for your GOV.UK account. You can no longer use this email address to sign in to your account.
+
+        Sign in to your GOV.UK account:
+        %{govuk_account_link}
+
+        -----
+
+        This is an automated email, please do not reply as we do not monitor responses.
     post_delete:
       subject: You’ve deleted your GOV.UK account
       body: |


### PR DESCRIPTION
When a user changes their email address:

- Send a notification to their old address
- And a confirmation link to the new one

When the user confirms the change:

- Send a notification to their old address
- Send a different notification to their new address:
  - The onboarding email if this is the first time
  - Otherwise the generic post-change confirmation

This was surprisingly tricky to get right, as devise sends the
"email_changed" email before it's actually been changed; and also we
can't rely entirely on the presence of "unconfirmed_email", as that
behaves differently for a brand new user (they have no
unconfirmed_email, but they're not confirmed).