### PR TITLE
Render 429 response directly from rack-attack

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -22,6 +22,11 @@ module ApplicationHelper
     else
       []
     end
+  rescue Devise::MissingWarden
+    # Since we render the 429 page directly from the rack-attack
+    # middleware, there is no warden in the env, so Devise throws an
+    # error.  Treat this the same as being logged out.
+    []
   end
 
   def has_criteria_keys?(registration_state)

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -9,5 +9,10 @@ Rack::Attack.throttle("limit login attempts per IP", limit: LIMIT_LOGIN_ATTEMPTS
 end
 
 Rack::Attack.throttled_response = lambda do |_request|
-  [302, { "Location" => "/429" }, ["You are being redirected.\n"]]
+  html = ApplicationController.render(
+    template: "standard_errors/generic",
+    assigns: { error: :too_many_requests },
+  )
+
+  [429, { "Content-Type" => "text/html" }, [html]]
 end

--- a/spec/requests/throttling_spec.rb
+++ b/spec/requests/throttling_spec.rb
@@ -11,13 +11,14 @@ RSpec.describe "Throttling" do
   context "POST /" do
     it "does not throttle" do
       (LIMIT_LOGIN_ATTEMPTS_PER_IP + 1).times { post "/" }
+      expect(response).to_not have_http_status 429
       expect(response.body).to_not have_content(I18n.t("standard_errors.too_many_requests.heading"))
     end
 
     context "with user[email] set" do
       it "throttles" do
         (LIMIT_LOGIN_ATTEMPTS_PER_IP + 1).times { post "/", params: { "user[email]" => "email@example.com" } }
-        follow_redirect!
+        expect(response).to have_http_status(429)
         expect(response.body).to have_content(I18n.t("standard_errors.too_many_requests.heading"))
       end
     end
@@ -26,7 +27,7 @@ RSpec.describe "Throttling" do
   context "POST /login" do
     it "throttles" do
       (LIMIT_LOGIN_ATTEMPTS_PER_IP + 1).times { post "/login" }
-      follow_redirect!
+      expect(response).to have_http_status(429)
       expect(response.body).to have_content(I18n.t("standard_errors.too_many_requests.heading"))
     end
   end


### PR DESCRIPTION
This is better as it serves the appropriate code immediately, rather than redirecting to a page which then serves a 429.

---

[Trello card](https://trello.com/c/H0dG0Sn2/444-implement-protection-against-password-spraying-attacks)