### PR TITLE
Present phone number to Notify in E.164 standard format

### DIFF
--- a/app/jobs/notify_sms_delivery_job.rb
+++ b/app/jobs/notify_sms_delivery_job.rb
@@ -13,7 +13,7 @@ class NotifySmsDeliveryJob < ApplicationJob
 
   def perform(phone_number, body)
     Notifications::Client.new(Rails.application.secrets.notify_api_key).send_sms(
-      phone_number: phone_number,
+      phone_number: TelephoneNumber.parse(phone_number, :gb).e164_number,
       template_id: ENV.fetch("GOVUK_NOTIFY_SMS_TEMPLATE_ID"),
       personalisation: {
         body: body,


### PR DESCRIPTION
This will ensure all user input formatting is removed and the number is presented in a standard format.

Note that this only accepts UK numbers, so we will need to remove this line when international support is added (in that case, we should be storing the E.164 number in the database instead).

Examples:
- `(00000) 123456` --> `+440000123456`
- `01234567890 ` --> `+441234567890`