### PR TITLE
Set Zendesk group environment variable on deployment

### DIFF
--- a/concourse/tasks/deploy-to-govuk-paas.yml
+++ b/concourse/tasks/deploy-to-govuk-paas.yml
@@ -65,6 +65,7 @@ run:
 
       cf set-env $CF_APP_NAME ZENDESK_CLIENT_USERNAME "$ZENDESK_CLIENT_USERNAME"
       cf set-env $CF_APP_NAME ZENDESK_CLIENT_TOKEN "$ZENDESK_CLIENT_TOKEN"
+      cf set-env $CF_APP_NAME ZENDESK_GROUP_ID "$ZENDESK_GROUP_ID"
 
       cf push $CF_APP_NAME --strategy rolling
       cf map-route $CF_APP_NAME "$CDN_DOMAIN" --hostname www


### PR DESCRIPTION
We weren't setting the environment variable for the Zendesk group ID on deployment.