### PR TITLE
Change production log level to :warn

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -44,7 +44,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :warn
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]


### PR DESCRIPTION
We are currently writing a lot of stuff to the logs and these are also getting in the way of rake task output. Changing the level to :warn (from :debug) should remove most of the noise.