### PR TITLE
Fix statistics rake task posting to Slack

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -22,6 +22,7 @@ require "sprockets/railtie"
 Bundler.require(*Rails.groups)
 
 Raven.configure do |config|
+  config.silence_ready = true
   config.dsn = ENV["SENTRY_DSN"]
   config.before_send = lambda { |event, _hint|
     if event.extra.dig(:sidekiq, :job, :args, :arguments)

--- a/lib/tasks/statistics.rake
+++ b/lib/tasks/statistics.rake
@@ -24,7 +24,7 @@ namespace :statistics do
       .tally
     results += "Cookie consents to #{args.end_date}:\n"
     all_cookie_consent.each do |value, count|
-      results += "#{value} #{count}"
+      results += "#{value} #{count}\n"
     end
     results += "\n"
 
@@ -33,7 +33,7 @@ namespace :statistics do
       .tally
     results += "Cookie consents for registrations between #{args.start_date} and #{args.end_date}:\n"
     new_cookie_consent.each do |value, count|
-      results += "#{value} #{count}"
+      results += "#{value} #{count}\n"
     end
     results += "\n"
 
@@ -42,7 +42,7 @@ namespace :statistics do
       .tally
     results += "Feedback consents to #{args.end_date}:\n"
     all_feedback_consent.each do |value, count|
-      results += "#{value} #{count}"
+      results += "#{value} #{count}\n"
     end
     results += "\n"
 
@@ -51,7 +51,7 @@ namespace :statistics do
       .tally
     results += "Feedback consents for registrations between #{args.start_date} and #{args.end_date}:\n"
     new_feedback_consent.each do |value, count|
-      results += "#{value} #{count}"
+      results += "#{value} #{count}\n"
     end
     results += "\n"
 
@@ -84,7 +84,7 @@ namespace :statistics do
       .sort
     results += "Number of logins per account to #{args.end_date}:\n"
     all_login_frequency.each do |frequency, count|
-      results += "Accounts logged into #{frequency} #{'time'.pluralize(frequency)}: #{count}"
+      results += "Accounts logged into #{frequency} #{'time'.pluralize(frequency)}: #{count}\n"
     end
     results += "\n"
 
@@ -98,7 +98,7 @@ namespace :statistics do
       .sort
     results += "Number of logins between #{args.start_date} and #{args.end_date}:\n"
     login_frequency.each do |frequency, count|
-      results += "Accounts logged into #{frequency} #{'time'.pluralize(frequency)}: #{count}"
+      results += "Accounts logged into #{frequency} #{'time'.pluralize(frequency)}: #{count}\n"
     end
 
     output = [{

--- a/lib/tasks/statistics.rake
+++ b/lib/tasks/statistics.rake
@@ -24,7 +24,7 @@ namespace :statistics do
       .tally
     results += "Cookie consents to #{args.end_date}:\n"
     all_cookie_consent.each do |value, count|
-      results += "#{value} #{count}\n"
+      results += "#{value.to_s.humanize} #{count}\n"
     end
     results += "\n"
 
@@ -33,7 +33,7 @@ namespace :statistics do
       .tally
     results += "Cookie consents for registrations between #{args.start_date} and #{args.end_date}:\n"
     new_cookie_consent.each do |value, count|
-      results += "#{value} #{count}\n"
+      results += "#{value.to_s.humanize} #{count}\n"
     end
     results += "\n"
 
@@ -42,7 +42,7 @@ namespace :statistics do
       .tally
     results += "Feedback consents to #{args.end_date}:\n"
     all_feedback_consent.each do |value, count|
-      results += "#{value} #{count}\n"
+      results += "#{value.to_s.humanize} #{count}\n"
     end
     results += "\n"
 
@@ -51,7 +51,7 @@ namespace :statistics do
       .tally
     results += "Feedback consents for registrations between #{args.start_date} and #{args.end_date}:\n"
     new_feedback_consent.each do |value, count|
-      results += "#{value} #{count}\n"
+      results += "#{value.to_s.humanize} #{count}\n"
     end
     results += "\n"
 


### PR DESCRIPTION
This behaved differently in my local environment to in production so it didn't post to Slack at 3pm yesterday.

This makes the following fix that was stopping the JSON from being valid:
- Stop Sentry writing "Raven [version] ready to catch errors" to STDOUT upon running each rake task

In addition, I have made a few improvements to the output:
- Added a few missing new lines, that were lost when changing puts multiple puts to a single usage
- Humanize the boolean values (i.e. `true` and `false` become `True` and `False`)

Trello card: https://trello.com/c/KR4v2IvD