### PR TITLE
Don't try to log in to ECR with dockerhub credentials

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -121,7 +121,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 98,
+        "line_number": 96,
         "type": "Basic Auth Credentials"
       }
     ],

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -43,8 +43,6 @@ resources:
     source:
       repository: ((readonly_private_ecr_repo_url))
       tag: govuk-accounts-manager-tests-image
-      username: ((docker_hub_username))
-      password: ((docker_hub_authtoken))
 
 jobs:
   - name: update-pipeline


### PR DESCRIPTION
This was mistakenly introduced in #358 and is breaking deploys: https://cd.gds-reliability.engineering/teams/govuk-tools/pipelines/govuk-account-manager-prototype/jobs/run-quality-checks/builds/521