### PR TITLE
Add rake task to extract basic usage statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,3 +223,18 @@ to set the environment variable:
 This approach will cause some brief downtime as the app restarts, and
 the environment variable change will be lost on the next Concourse
 deployment.
+
+## Exporting registration statistics
+
+We may periodically be asked to produce reports with information about the
+number of registrations, logins, etc. There is a rake task to handle this and
+has to be run manually in production, e.g. to produce statistics for the 28th
+October 2020:
+
+```
+cf login -u <your_email> -a https://api.london.cloud.service.gov.uk --sso
+cf target -s production
+cf v3-ssh govuk-account-manager
+$ /tmp/lifecycle/shell
+$ rake "statistics:general[2020-10-28 00:00, 2020-10-28 23:59]"
+```

--- a/lib/tasks/statistics.rake
+++ b/lib/tasks/statistics.rake
@@ -1,0 +1,62 @@
+namespace :statistics do
+  desc "Get information on all registrations and logins"
+  task :general, %i[start_date end_date] => [:environment] do |_, args|
+    args.with_defaults(start_date: Date.yesterday.midnight.to_s, end_date: Date.yesterday.end_of_day.to_s)
+
+    total_users = User
+      .where("created_at < ?", args.end_date)
+      .count
+    puts "All registrations to #{args.end_date}: \n#{total_users}\n\n"
+
+    new_users = User
+      .where("created_at BETWEEN ? AND ?", args.start_date, args.end_date)
+      .count
+    puts "New registrations between #{args.start_date} and #{args.end_date}: \n#{new_users}\n\n"
+
+    all_logins = SecurityActivity
+      .where(event_type: "login")
+      .where("created_at < ?", args.end_date)
+    puts "Total number of logins to #{args.end_date}: \n#{all_logins.count}\n\n"
+
+    interval_logins = all_logins
+      .where("created_at BETWEEN ? AND ?", args.start_date, args.end_date)
+    puts "Total number of logins between #{args.start_date} and #{args.end_date}: \n#{interval_logins.count}\n\n"
+
+    all_user_logins = all_logins
+      .pluck(:user_id)
+      .uniq
+    puts "Accounts logged in to #{args.end_date}: \n#{all_user_logins.count}\n\n"
+
+    user_logins = interval_logins
+      .pluck(:user_id)
+      .uniq
+    puts "Accounts logged in between #{args.start_date} and #{args.end_date}: \n#{user_logins.count}\n\n"
+
+    all_login_frequency = SecurityActivity
+      .where(event_type: "login")
+      .where("created_at < ?", args.end_date)
+      .pluck(:user_id)
+      .tally
+      .values
+      .tally
+      .sort
+    puts "Number of logins per account to #{args.end_date}:\n"
+    all_login_frequency.each do |frequency, count|
+      puts "Accounts logged into #{frequency} #{'time'.pluralize(frequency)}: #{count}"
+    end
+    puts "\n"
+
+    login_frequency = SecurityActivity
+      .where(event_type: "login")
+      .where("created_at BETWEEN ? AND ?", args.start_date, args.end_date)
+      .pluck(:user_id)
+      .tally
+      .values
+      .tally
+      .sort
+    puts "Number of logins between #{args.start_date} and #{args.end_date}:\n"
+    login_frequency.each do |frequency, count|
+      puts "Accounts logged into #{frequency} #{'time'.pluralize(frequency)}: #{count}"
+    end
+  end
+end


### PR DESCRIPTION
This will allow us to produce some basic statistics about numbers of registrations and logins, until we have developed a proper dashboard for this data.

Example of the report (e.g. for the app running on my local machine on 28th October 2020):
```
All registrations to 2020-10-28 23:59: 
5

New registrations between 2020-10-28 00:00 and 2020-10-28 23:59: 
1

Total number of logins to 2020-10-28 23:59: 
23

Total number of logins between 2020-10-28 00:00 and 2020-10-28 23:59: 
10

Accounts logged in to 2020-10-28 23:59: 
5

Accounts logged in between 2020-10-28 00:00 and 2020-10-28 23:59: 
2

Number of logins per account to 2020-10-28 23:59:
Accounts logged into 1 time: 3
Accounts logged into 7 times: 1
Accounts logged into 13 times: 1

Number of logins between 2020-10-28 00:00 and 2020-10-28 23:59:
Accounts logged into 1 time: 1
Accounts logged into 9 times: 1
```

Trello card: https://trello.com/c/nJi5x51l