### PR TITLE
Remove frontend cookie setting

### DIFF
--- a/app/assets/javascripts/analytics.js
+++ b/app/assets/javascripts/analytics.js
@@ -16,20 +16,5 @@ $(document).ready(function() {
         $('input[name=cookie_consent][value=no]').prop('checked', true)
       }
     }
-
-    $('.js-cookie-consent .govuk-radios__input').on('click', function() {
-      var response = $(this).val()
-
-      if (response === 'yes') {
-        window.GOVUK.approveAllCookieTypes()
-      }
-
-      else {
-        window.GOVUK.setDefaultConsentCookie()
-      }
-
-      window.GOVUK.cookie('cookies_preferences_set', 'true', { days: 365 })
-      window.GOVUK.analyticsInit(gaProperty, gaPropertyCrossDomain, linkedDomains)
-    })
   }
 })

--- a/app/views/devise/registrations/your_information.html.erb
+++ b/app/views/devise/registrations/your_information.html.erb
@@ -37,7 +37,6 @@
       }
     ) do %>
 
-    <div class="js-cookie-consent">
       <%= render "govuk_publishing_components/components/radio", {
         name: "cookie_consent",
         id: "cookie_consent",
@@ -64,7 +63,6 @@
           }
         ]
       } %>
-    </div>
 
       <%= render "govuk_publishing_components/components/heading", {
         text:  t("devise.registrations.your_information.fields.feedback_consent.section_heading"),

--- a/app/views/edit_consent/cookie.html.erb
+++ b/app/views/edit_consent/cookie.html.erb
@@ -17,32 +17,30 @@
       }
     ) do %>
 
-      <div class="js-cookie-consent">
-        <%= render "govuk_publishing_components/components/radio", {
-          name: "cookie_consent",
-          heading: yield(:title),
-          heading_size: "l",
-          is_page_heading: true,
-          items: [
-            {
-              value: "yes",
-              text: t("devise.registrations.your_information.fields.cookie_consent.yes"),
-              checked: current_user.cookie_consent,
-              data_attributes: {
-                "track-action": "personal-information-cookies"
-              }
-            },
-            {
-              value: "no",
-              text: t("devise.registrations.your_information.fields.cookie_consent.no"),
-              checked: !current_user.cookie_consent,
-              data_attributes: {
-                "track-action": "personal-information-cookies"
-              }
+      <%= render "govuk_publishing_components/components/radio", {
+        name: "cookie_consent",
+        heading: yield(:title),
+        heading_size: "l",
+        is_page_heading: true,
+        items: [
+          {
+            value: "yes",
+            text: t("devise.registrations.your_information.fields.cookie_consent.yes"),
+            checked: current_user.cookie_consent,
+            data_attributes: {
+              "track-action": "personal-information-cookies"
             }
-          ]
-        } %>
-      </div>
+          },
+          {
+            value: "no",
+            text: t("devise.registrations.your_information.fields.cookie_consent.no"),
+            checked: !current_user.cookie_consent,
+            data_attributes: {
+              "track-action": "personal-information-cookies"
+            }
+          }
+        ]
+      } %>
 
       <%= render "govuk_publishing_components/components/button", {
         text: t("devise.registrations.your_information.fields.submit.update_label"),


### PR DESCRIPTION
- we were setting the analytics cookies_policy cookie dynamically in-page using JS on the sign in and consent screens, but we were already setting this cookie from the backend, so this approach is redundant
- also removes the possibility that a user could change their setting but then hit cancel, where their change would not be honoured

Trello card: https://trello.com/c/4kIhJHvE/390-analytics-snags