### PR TITLE
Ignore 404 and 410 errors in deactivating email subscription

### DIFF
--- a/app/models/email_subscription.rb
+++ b/app/models/email_subscription.rb
@@ -23,5 +23,8 @@ class EmailSubscription < ApplicationRecord
     return unless subscription_id
 
     Services.email_alert_api.unsubscribe(subscription_id)
+  rescue GdsApi::HTTPGone, GdsApi::HTTPNotFound
+    # this can happen if the subscription has been deactivated by the
+    # user through email-alert-frontend
   end
 end


### PR DESCRIPTION
If deactivating a subscription fails because it's already gone, don't
throw an error.