### PR TITLE
Move the success alert to appear above the h1 on the account index

### DIFF
--- a/app/views/account/show.html.erb
+++ b/app/views/account/show.html.erb
@@ -7,16 +7,16 @@
   </div>
 
   <div class="govuk-grid-column-two-thirds-from-desktop">
+    <% if flash[:notice] %>
+      <%= render "govuk_publishing_components/components/success_alert", { message: flash[:notice] } %>
+    <% end %>
+
     <%= render "govuk_publishing_components/components/heading", {
       text: yield(:title),
       heading_level: 1,
       font_size: "xl",
       margin_bottom: 4,
     } %>
-
-    <% if flash[:notice] %>
-      <%= render "govuk_publishing_components/components/success_alert", { message: flash[:notice] } %>
-    <% end %>
 
     <% if current_user.email %>
       <p class="govuk-body">


### PR DESCRIPTION
## What
Moves the success alert component call above the heading on Your account.

## Why
To line up with Conor's designs and maintain consistency re:alerts across our service.

## Visual changes
### Before
![Screenshot 2020-10-30 at 17 58 47](https://user-images.githubusercontent.com/64783893/97740847-c0373100-1ad9-11eb-8a68-8ce291e95fc5.png)

### After
![Screenshot 2020-10-30 at 17 58 14](https://user-images.githubusercontent.com/64783893/97740870-c62d1200-1ad9-11eb-9a1f-56eccfff66a9.png)
