### PR TITLE
Add cancel link to all account edit forms

### DIFF
--- a/app/views/devise/registrations/edit_email.html.erb
+++ b/app/views/devise/registrations/edit_email.html.erb
@@ -50,6 +50,7 @@
       <%= render "govuk_publishing_components/components/button", {
         text: t("devise.registrations.edit.fields.submit.label"),
         margin_bottom: 3,
+        inline_layout: true,
         data_attributes: {
           module: "gem-track-click",
           "track-category": "account-manage",
@@ -57,6 +58,17 @@
           "track-label": ""
         }
       } %>
+      <span class="govuk-body"><%= t("general.or") %></span>
+      <%= link_to t("general.cancel"),
+        account_manage_path,
+        class: "govuk-body govuk-link",
+        data: {
+          module: "gem-track-click",
+          "track-category": "account-manage",
+          "track-action": "email",
+          "track-label": "cancel"
+        }
+      %>
     <% end %>
   </div>
 </div>

--- a/app/views/devise/registrations/edit_password.html.erb
+++ b/app/views/devise/registrations/edit_password.html.erb
@@ -57,6 +57,7 @@
       <%= render "govuk_publishing_components/components/button", {
         text: t("devise.registrations.edit.fields.submit.label"),
         margin_bottom: 3,
+        inline_layout: true,
         data_attributes: {
           module: "gem-track-click",
           "track-category": "account-manage",
@@ -64,6 +65,17 @@
           "track-label": ""
         }
       } %>
+      <span class="govuk-body"><%= t("general.or") %></span>
+      <%= link_to t("general.cancel"),
+        account_manage_path,
+        class: "govuk-body govuk-link",
+        data: {
+          module: "gem-track-click",
+          "track-category": "account-manage",
+          "track-action": "password",
+          "track-label": "cancel"
+        }
+      %>
     <% end %>
   </div>
 </div>

--- a/app/views/edit_consent/cookie.html.erb
+++ b/app/views/edit_consent/cookie.html.erb
@@ -44,7 +44,13 @@
 
       <%= render "govuk_publishing_components/components/button", {
         text: t("devise.registrations.your_information.fields.submit.update_label"),
+        inline_layout: true,
       } %>
+      <span class="govuk-body"><%= t("general.or") %></span>
+      <%= link_to t("general.cancel"),
+        account_manage_path,
+        class: "govuk-body govuk-link"
+      %>
     <% end %>
   </div>
 </div>

--- a/app/views/edit_consent/feedback.html.erb
+++ b/app/views/edit_consent/feedback.html.erb
@@ -44,7 +44,13 @@
 
       <%= render "govuk_publishing_components/components/button", {
         text: t("devise.registrations.your_information.fields.submit.update_label"),
+        inline_layout: true,
       } %>
+      <span class="govuk-body"><%= t("general.or") %></span>
+      <%= link_to t("general.cancel"),
+        account_manage_path,
+        class: "govuk-body govuk-link"
+      %>
     <% end %>
   </div>
 </div>

--- a/app/views/edit_phone/show.html.erb
+++ b/app/views/edit_phone/show.html.erb
@@ -43,7 +43,13 @@
 
       <%= render "govuk_publishing_components/components/button", {
         text: t("mfa.phone.update.start.fields.submit.label"),
+        inline_layout: true,
       } %>
+      <span class="govuk-body"><%= t("general.or") %></span>
+      <%= link_to t("general.cancel"),
+        account_manage_path,
+        class: "govuk-body govuk-link"
+      %>
     <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -133,7 +133,7 @@ en:
         <p class="govuk-body"><a href="/account" class="govuk-link">Go to your account</a></p>
       heading: Feedback sent
   general:
-    cancel: Cancel
+    cancel: cancel
     change: Change
     email: Email
     'no': 'No'


### PR DESCRIPTION
Adds a "or cancel" link to each account edit form, which returns the user to the main account management view.

I've added analytics data where this has already been included elsewhere in the view.

Example:
![Screenshot 2020-11-11 at 11 37 00](https://user-images.githubusercontent.com/6329861/98807410-8556c680-2412-11eb-8793-1603cb445e50.png)

Trello card: https://trello.com/c/nYgMdHG6