### PR TITLE
Do not trigger statistics job on git-main

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -272,7 +272,6 @@ jobs:
       - get: every-afternoon
         trigger: true
       - get: git-main
-        trigger: true
       - task: daily-statistics
         file: git-main/concourse/tasks/daily-statistics.yml
         params:


### PR DESCRIPTION
This was triggering the daily statistics job each time code was merged into main.

Trello card: https://trello.com/c/KR4v2IvD