### PR TITLE
Log out of the checker on delete

### DIFF
--- a/app/controllers/delete_controller.rb
+++ b/app/controllers/delete_controller.rb
@@ -1,4 +1,6 @@
 class DeleteController < ApplicationController
+  include ApplicationHelper
+
   before_action :authenticate_user!, only: %i[show destroy]
 
   def show; end
@@ -14,7 +16,7 @@ class DeleteController < ApplicationController
     current_user.destroy!
     sign_out
     UserMailer.with(email: email).post_delete_email.deliver_later
-    redirect_to account_delete_confirmation_path
+    redirect_to "#{transition_checker_path}/logout?continue=delete"
   end
 
   def confirmation; end

--- a/app/controllers/devise_sessions_controller.rb
+++ b/app/controllers/devise_sessions_controller.rb
@@ -60,10 +60,14 @@ class DeviseSessionsController < Devise::SessionsController
     if params[:continue]
       current_user.invalidate_all_sessions!
       Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name)
-      redirect_to "#{transition_checker_path}/logout?done=1"
+      redirect_to "#{transition_checker_path}/logout?done=#{params[:continue]}"
     elsif params[:done]
-      current_user.invalidate_all_sessions!
-      super
+      if params[:done] == "delete"
+        redirect_to account_delete_confirmation_path
+      else
+        current_user.invalidate_all_sessions!
+        super
+      end
     else
       redirect_to "#{transition_checker_path}/logout?continue=1"
     end


### PR DESCRIPTION
Depends on https://github.com/alphagov/finder-frontend/pull/2293

---


Redirect to checker?continue=delete then, in the logout controller,
check if ?done == delete and if so redirect to the post-delete
confirmation page.

How deleting your account works with services which may have a long
session time is something we'll need to figure out.  The service will
notice as soon as it tries to fetch any of your attributes, but if it
just uses the session cookie to persist some service-specific state it
may be a while before the user is logged out.

---

[Trello card](https://trello.com/c/a9vNNw0Z/395-remove-sign-out-on-nav-after-deleting-account)