### PR TITLE
Only use the phrase 'current password' when changing password

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -4,7 +4,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2020-11-12T10:00:21Z",
+  "generated_at": "2020-11-12T10:16:18Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -168,13 +168,13 @@
       {
         "hashed_secret": "7550b672e162c224c309bdea5d48ca975081a904",
         "is_verified": false,
-        "line_number": 187,
+        "line_number": 188,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "0be7a248fb840ae80587ee2cafee5388126e543c",
         "is_verified": false,
-        "line_number": 277,
+        "line_number": 278,
         "type": "Secret Keyword"
       }
     ],

--- a/app/views/devise/registrations/edit_password.html.erb
+++ b/app/views/devise/registrations/edit_password.html.erb
@@ -46,7 +46,7 @@
           text: t("devise.registrations.edit.fields.current_password.label"),
         },
         heading_size: "m",
-        hint: t("devise.registrations.edit.fields.current_password.hint"),
+        hint: t("devise.registrations.edit.fields.current_password.hint_current"),
         name: "user[current_password]",
         type: "password",
         id: "current__confirmation",

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -169,7 +169,8 @@ en:
           heading: Cancel my account
         fields:
           current_password:
-            hint: Enter your current password to make this change
+            hint: Enter your password to make this change
+            hint_current: Enter your current password to make this change
             hint_delete: Enter your password to delete your account
             label: Confirm it’s you
           email:


### PR DESCRIPTION
We want to say `Enter your password to make this change` in all places, except when deleting your account or changing your current password.

Trello card: https://trello.com/c/yhztJsP6