### PR TITLE
Post account statistics to Slack daily at 3pm

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -4,7 +4,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2020-11-12T10:16:18Z",
+  "generated_at": "2020-11-13T11:14:32Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -121,8 +121,16 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 105,
+        "line_number": 112,
         "type": "Basic Auth Credentials"
+      }
+    ],
+    "concourse/tasks/daily-statistics.yml": [
+      {
+        "hashed_secret": "47748b1fd1747e8bff5493fa6c3bcf16d6449969",
+        "is_verified": false,
+        "line_number": 6,
+        "type": "Hex High Entropy String"
       }
     ],
     "concourse/tasks/deploy-to-govuk-paas.yml": [

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -35,6 +35,13 @@ resources:
     source:
       interval: 24h
 
+  - name: every-afternoon
+    type: time
+    source:
+      start: 15:00
+      stop: 16:00
+      location: Europe/London
+
   - name: tests-image
     type: docker-image
     icon: docker
@@ -258,3 +265,24 @@ jobs:
               :kaboom:
               Production smoke tests for the GOV.UK Account manager have failed
               Failed build: http://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
+
+  - name: daily-statistics-export
+    serial: true
+    plan:
+      - get: every-afternoon
+        trigger: true
+      - get: git-main
+        trigger: true
+      - task: daily-statistics
+        file: git-main/concourse/tasks/daily-statistics.yml
+        params:
+          CF_ORG: govuk-accounts
+          CF_APP_NAME: govuk-account-manager
+          CF_SPACE: production
+        on_success:
+          put: govuk-slack
+          params:
+            channel: '#govuk-accounts'
+            username: 'Daily GOV.UK Account Statistics'
+            icon_emoji: ':chart_with_upwards_trend:'
+            attachments_file: statistics/output.json

--- a/concourse/tasks/daily-statistics.yml
+++ b/concourse/tasks/daily-statistics.yml
@@ -1,0 +1,28 @@
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: governmentpaas/cf-cli
+    tag: e1ffec0d1940706f157a8c1e0ab8131b7084fa1c
+inputs:
+  - name: git-main
+    path: src
+outputs:
+  - name: statistics
+params:
+  CF_API: https://api.london.cloud.service.gov.uk
+  CF_USERNAME: ((paas-username))
+  CF_PASSWORD: ((paas-password))
+
+run:
+  path: sh
+  args:
+    - "-c"
+    - |
+      set -eu
+
+      cf api "$CF_API"
+      cf auth
+      cf t -o "$CF_ORG" -s "$CF_SPACE"
+
+      cf ssh $CF_APP_NAME -c "/tmp/lifecycle/launcher /home/vcap/app 'rake statistics:general' ''" > statistics/output.json

--- a/lib/tasks/statistics.rake
+++ b/lib/tasks/statistics.rake
@@ -1,7 +1,7 @@
 namespace :statistics do
   desc "Get information on all registrations and logins"
   task :general, %i[start_date end_date] => [:environment] do |_, args|
-    args.with_defaults(start_date: Date.yesterday.midnight.to_s, end_date: Date.yesterday.end_of_day.to_s)
+    args.with_defaults(start_date: Time.zone.parse("15:00:00") - 1.day, end_date: Time.zone.parse("14:59:59"))
 
     all_users = User
       .where("created_at < ?", args.end_date)

--- a/lib/tasks/statistics.rake
+++ b/lib/tasks/statistics.rake
@@ -3,74 +3,76 @@ namespace :statistics do
   task :general, %i[start_date end_date] => [:environment] do |_, args|
     args.with_defaults(start_date: Time.zone.parse("15:00:00") - 1.day, end_date: Time.zone.parse("14:59:59"))
 
+    results = ""
+
     all_users = User
       .where("created_at < ?", args.end_date)
 
     total_users = all_users
       .count
-    puts "All registrations to #{args.end_date}: \n#{total_users}\n\n"
+    results += "All registrations to #{args.end_date}: \n#{total_users}\n\n"
 
     all_new_users = User
       .where("created_at BETWEEN ? AND ?", args.start_date, args.end_date)
 
     new_users = all_new_users
       .count
-    puts "New registrations between #{args.start_date} and #{args.end_date}: \n#{new_users}\n\n"
+    results += "New registrations between #{args.start_date} and #{args.end_date}: \n#{new_users}\n\n"
 
     all_cookie_consent = all_users
       .pluck(:cookie_consent)
       .tally
-    puts "Cookie consents to #{args.end_date}:\n"
+    results += "Cookie consents to #{args.end_date}:\n"
     all_cookie_consent.each do |value, count|
-      puts "#{value} #{count}"
+      results += "#{value} #{count}"
     end
-    puts "\n"
+    results += "\n"
 
     new_cookie_consent = all_new_users
       .pluck(:cookie_consent)
       .tally
-    puts "Cookie consents for registrations between #{args.start_date} and #{args.end_date}:\n"
+    results += "Cookie consents for registrations between #{args.start_date} and #{args.end_date}:\n"
     new_cookie_consent.each do |value, count|
-      puts "#{value} #{count}"
+      results += "#{value} #{count}"
     end
-    puts "\n"
+    results += "\n"
 
     all_feedback_consent = all_users
       .pluck(:feedback_consent)
       .tally
-    puts "Feedback consents to #{args.end_date}:\n"
+    results += "Feedback consents to #{args.end_date}:\n"
     all_feedback_consent.each do |value, count|
-      puts "#{value} #{count}"
+      results += "#{value} #{count}"
     end
-    puts "\n"
+    results += "\n"
 
     new_feedback_consent = all_new_users
       .pluck(:feedback_consent)
       .tally
-    puts "Feedback consents for registrations between #{args.start_date} and #{args.end_date}:\n"
+    results += "Feedback consents for registrations between #{args.start_date} and #{args.end_date}:\n"
     new_feedback_consent.each do |value, count|
-      puts "#{value} #{count}"
+      results += "#{value} #{count}"
     end
-    puts "\n"
+    results += "\n"
 
     all_logins = SecurityActivity
       .where(event_type: "login")
       .where("created_at < ?", args.end_date)
-    puts "Total number of logins to #{args.end_date}: \n#{all_logins.count}\n\n"
+    results += "Total number of logins to #{args.end_date}: \n#{all_logins.count}\n\n"
 
     interval_logins = all_logins
       .where("created_at BETWEEN ? AND ?", args.start_date, args.end_date)
-    puts "Total number of logins between #{args.start_date} and #{args.end_date}: \n#{interval_logins.count}\n\n"
+    results += "Total number of logins between #{args.start_date} and #{args.end_date}: \n#{interval_logins.count}\n\n"
 
     all_user_logins = all_logins
       .pluck(:user_id)
       .uniq
-    puts "Accounts logged in to #{args.end_date}: \n#{all_user_logins.count}\n\n"
+    results += "Accounts logged in to #{args.end_date}: \n#{all_user_logins.count}\n\n"
 
     user_logins = interval_logins
       .pluck(:user_id)
       .uniq
-    puts "Accounts logged in between #{args.start_date} and #{args.end_date}: \n#{user_logins.count}\n\n"
+    results += "Accounts logged in between #{args.start_date} and #{args.end_date}: \n#{user_logins.count}\n\n"
 
     all_login_frequency = SecurityActivity
       .where(event_type: "login")
@@ -80,11 +82,11 @@ namespace :statistics do
       .values
       .tally
       .sort
-    puts "Number of logins per account to #{args.end_date}:\n"
+    results += "Number of logins per account to #{args.end_date}:\n"
     all_login_frequency.each do |frequency, count|
-      puts "Accounts logged into #{frequency} #{'time'.pluralize(frequency)}: #{count}"
+      results += "Accounts logged into #{frequency} #{'time'.pluralize(frequency)}: #{count}"
     end
-    puts "\n"
+    results += "\n"
 
     login_frequency = SecurityActivity
       .where(event_type: "login")
@@ -94,9 +96,16 @@ namespace :statistics do
       .values
       .tally
       .sort
-    puts "Number of logins between #{args.start_date} and #{args.end_date}:\n"
+    results += "Number of logins between #{args.start_date} and #{args.end_date}:\n"
     login_frequency.each do |frequency, count|
-      puts "Accounts logged into #{frequency} #{'time'.pluralize(frequency)}: #{count}"
+      results += "Accounts logged into #{frequency} #{'time'.pluralize(frequency)}: #{count}"
     end
+
+    output = [{
+      title: "Daily Statistics",
+      text: results,
+    }]
+
+    puts output.to_json
   end
 end


### PR DESCRIPTION
I am currently running the `statistics:general` rake task each day after 3pm to provide our performance analyst with metrics on account signups and logins.  Posting this to Slack daily will eliminate the need for this task to be run manually, and remove the need to SSH into a production machine.

Example of the Slack post (the metrics are an attachment and can be downloaded as a file, if needed):
![Screenshot 2020-11-16 at 09 52 18](https://user-images.githubusercontent.com/6329861/99238839-228a7400-27f2-11eb-9366-bf6ecf43a6ab.png)
_Note that data in this screenshot is all fake data from my local development environment._

Trello card: https://trello.com/c/KR4v2IvD