### PR TITLE
Set path=/ for cookies_policy

### DIFF
--- a/app/controllers/devise_sessions_controller.rb
+++ b/app/controllers/devise_sessions_controller.rb
@@ -1,5 +1,6 @@
 class DeviseSessionsController < Devise::SessionsController
   include ApplicationHelper
+  include CookiesHelper
 
   before_action :check_login_state, only: %i[
     create
@@ -85,7 +86,7 @@ protected
 
   def do_sign_in
     cookies[:cookies_preferences_set] = "true"
-    response["Set-Cookie"] = "cookies_policy={\"essential\": true, \"settings\": false, \"usage\": #{login_state.user.cookie_consent}, \"campaigns\": false}"
+    response["Set-Cookie"] = cookies_policy_header(login_state.user)
 
     set_flash_message!(:notice, :signed_in)
     sign_in(resource_name, login_state.user)

--- a/app/controllers/edit_consent_controller.rb
+++ b/app/controllers/edit_consent_controller.rb
@@ -1,4 +1,6 @@
 class EditConsentController < ApplicationController
+  include CookiesHelper
+
   before_action :authenticate_user!
 
   def cookie; end
@@ -8,7 +10,7 @@ class EditConsentController < ApplicationController
     current_user.update!(cookie_consent: cookie_consent)
 
     cookies[:cookies_preferences_set] = "true"
-    response["Set-Cookie"] = "cookies_policy={\"essential\": true, \"settings\": false, \"usage\": #{cookie_consent}, \"campaigns\": false}"
+    response["Set-Cookie"] = cookies_policy_header(current_user.reload)
 
     redirect_to(account_manage_path)
   end

--- a/app/helpers/cookies_helper.rb
+++ b/app/helpers/cookies_helper.rb
@@ -1,0 +1,5 @@
+module CookiesHelper
+  def cookies_policy_header(user)
+    "cookies_policy={\"essential\": true, \"settings\": false, \"usage\": #{user.cookie_consent}, \"campaigns\": false}; path=/"
+  end
+end


### PR DESCRIPTION
From RFC 6265 (HTTP State Management):

> 11. If the cookie store contains a cookie with the same name,
>     domain, and path as the newly created cookie:
>
>     1. Let old-cookie be the existing cookie with the same name,
>        domain, and path as the newly created cookie.  (Notice that
>        this algorithm maintains the invariant that there is at most
>        one such cookie.)
>
>     2. If the newly created cookie was received from a "non-HTTP"
>        API and the old-cookie's http-only-flag is set, abort these
>        steps and ignore the newly created cookie entirely.
>
>     3. Update the creation-time of the newly created cookie to
>        match the creation-time of the old-cookie.
>
>     4. Remove the old-cookie from the cookie store.
>
> 12. Insert the newly created cookie into the cookie store.

We're already setting a default cookie (with the cookie banner), and
currently this new cookie we're setting on sign-in isn't overwriting
the old one.  I suspect the issue is the path, as Firefox dev tools
shows that the default cookie has a path of "/", whereas we're not
setting a path at all for our new cookie.

---

[Trello card](https://trello.com/c/4kIhJHvE/390-analytics-snags)