### PR TITLE
Set consent cookie in registration in POST your-information response

### DIFF
--- a/app/controllers/devise_registration_controller.rb
+++ b/app/controllers/devise_registration_controller.rb
@@ -128,6 +128,9 @@ class DeviseRegistrationController < Devise::RegistrationsController
     end
 
     if !registration_state.cookie_consent.nil? && !registration_state.feedback_consent.nil?
+      cookies[:cookies_preferences_set] = "true"
+      response["Set-Cookie"] = cookies_policy_header(registration_state)
+
       email_topic_slug = registration_state.jwt_payload&.dig("attributes", "transition_checker_state", "email_topic_slug")
       if email_topic_slug
         registration_state.update!(state: :transition_emails)
@@ -178,9 +181,6 @@ class DeviseRegistrationController < Devise::RegistrationsController
 
       @previous_url = registration_state.previous_url
       registration_state.destroy!
-
-      cookies[:cookies_preferences_set] = "true"
-      response["Set-Cookie"] = cookies_policy_header(resource)
     end
   end
 

--- a/app/helpers/cookies_helper.rb
+++ b/app/helpers/cookies_helper.rb
@@ -1,5 +1,5 @@
 module CookiesHelper
-  def cookies_policy_header(user)
-    "cookies_policy={\"essential\": true, \"settings\": false, \"usage\": #{user.cookie_consent}, \"campaigns\": false}; path=/"
+  def cookies_policy_header(resource)
+    "cookies_policy={\"essential\": true, \"settings\": false, \"usage\": #{resource.cookie_consent}, \"campaigns\": false}; path=/"
   end
 end


### PR DESCRIPTION
Currently, we still display the cookie banner on the email alerts
page (for users who sign up through the transition checker), because
we're setting the cookie only on the finish page.

So to fix that, set the cookie in the POST response.

I renamed the parameter of the cookies_policy_header helper because it
doesn't have to be a user, just something with a cookie_consent
method.

---

[Trello card](https://trello.com/c/4kIhJHvE/390-analytics-snags)