### PR TITLE
Do not allow Sidekiq to retry jobs

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class ApplicationJob < ActiveJob::Base
-  # Automatically retry jobs that encountered a deadlock
-  # retry_on ActiveRecord::Deadlocked
-
-  # Most jobs are safe to ignore if the underlying records are no longer available
-  # discard_on ActiveJob::DeserializationError
+  sidekiq_options retry: false
+  retry_on StandardError, wait: :exponentially_longer, attempts: 5
 end


### PR DESCRIPTION
Sidekiq is currently retrying all jobs and ignoring the ActiveJob `retry_on` and `discard_on` options.

By setting Sidekiq's retry to false, this will allow us to fall back to the ActiveJob retry/discard options.