### PR TITLE
Rearrange tests to match rspec directory layout best practice

### DIFF
--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe ApplicationHelper, type: :helper do
+RSpec.describe ApplicationHelper do
   include ActiveSupport::Testing::TimeHelpers
 
   describe "#date_with_time_ago" do

--- a/spec/helpers/post_registration_helper_spec.rb
+++ b/spec/helpers/post_registration_helper_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe PostRegistrationHelper, type: :helper do
+RSpec.describe PostRegistrationHelper do
   describe "#service_for" do
     let(:user) { FactoryBot.create(:user) }
 

--- a/spec/jobs/activate_email_subscriptions_job_spec.rb
+++ b/spec/jobs/activate_email_subscriptions_job_spec.rb
@@ -1,6 +1,6 @@
 require "gds_api/test_helpers/email_alert_api"
 
-RSpec.describe ActivateEmailSubscriptionsJob, type: :job do
+RSpec.describe ActivateEmailSubscriptionsJob do
   include GdsApi::TestHelpers::EmailAlertApi
 
   let(:user) { FactoryBot.create(:confirmed_user) }

--- a/spec/jobs/expire_login_state_job_spec.rb
+++ b/spec/jobs/expire_login_state_job_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe ExpireLoginStateJob, type: :job do
+RSpec.describe ExpireLoginStateJob do
   include ActiveSupport::Testing::TimeHelpers
 
   let!(:user) { FactoryBot.create(:user) }

--- a/spec/jobs/expire_registration_state_job_spec.rb
+++ b/spec/jobs/expire_registration_state_job_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe ExpireRegistrationStateJob, type: :job do
+RSpec.describe ExpireRegistrationStateJob do
   include ActiveSupport::Testing::TimeHelpers
 
   it "deletes hour-old state" do

--- a/spec/jobs/zendesk_ticket_job_spec.rb
+++ b/spec/jobs/zendesk_ticket_job_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe ZendeskTicketJob, type: :job do
+RSpec.describe ZendeskTicketJob do
   let(:ticket_attributes) do
     {
       subject: I18n.t("feedback.email_subject"),

--- a/spec/lib/account_manager_application_spec.rb
+++ b/spec/lib/account_manager_application_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe AccountManagerApplication, type: :unit do
+RSpec.describe AccountManagerApplication do
   context "the application exists" do
     let!(:application) do
       FactoryBot.create(

--- a/spec/lib/healthcheck_spec.rb
+++ b/spec/lib/healthcheck_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Healthcheck, type: :unit do
+RSpec.describe Healthcheck do
   let(:subject) { Healthcheck.check }
 
   let(:active_record) { double(:active_record, connection: true) }

--- a/spec/lib/remote_user_info_spec.rb
+++ b/spec/lib/remote_user_info_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe RemoteUserInfo, type: :unit do
+RSpec.describe RemoteUserInfo do
   let(:attribute_service_url) { "https://attribute-service" }
 
   let(:user) { FactoryBot.create(:user) }

--- a/spec/lib/zendesk/ticket_spec.rb
+++ b/spec/lib/zendesk/ticket_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Zendesk::Ticket, type: :unit do
+RSpec.describe Zendesk::Ticket do
   context "with a valid request" do
     let(:ticket_attributes) do
       {

--- a/spec/models/application_key_spec.rb
+++ b/spec/models/application_key_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe ApplicationKey, type: :unit do
+RSpec.describe ApplicationKey do
   let!(:application) do
     FactoryBot.create(
       :oauth_application,

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,6 @@
 require "gds_api/test_helpers/email_alert_api"
 
-RSpec.describe User, type: :unit do
+RSpec.describe User do
   include GdsApi::TestHelpers::EmailAlertApi
 
   let(:attribute_service_url) { "https://attribute-service" }

--- a/spec/requests/account_spec.rb
+++ b/spec/requests/account_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-RSpec.feature "/account" do
+RSpec.describe "/account" do
   let!(:application) do
     FactoryBot.create(
       :oauth_application,
@@ -15,7 +15,7 @@ RSpec.feature "/account" do
   let(:userinfo) { {} }
 
   before do
-    log_in(user.email, user.password)
+    sign_in user
 
     stub_request(:get, "http://attribute-service/oidc/user_info").to_return(body: userinfo.to_json)
   end
@@ -28,9 +28,9 @@ RSpec.feature "/account" do
 
   context "without any states" do
     it "shows the zero state service card" do
-      visit user_root_path
+      get user_root_path
 
-      expect(page).to have_text(I18n.t("account.your_account.account_not_used.heading"))
+      expect(response.body).to have_content(I18n.t("account.your_account.account_not_used.heading"))
     end
   end
 
@@ -38,9 +38,9 @@ RSpec.feature "/account" do
     let(:userinfo) { { transition_checker_state: { timestamp: 42 } } }
 
     it "shows the service card" do
-      visit user_root_path
+      get user_root_path
 
-      expect(page).to have_text(I18n.t("account.your_account.transition.heading"))
+      expect(response.body).to have_content(I18n.t("account.your_account.transition.heading"))
     end
   end
 end

--- a/spec/requests/data_exchange_spec.rb
+++ b/spec/requests/data_exchange_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-RSpec.feature "/account/your-data" do
+RSpec.describe "/account/your-data" do
   let(:user) { FactoryBot.create(:user) }
 
   let(:application) do
@@ -33,21 +33,19 @@ RSpec.feature "/account/your-data" do
   end
 
   context "with a user logged in" do
-    before do
-      log_in(user.email, user.password)
-    end
+    before { sign_in user }
 
     it "lists how and when data was used" do
-      visit account_security_path(client: application, scope: "openid email")
+      get account_security_path(client: application, scope: "openid email")
 
-      expect(page).to have_text(application.name)
-      expect(page).to have_text("used #{I18n.t('account.data_exchange.scope.email')}")
+      expect(response.body).to have_content(application.name)
+      expect(response.body).to have_content(I18n.t("account.data_exchange.scope.email"))
     end
 
     it "does not list transition checker data usage" do
-      visit account_security_path(client: application, scope: "openid email transition_checker")
+      get account_security_path(client: application, scope: "openid email transition_checker")
 
-      expect(page).not_to have_text(I18n.t("account.data_exchange.scope.transition_checker"))
+      expect(response.body).not_to have_content(I18n.t("account.data_exchange.scope.transition_checker"))
     end
   end
 end

--- a/spec/requests/discovery_spec.rb
+++ b/spec/requests/discovery_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Doorkeeper::OpenidConnect::DiscoveryController", type: :request do
+RSpec.describe "Doorkeeper::OpenidConnect::DiscoveryController" do
   let(:attribute_service_url) { "https://attribute-service" }
 
   around do |example|

--- a/spec/requests/feedback_spec.rb
+++ b/spec/requests/feedback_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "feedback", type: :request do
+RSpec.describe "feedback" do
   describe "GET" do
     it "renders the form" do
       get feedback_form_path

--- a/spec/requests/healthcheck_spec.rb
+++ b/spec/requests/healthcheck_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "/healthcheck", type: :request do
+RSpec.describe "/healthcheck" do
   before do
     # redis is not connected in test mode
     stub_const("Sidekiq", double(:sidekiq, redis_info: double(:redis_info)))

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,15 @@ SimpleCov.start
 
 ActiveJob::Base.queue_adapter = :test
 
+# Checks for pending migrations and applies them before tests are run.
+# If you are not using ActiveRecord, you can remove these lines.
+begin
+  ActiveRecord::Migration.maintain_test_schema!
+rescue ActiveRecord::PendingMigrationError => e
+  puts e.to_s.strip
+  exit 1
+end
+
 RSpec.configure do |config|
   config.render_views
   config.expose_dsl_globally = false


### PR DESCRIPTION
1. Put everything in the right directory so we don't need to specify the `type`
2. Turn some feature-specs-pretending-to-be-request-specs into actual request specs
3. Make sure the test DB is migrated before running tests.

---

[Trello](https://trello.com/c/mPw3Gzme/400-do-we-need-a-testing-strategy-for-accounts)