### PR TITLE
Require a "." after the "@" of an email address

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -180,10 +180,12 @@ Devise.setup do |config|
   # Range for password length.
   config.password_length = 8..128
 
-  # Email regex used to validate email formats. It simply asserts that
-  # one (and only one) @ exists in the given string. This is mainly
-  # to give user feedback and not to assert the e-mail validity.
-  config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
+  # Check email has exactly one "@" and at least one "." following the
+  # "@".  This doesn't aim to check the email is correct (the only way
+  # you can check that is by sending a message to it and seeing if the
+  # user receives it), but prevents some common syntactic errors which
+  # could never correspond to a valid email address on the Internet.
+  config.email_regexp = /\A[^@\s]+@[^@\s]+\.[^@\s]+\z/
 
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this

--- a/spec/feature/registration_spec.rb
+++ b/spec/feature/registration_spec.rb
@@ -65,8 +65,28 @@ RSpec.feature "Registration" do
     end
   end
 
-  context "when the email is invalid" do
+  context "when the email is missing an '@'" do
     let(:email) { "foo" }
+
+    it "shows an error" do
+      enter_email_address
+
+      expect(page).to have_text(I18n.t("activerecord.errors.models.user.attributes.email.blank"))
+    end
+  end
+
+  context "when the email is missing a '.' after the '@'" do
+    let(:email) { "foo@bar" }
+
+    it "shows an error" do
+      enter_email_address
+
+      expect(page).to have_text(I18n.t("activerecord.errors.models.user.attributes.email.blank"))
+    end
+  end
+
+  context "when the email has multiple '@'s" do
+    let(:email) { "foo@bar@baz" }
 
     it "shows an error" do
       enter_email_address


### PR DESCRIPTION
We've seen an instance of a user registering with "username@gmail" -
we currently allow this, but Notify rejects any attempt to send emails
to the address.  So we should prevent the user from signing up in the
first place.