### PR TITLE
Pluck email out of user model on post-registration page

### DIFF
--- a/app/controllers/devise_confirmations_controller.rb
+++ b/app/controllers/devise_confirmations_controller.rb
@@ -1,21 +1,5 @@
 class DeviseConfirmationsController < Devise::ConfirmationsController
-  # POST /resource/confirmation
-  # Taken from (https://github.com/heartcombo/devise/blob/715192a7709a4c02127afb067e66230061b82cf2/app/controllers/devise/confirmations_controller.rb)
-  def create
-    self.resource = resource_class.send_confirmation_instructions(resource_params)
-    yield resource if block_given?
-
-    if successfully_sent?(resource)
-      # this passes resource.email, unlike resource_name in the standard method
-      respond_with({}, location: after_resending_confirmation_instructions_path_for(resource.email))
-    else
-      respond_with(resource)
-    end
-  end
-
-protected
-
-  def after_resending_confirmation_instructions_path_for(resource_email)
-    new_user_after_sign_up_path(email: resource_email)
+  def after_resending_confirmation_instructions_path_for(_resource_name)
+    new_user_after_sign_up_path
   end
 end

--- a/app/controllers/devise_registration_controller.rb
+++ b/app/controllers/devise_registration_controller.rb
@@ -234,12 +234,12 @@ class DeviseRegistrationController < Devise::RegistrationsController
 
 protected
 
-  def after_sign_up_path_for(resource)
-    new_user_after_sign_up_path(previous_url: @previous_url, email: resource.email)
+  def after_sign_up_path_for(_resource)
+    new_user_after_sign_up_path(previous_url: @previous_url)
   end
 
-  def after_inactive_sign_up_path_for(resource)
-    new_user_after_sign_up_path(previous_url: @previous_url, email: resource.email)
+  def after_inactive_sign_up_path_for(_resource)
+    new_user_after_sign_up_path(previous_url: @previous_url)
   end
 
   def check_registration_state

--- a/app/controllers/post_registration_controller.rb
+++ b/app/controllers/post_registration_controller.rb
@@ -1,3 +1,5 @@
 class PostRegistrationController < ApplicationController
+  before_action :authenticate_user!
+
   def show; end
 end

--- a/app/views/post_registration/show.html.erb
+++ b/app/views/post_registration/show.html.erb
@@ -11,7 +11,7 @@
     } %>
 
     <p class="govuk-body">
-      <%= t("post_registration.instruction_one") %> <strong><%= params[:email] %></strong>
+      <%= t("post_registration.instruction_one") %> <strong><%= current_user.email %></strong>
     </p>
 
     <p class="govuk-body">


### PR DESCRIPTION
The user exists at this point, and gets logged in at the end of
registration, so there's no need to pass the email address along in
the URL.  This also removes a place where we're logging PII.

And as an additional bonus, we get to remove some copy&pasted Devise
code, which we currently have too much of.

To ensure current_user is not nil (to prevent people from going
straight to the page), check the user is authenticated in the
controller.