### PR TITLE
Update "UK transition" langauge to "Brexit transition"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The GOV.UK account manager prototype is an application to test how users:
 This content tells you how to:
 
 - set up and run the GOV.UK account manager prototype
-- integrate the `finder-frontend` transition checker with the GOV.UK account manager
+- integrate the `finder-frontend` Brexit transition checker with the GOV.UK account manager
 
 This content is for GOV.UK developers working on Macs or Linux. If you are not a GOV.UK developer, you cannot use this prototype.
 
@@ -24,7 +24,7 @@ To set up GOV.UK account manager, clone the following repositories (repos) to th
 
 - the [GOV.UK account manager prototype](https://github.com/alphagov/govuk-account-manager-prototype)
 - the [GOV.UK attribute service prototype](https://github.com/alphagov/govuk-attribute-service-prototype)
-- the [finder frontend](https://github.com/alphagov/finder-frontend) that contains the transition checker
+- the [finder frontend](https://github.com/alphagov/finder-frontend) that contains the Brexit transition checker
 - the [email alert API](https://github.com/alphagov/email-alert-api/)
 
 You [create the `~/govuk` folder](https://github.com/alphagov/govuk-docker/blob/master/docs/installation.md#prerequisites) when you install GOV.UK Docker.
@@ -34,7 +34,7 @@ Check out the following branches on the different repos:
 - `enable-account-finder-frontend` branch on the GOV.UK Docker repo
 - `main` branch on the GOV.UK account manager prototype repo
 - `main` branch on the GOV.UK attribute service prototype repo
-- `master` branch on the transition checker repo
+- `master` branch on the Brexit transition checker repo
 
 ## Set up the docker image and database
 
@@ -65,21 +65,21 @@ The `detect-secrets` plugin to the Pre-Commit framework detects secrets within a
 
 To alert developers when they attempt to enter a secret in the codebase, [install the client-side pre-commit hook](https://github.com/Yelp/detect-secrets#client-side-pre-commit-hook).
 
-## Start the transition checker and account manager prototype apps
+## Start the Brexit transition checker and account manager prototype apps
 
-In the command line, go to the `finder-frontend` repo folder and run `govuk-docker-up`. This starts the `finder-frontend` transition checker and its dependencies.
+In the command line, go to the `finder-frontend` repo folder and run `govuk-docker-up`. This starts the `finder-frontend` Brexit transition checker and its dependencies.
 
 Open up a web browser and go to `https://finder-frontend.dev.gov.uk`.
 
 If you have set up the apps correctly, you will be able to access the following links:
 
-- the [transition checker journey start page](http://finder-frontend.dev.gov.uk/transition-check/questions)
-- the [transition checker results page](http://finder-frontend.dev.gov.uk/transition-check/results?c[]=living-ie) that reflects the answers you give during the transition checker journey
+- the [Brexit transition checker journey start page](http://finder-frontend.dev.gov.uk/transition-check/questions)
+- the [Brexit transition checker results page](http://finder-frontend.dev.gov.uk/transition-check/results?c[]=living-ie) that reflects the answers you give during the Brexit transition checker journey
 - select the subscribe banner or button to access the [account sign up page](http://finder-frontend.dev.gov.uk/transition-check/save-your-results?c%5B%5D=living-ie)
 
 When you have set up your local account, you can [sign into your account](http://www.login.service.dev.gov.uk/) and view the manage screens.
 
-You have now set up and run the GOV.UK account manager prototype, and integrated the `finder-frontend` transition checker with the GOV.UK account manager.
+You have now set up and run the GOV.UK account manager prototype, and integrated the `finder-frontend` Brexit transition checker with the GOV.UK account manager.
 
 ## Troubleshooting
 
@@ -102,7 +102,7 @@ govuk-docker run govuk-account-manager-prototype-lite bundle exec rake db:migrat
 govuk-docker run govuk-account-manager-prototype-lite bundle exec rake db:migrate RAILS_ENV=test
 ```
 
-Then [restart the transition checker and account manager prototype apps](#start-the-transition-checker-and-account-manager-prototype-apps).
+Then [restart the Brexit transition checker and account manager prototype apps](#start-the-transition-checker-and-account-manager-prototype-apps).
 
 ### Ruby on Rails configuration changes to the app
 

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -52,7 +52,7 @@ en:
 
           You need to click on the confirmation link to:
             - finish updating the email address for your account
-            - get email updates about the UK transition sent to your new email address
+            - get email updates about the Brexit transition sent to your new email address
 
           If this was not you, you can ignore this email.
 
@@ -72,7 +72,7 @@ en:
 
           You need to click on the confirmation link to:
             - finish creating your account
-            - start receiving email updates about the UK transition
+            - start receiving email updates about the Brexit transition
 
           You will be locked out of your account if you do not confirm your email address within 7 days.
 
@@ -202,7 +202,7 @@ en:
             label: Continue
       transition_checker:
         heading: This email address does not have a GOV.UK account
-        message: To create an account, you need to <a class="govuk-link" href="%{link}">answer a few questions in the UK transition checker</a> and subscribe to email updates.
+        message: To create an account, you need to <a class="govuk-link" href="%{link}">answer a few questions in the Brexit transition checker</a> and subscribe to email updates.
       transition_emails:
         description: |
           <p class="govuk-body">The emails will tell you what you, your family, or your business should do to prepare for new rules from 1 January 2021.</p>
@@ -214,12 +214,12 @@ en:
           <p class="govuk-body">You’ll never get more than one email a day. The email will include all the updates made that day.</p>
         fields:
           emailsignup:
-            heading: Do you want to receive emails about the UK transition?
+            heading: Do you want to receive emails about the Brexit transition?
             'no': No, I just want to save my results
             'yes': 'Yes'
           submit:
             label: Continue
-        heading: Do you want to receive emails about the UK transition?
+        heading: Do you want to receive emails about the Brexit transition?
         unsubscribe: You can unsubscribe from emails or change your subscription at any time.
       update_needs_confirmation: The email address for your account has not been updated yet. You need to click on the confirmation link we’ve emailed you to finish the update.
       updated: Your account has been updated successfully.

--- a/config/locales/doorkeeper_openid_connect.en.yml
+++ b/config/locales/doorkeeper_openid_connect.en.yml
@@ -20,4 +20,4 @@ en:
       openid: Authenticate your account
       test_scope_read: View your local development testing data
       test_scope_write: View and update your local development testing data
-      transition_checker: View your transition checker data
+      transition_checker: View your Brexit transition checker data

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,8 +18,8 @@ en:
       description: 'This will permanently delete this account and all the information stored in it, including:'
       doomed:
       - your contact details
-      - your UK transition results
-      - email alerts about your UK transition results
+      - your Brexit transition results
+      - email alerts about your Brexit transition results
       heading: Delete this GOV.UK account
       insert_text: Deleting your GOV.UK account will not affect any of your other GOV.UK email subscriptions.
     manage:
@@ -64,17 +64,17 @@ en:
     your_account:
       account_not_used:
         action: "%{link} to start getting the most out of your account."
-        description: GOV.UK accounts are designed to make it easier for you to use online government services. At the moment you can only use your account with the UK transition checker.
+        description: GOV.UK accounts are designed to make it easier for you to use online government services. At the moment you can only use your account with the Brexit transition checker.
         heading: You have not used your account to access any services yet
-        link_text: Answer the questions in the UK transition checker
+        link_text: Answer the questions in the Brexit transition checker
       heading: Your GOV.UK account
       transition:
-        description: A personalised list of actions to help you, your family, and your business prepare for the end of the UK transition.
+        description: A personalised list of actions to help you, your family, and your business prepare for the end of the Brexit transition.
         heading: 'Get ready for new rules in 2021: Your results'
         link1: See your results
-        link1_description: Go back to the UK transition results you’ve saved.
+        link1_description: Go back to the Brexit transition results you’ve saved.
         link2: Update your results and email alerts
-        link2_description: Answer the UK transition questions again to update your results.
+        link2_description: Answer the Brexit transition questions again to update your results.
   change_password:
     content: Enter the email address you used to create your GOV.UK account. We’ll  send you an email with instructions for changing your password.
     heading: Change your password
@@ -162,7 +162,7 @@ en:
     instruction_list: |
       <ul class="govuk-list govuk-list--bullet">
         <li>finish creating your account</li>
-        <li>start receiving email updates about the UK transition</li>
+        <li>start receiving email updates about the Brexit transition</li>
       </ul>
     instruction_one: We’ve sent an email to
     instruction_two: 'You need to click on the confirmation link in the email to:'
@@ -201,7 +201,7 @@ en:
     instruction_list: |
       <ul class="govuk-list govuk-list--bullet">
         <li>finish updating the email address for your account</li>
-        <li>get email updates about the UK transition sent to your new email address</li>
+        <li>get email updates about the Brexit transition sent to your new email address</li>
       </ul>
     instruction_one: We’ve sent an email to %{new_email}.
     instruction_two: 'You need to click on the confirmation link in the email to:'

--- a/config/locales/mailer.en.yml
+++ b/config/locales/mailer.en.yml
@@ -63,10 +63,10 @@ en:
 
         GOV.UK accounts are a trial. They’re a first step towards creating a GOV.UK that is more tailored to you and your circumstances.
 
-        At the moment, you can only use your account with the UK transition checker (%{transition_checker_link}) to:
+        At the moment, you can only use your account with the Brexit transition checker (%{transition_checker_link}) to:
 
-          - get email updates about UK transition changes that may affect you
-          - save your UK transition checker results
+          - get email updates about Brexit transition changes that may affect you
+          - save your Brexit transition checker results
 
         In future, we want to add more features to your account so you can:
 


### PR DESCRIPTION
UK civil service has decided that this is the clearest language to
identify the checker, therefore we're updating this everywhere that's
user facing and in our README.md to keep things consistent