### PR TITLE
Add hint text on "Delete this GOV.UK account" page

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -4,7 +4,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2020-11-10T09:58:33Z",
+  "generated_at": "2020-11-10T15:29:21Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -168,7 +168,7 @@
       {
         "hashed_secret": "7550b672e162c224c309bdea5d48ca975081a904",
         "is_verified": false,
-        "line_number": 186,
+        "line_number": 187,
         "type": "Secret Keyword"
       }
     ],

--- a/app/views/delete/show.html.erb
+++ b/app/views/delete/show.html.erb
@@ -30,6 +30,8 @@
         label: {
           text: t("devise.registrations.edit.fields.current_password.label"),
         },
+        heading_size: "m",
+        hint: t("devise.registrations.edit.fields.current_password.hint_delete"),
         name: "current_password",
         type: "password",
         error_message: @password_error_message,

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -170,6 +170,7 @@ en:
         fields:
           current_password:
             hint: Enter your current password to make this change
+            hint_delete: Enter your password to delete your account
             label: Confirm it’s you
           email:
             inset_text: 'The email address currently stored in your GOV.UK account is: %{email}'


### PR DESCRIPTION
In 7352963e1d2cd17df1ffb12aba9137c08b6dd87d, we updated the label for the current password field and added a hint in other places. This was missed, so adding the hint now.

Example: 
![Screenshot 2020-11-10 at 15 31 48](https://user-images.githubusercontent.com/6329861/98695016-0efe8980-236a-11eb-8b9e-baf457c6df7a.png)