### PR TITLE
Make the email not found error more descriptive when resetting password

### DIFF
--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -264,7 +264,7 @@ en:
       already_confirmed: "was already confirmed, please try signing in"
       confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
       expired: "has expired, please request a new one"
-      not_found: "not found"
+      not_found: "This email address does not have a GOV.UK account"
       not_locked: "was not locked"
   activerecord:
     errors:


### PR DESCRIPTION
In theory, users should rarely see this error, since we already check the email address has an account before they reach the reset password form.  However, the email may get mis-typed in the second form, so we should show an error that explains the issue properly.

Trello card: https://trello.com/c/rIxNcFqF