### PR TITLE
Permit only mobile numbers for MFA

### DIFF
--- a/lib/multi_factor_auth.rb
+++ b/lib/multi_factor_auth.rb
@@ -7,7 +7,7 @@ module MultiFactorAuth
   class NotConfigured < MFAError; end
 
   def self.valid?(phone_number)
-    TelephoneNumber.valid?(phone_number, :gb)
+    TelephoneNumber.valid?(phone_number, :gb, [:mobile])
   end
 
   def self.generate_and_send_code(auth, use_unconfirmed: false)

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     email { "email@example.com" }
     password { "abcd1234" }
     password_confirmation { "abcd1234" }
-    phone { "01234567890" }
+    phone { "07958123456" }
 
     factory :confirmed_user do
       confirmed_at { Time.zone.now }

--- a/spec/feature/change_phone_spec.rb
+++ b/spec/feature/change_phone_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Change Phone" do
   let(:user) { FactoryBot.create(:user) }
 
   # BT line test number
-  let(:new_phone_number) { "02087599036" }
+  let(:new_phone_number) { "07581123456" }
 
   it "updates the phone number" do
     log_in
@@ -28,6 +28,17 @@ RSpec.feature "Change Phone" do
       enter_password
 
       expect(page).to have_text(I18n.t("mfa.errors.phone.nochange"))
+    end
+  end
+
+  context "when the phone number is not a mobile" do
+    it "returns an error" do
+      log_in
+      go_to_change_number_page
+      enter_non_mobile_phone_number
+      enter_password
+
+      expect(page).to have_text(I18n.t("mfa.errors.phone.invalid"))
     end
   end
 
@@ -115,6 +126,10 @@ RSpec.feature "Change Phone" do
 
   def enter_same_phone_number
     fill_in "phone", with: user.phone
+  end
+
+  def enter_non_mobile_phone_number
+    fill_in "phone", with: "01234567890"
   end
 
   def enter_invalid_phone_number

--- a/spec/feature/registration_from_another_application_spec.rb
+++ b/spec/feature/registration_from_another_application_spec.rb
@@ -157,7 +157,7 @@ RSpec.feature "Registration (coming from another application)" do
     fill_in "password_confirmation", with: password
     click_on I18n.t("devise.registrations.start.fields.submit.label")
 
-    fill_in "phone", with: "01234567890"
+    fill_in "phone", with: "07958123456"
     click_on I18n.t("mfa.phone.create.fields.submit.label")
 
     phone_code = RegistrationState.last.phone_code

--- a/spec/feature/registration_spec.rb
+++ b/spec/feature/registration_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Registration" do
   let(:force_jwt) { false }
   let(:email) { "email@example.com" }
   # https://www.ofcom.org.uk/phones-telecoms-and-internet/information-for-industry/numbering/numbers-for-drama
-  let(:phone_number) { "01234567890" }
+  let(:phone_number) { "07958123456" }
   let(:password) { "abcd1234" } # pragma: allowlist secret
   let(:password_confirmation) { password }
 
@@ -116,6 +116,16 @@ RSpec.feature "Registration" do
       enter_password_and_confirmation
 
       expect(page).to have_text(I18n.t("activerecord.errors.models.user.attributes.password.too_short"))
+    end
+  end
+
+  context "when the phone number is not a mobile" do
+    it "returns an error" do
+      enter_email_address
+      enter_password_and_confirmation
+      enter_non_mobile_phone_number
+
+      expect(page).to have_text(I18n.t("mfa.errors.phone.invalid"))
     end
   end
 
@@ -224,6 +234,11 @@ RSpec.feature "Registration" do
 
   def enter_phone_number
     fill_in "phone", with: phone_number
+    click_on I18n.t("mfa.phone.create.fields.submit.label")
+  end
+
+  def enter_non_mobile_phone_number
+    fill_in "phone", with: "01234567890"
     click_on I18n.t("mfa.phone.create.fields.submit.label")
   end
 


### PR DESCRIPTION
Notify does not support SMS to landlines, therefore we should validate the number is a mobile, so we do not get an error returned by Notify.