### PR TITLE
Allow use of non-UK mobile numbers for two-factor authentication

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,14 @@ class ApplicationController < ActionController::Base
 
   rescue_from Exception, with: :top_level_error_handler
 
+  def e164_number(phone_number)
+    if TelephoneNumber.valid?(phone_number, :gb)
+      TelephoneNumber.parse(phone_number, :gb).e164_number
+    else
+      TelephoneNumber.parse(phone_number).e164_number
+    end
+  end
+
 protected
 
   def top_level_error_handler(exception = nil)

--- a/app/controllers/devise_registration_controller.rb
+++ b/app/controllers/devise_registration_controller.rb
@@ -67,7 +67,7 @@ class DeviseRegistrationController < Devise::RegistrationsController
       return
     end
 
-    phone_number = params[:phone].presence || registration_state.phone
+    phone_number = e164_number(params[:phone].presence || registration_state.phone)
 
     registration_state.transaction do
       registration_state.update!(phone: phone_number)

--- a/app/controllers/edit_phone_controller.rb
+++ b/app/controllers/edit_phone_controller.rb
@@ -10,7 +10,11 @@ class EditPhoneController < ApplicationController
     phone_number = current_user.unconfirmed_phone
 
     if params[:phone]
-      phone_number = params[:phone]
+      phone_number = if TelephoneNumber.valid?(params[:phone], :gb)
+                       TelephoneNumber.parse(params[:phone], :gb).e164_number
+                     else
+                       TelephoneNumber.parse(params[:phone]).e164_number
+                     end
 
       unless current_user.valid_password? params[:current_password]
         @password_error_message = I18n.t("activerecord.errors.models.user.attributes.password.#{params[:current_password].blank? ? 'blank' : 'invalid'}")

--- a/app/controllers/edit_phone_controller.rb
+++ b/app/controllers/edit_phone_controller.rb
@@ -10,11 +10,7 @@ class EditPhoneController < ApplicationController
     phone_number = current_user.unconfirmed_phone
 
     if params[:phone]
-      phone_number = if TelephoneNumber.valid?(params[:phone], :gb)
-                       TelephoneNumber.parse(params[:phone], :gb).e164_number
-                     else
-                       TelephoneNumber.parse(params[:phone]).e164_number
-                     end
+      phone_number = e164_number(params[:phone])
 
       unless current_user.valid_password? params[:current_password]
         @password_error_message = I18n.t("activerecord.errors.models.user.attributes.password.#{params[:current_password].blank? ? 'blank' : 'invalid'}")

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -46,4 +46,14 @@ module ApplicationHelper
     base_url = Rails.env.development? ? Plek.find("collections") : Plek.new.website_root
     "#{base_url}/transition"
   end
+
+  def formatted_phone_number(number)
+    parsed_number = TelephoneNumber.parse(number)
+
+    if parsed_number.country && parsed_number.country.country_id == "GB"
+      parsed_number.national_number
+    else
+      parsed_number.international_number
+    end
+  end
 end

--- a/app/helpers/manage_helper.rb
+++ b/app/helpers/manage_helper.rb
@@ -34,7 +34,7 @@ module ManageHelper
 
     phone = {
       field: t("general.phone"),
-      value: current_user.phone,
+      value: formatted_phone_number(current_user.phone),
       edit: {
         href: edit_user_registration_phone_url,
         text: t("general.change"),

--- a/app/jobs/notify_sms_delivery_job.rb
+++ b/app/jobs/notify_sms_delivery_job.rb
@@ -13,7 +13,7 @@ class NotifySmsDeliveryJob < ApplicationJob
 
   def perform(phone_number, body)
     Notifications::Client.new(Rails.application.secrets.notify_api_key).send_sms(
-      phone_number: TelephoneNumber.parse(phone_number, :gb).e164_number,
+      phone_number: phone_number,
       template_id: ENV.fetch("GOVUK_NOTIFY_SMS_TEMPLATE_ID"),
       personalisation: {
         body: body,

--- a/app/views/devise/registrations/phone_code.html.erb
+++ b/app/views/devise/registrations/phone_code.html.erb
@@ -10,7 +10,7 @@
       margin_bottom: 3,
     } %>
 
-    <% t("mfa.phone.code.description_with_phone_number", phone_number: @registration_state.phone).each do |msg| %>
+    <% t("mfa.phone.code.description_with_phone_number", phone_number: formatted_phone_number(@registration_state.phone)).each do |msg| %>
       <p class="govuk-body"><%= sanitize(msg) %></p>
     <% end %>
 

--- a/app/views/devise/registrations/phone_resend.html.erb
+++ b/app/views/devise/registrations/phone_resend.html.erb
@@ -23,7 +23,7 @@
         <%= render "govuk_publishing_components/components/input", {
           label: { text: t("mfa.phone.resend.fields.phone.label") },
           name: "phone",
-          value: @phone,
+          value: formatted_phone_number(@phone),
           width: 10,
           autocomplete: "tel",
         } %>

--- a/app/views/edit_phone/code.html.erb
+++ b/app/views/edit_phone/code.html.erb
@@ -7,7 +7,7 @@
       margin_bottom: 3,
     } %>
 
-    <% t("mfa.phone.code.description_with_phone_number", phone_number: current_user.unconfirmed_phone).each do |msg| %>
+    <% t("mfa.phone.code.description_with_phone_number", phone_number: formatted_phone_number(current_user.unconfirmed_phone)).each do |msg| %>
       <p class="govuk-body"><%= sanitize(msg) %></p>
     <% end %>
 
@@ -39,7 +39,7 @@
     </p>
 
     <p class="govuk-body">
-      <%= sanitize(t("mfa.phone.code.not_received.change_number_message", link: edit_user_registration_phone_path,  phone_number: current_user.unconfirmed_phone)) %>
+      <%= sanitize(t("mfa.phone.code.not_received.change_number_message", link: edit_user_registration_phone_path,  phone_number: formatted_phone_number(current_user.unconfirmed_phone))) %>
     </p>
   </div>
 </div>

--- a/app/views/edit_phone/show.html.erb
+++ b/app/views/edit_phone/show.html.erb
@@ -19,7 +19,7 @@
     </p>
 
     <%= render "govuk_publishing_components/components/inset_text", {
-      text: t("mfa.phone.update.start.current", phone_number: current_user.phone)
+      text: t("mfa.phone.update.start.current", phone_number: formatted_phone_number(current_user.phone))
     } %>
 
     <%= form_with(url: edit_user_registration_phone_code_path, method: :post) do %>

--- a/db/migrate/20201110103355_standardise_phone_number.rb
+++ b/db/migrate/20201110103355_standardise_phone_number.rb
@@ -1,0 +1,22 @@
+class StandardisePhoneNumber < ActiveRecord::Migration[6.0]
+  def up
+    User.all.each do |user|
+      if user.phone
+        standardised_phone = TelephoneNumber.parse(user.phone, :gb).e164_number
+        user.update!(phone: standardised_phone)
+      end
+
+      if user.unconfirmed_phone
+        standardised_phone = TelephoneNumber.parse(user.unconfirmed_phone, :gb).e164_number
+        user.update!(unconfirmed_phone: standardised_phone)
+      end
+    end
+
+    RegistrationState.all.each do |registration|
+      if registration.phone
+        standardised_phone = TelephoneNumber.parse(registration.phone, :gb).e164_number
+        registration.update!(phone: standardised_phone)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_02_155441) do
+ActiveRecord::Schema.define(version: 2020_11_10_103355) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/lib/multi_factor_auth.rb
+++ b/lib/multi_factor_auth.rb
@@ -7,7 +7,15 @@ module MultiFactorAuth
   class NotConfigured < MFAError; end
 
   def self.valid?(phone_number)
-    TelephoneNumber.valid?(phone_number, :gb, [:mobile])
+    parsed_number = TelephoneNumber.parse(phone_number)
+
+    if TelephoneNumber.valid?(phone_number, :gb, [:mobile])
+      true
+    elsif parsed_number.country && parsed_number.valid? && parsed_number.valid_types.include?(:mobile)
+      true
+    else
+      false
+    end
   end
 
   def self.generate_and_send_code(auth, use_unconfirmed: false)

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     email { "email@example.com" }
     password { "abcd1234" }
     password_confirmation { "abcd1234" }
-    phone { "07958123456" }
+    phone { "+447958123456" }
 
     factory :confirmed_user do
       confirmed_at { Time.zone.now }

--- a/spec/feature/change_phone_spec.rb
+++ b/spec/feature/change_phone_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Change Phone" do
     enter_mfa
 
     expect(page).to have_text(I18n.t("account.manage.heading"))
-    expect(user.reload.phone).to eq(new_phone_number)
+    expect(user.reload.phone).to eq("+447581123456")
   end
 
   context "when the user enters the same phone number" do

--- a/spec/feature/change_phone_spec.rb
+++ b/spec/feature/change_phone_spec.rb
@@ -6,7 +6,6 @@ RSpec.feature "Change Phone" do
 
   let(:user) { FactoryBot.create(:user) }
 
-  # BT line test number
   let(:new_phone_number) { "07581123456" }
 
   it "updates the phone number" do

--- a/spec/feature/registration_spec.rb
+++ b/spec/feature/registration_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Registration" do
   let(:force_jwt) { false }
   let(:email) { "email@example.com" }
   # https://www.ofcom.org.uk/phones-telecoms-and-internet/information-for-industry/numbering/numbers-for-drama
-  let(:phone_number) { "07958123456" }
+  let(:phone_number) { "07958 123 456" }
   let(:password) { "abcd1234" } # pragma: allowlist secret
   let(:password_confirmation) { password }
 
@@ -26,7 +26,7 @@ RSpec.feature "Registration" do
 
     expect(User.last).to_not be_nil
     expect(User.last.email).to eq(email)
-    expect(User.last.phone).to eq(phone_number)
+    expect(User.last.phone).to eq("+447958123456")
   end
 
   it "sends an email" do

--- a/spec/feature/registration_spec.rb
+++ b/spec/feature/registration_spec.rb
@@ -159,6 +159,18 @@ RSpec.feature "Registration" do
     end
   end
 
+  context "when the phone number is international" do
+    it "sends an email" do
+      enter_email_address
+      enter_password_and_confirmation
+      enter_international_phone_number
+      enter_mfa
+      provide_consent
+
+      assert_enqueued_jobs 1, only: NotifyDeliveryJob
+    end
+  end
+
   context "when the MFA code is incorrect" do
     it "returns an error" do
       enter_email_address
@@ -264,6 +276,11 @@ RSpec.feature "Registration" do
 
   def enter_invalid_phone_number
     fill_in "phone", with: "999"
+    click_on I18n.t("mfa.phone.create.fields.submit.label")
+  end
+
+  def enter_international_phone_number
+    fill_in "phone", with: "+15417543010"
     click_on I18n.t("mfa.phone.create.fields.submit.label")
   end
 


### PR DESCRIPTION
We currently only permit UK mobile numbers for the MFA process.  There has been user demand to use non-UK numbers, and Notify already support this.

This PR makes a number of changes to support international numbers and standardise the way we store telephone numbers across the application:
- Changes all existing, unconfirmed and registration in progress phone numbers to E.164 format (an international standard, where we include the country code and remove localised formatting).
- As a side effect of the above, we now validate the user isn't entering a slightly reformatted version of their existing phone number when changing the number.
- Additionally, the above change means we strip control characters (e.g. left-to-right overrides added by browsers when certain languages are enabled) and removes user errors (e.g. `O` entered instead of `0`).
- Present numbers to the user in the correct format, e.g. a UK mobile number will always be presented as `00000 000000` regardless of how it is stored in the database; international numbers will always be presented with an international code.
- Update the validation to allow non-UK numbers with an international dialling code, plus UK numbers with or without the international dialling code.

Trello card: https://trello.com/c/Qf5KpJ4R