### PR TITLE
Set consent cookie at end of registration process

### DIFF
--- a/app/controllers/devise_registration_controller.rb
+++ b/app/controllers/devise_registration_controller.rb
@@ -1,4 +1,6 @@
 class DeviseRegistrationController < Devise::RegistrationsController
+  include CookiesHelper
+
   # rubocop:disable Rails/LexicallyScopedActionFilter
   prepend_before_action :authenticate_scope!, only: %i[edit_password edit_email update destroy]
   prepend_before_action :set_minimum_password_length, only: %i[new edit_password edit_email]
@@ -176,6 +178,9 @@ class DeviseRegistrationController < Devise::RegistrationsController
 
       @previous_url = registration_state.previous_url
       registration_state.destroy!
+
+      cookies[:cookies_preferences_set] = "true"
+      response["Set-Cookie"] = cookies_policy_header(resource)
     end
   end
 


### PR DESCRIPTION
We set it at log in and when the user changes their consent, but the
sign-in which happens at the end of the registration process isn't the
same code as the normal log in process, so the cookie isn't being set.