### PR TITLE
Put mobile number hint over multiple paragraphs

### DIFF
--- a/app/views/devise/registrations/phone.html.erb
+++ b/app/views/devise/registrations/phone.html.erb
@@ -5,7 +5,7 @@
     <%= form_with(url: new_user_registration_phone_code_path(registration_state_id: @registration_state_id), method: :post, class: "mfa-phone-create") do %>
       <%= render "govuk_publishing_components/components/input", {
         label: { text: yield(:title), },
-        hint: t("mfa.phone.create.fields.phone.hint"),
+        hint: sanitize(t("mfa.phone.create.fields.phone.hint")),
         name: "phone",
         heading_size: "xl",
         heading_level: 1,

--- a/config/locales/mfa.en.yml
+++ b/config/locales/mfa.en.yml
@@ -36,7 +36,9 @@ en:
         email_only_alternative: If you do not have a mobile phone, you can still <a class="govuk-link" href="%{email_link}">get email alerts and a link to your results</a>.
         fields:
           phone:
-            hint: We’ll send you a security code by text message. You’ll need the security code to finish creating your account. Security codes help keep your account secure.
+            hint: |
+              <p>We’ll send you a security code by text message. You’ll need the security code to finish creating your account.</p>
+              <p>Security codes help keep your account secure.</p>
             label: Enter your mobile number
           submit:
             label: Continue


### PR DESCRIPTION
Example:
<img width="660" alt="Screenshot 2020-11-09 at 11 14 32" src="https://user-images.githubusercontent.com/6329861/98535491-1ba5b380-227e-11eb-95c4-107e09e902b6.png">

Trello card: https://trello.com/c/gcabI5F6