### PR TITLE
Clone Concourse git resources over https

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -121,7 +121,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 107,
+        "line_number": 105,
         "type": "Basic Auth Credentials"
       }
     ],

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -12,9 +12,8 @@ resources:
     type: git
     icon: github-circle
     source:
-      uri: git@github.com:alphagov/govuk-account-manager-prototype.git
+      uri: https://github.com/alphagov/govuk-account-manager-prototype.git
       branch: main
-      private_key: ((concourse_ci_github_ssh_read_only))
 
   - name: govuk-slack
     type: slack-notification
@@ -25,9 +24,8 @@ resources:
     icon: github-circle
     type: git
     source:
-      uri: git@github.com:alphagov/govuk-account-manager-prototype.git
+      uri: https://github.com/alphagov/govuk-account-manager-prototype.git
       branch: main
-      private_key: ((concourse_ci_github_ssh_read_only))
       paths:
         - concourse/Dockerfile
         - Gemfile*


### PR DESCRIPTION
This repository is public now so we don't need the SSH key.