### PR TITLE
Add email confirmation reminder

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -4,7 +4,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2020-12-08T11:01:04Z",
+  "generated_at": "2020-12-08T11:26:51Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -128,6 +128,7 @@
     "concourse/tasks/daily-statistics.yml": [
       {
         "hashed_secret": "47748b1fd1747e8bff5493fa6c3bcf16d6449969",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 6,
         "type": "Hex High Entropy String"
@@ -161,12 +162,14 @@
     "config/i18n-tasks.yml": [
       {
         "hashed_secret": "3d9221c542029ecf9d3f1a9fbb7d02db052510b8",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 90,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "d907a1d005ac32bceeff3e619ba7075b4c857004",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 93,
         "type": "Secret Keyword"
@@ -175,20 +178,23 @@
     "config/locales/devise.en.yml": [
       {
         "hashed_secret": "7550b672e162c224c309bdea5d48ca975081a904",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 187,
+        "line_number": 188,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "0be7a248fb840ae80587ee2cafee5388126e543c",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 272,
+        "line_number": 273,
         "type": "Secret Keyword"
       }
     ],
     "config/locales/en.yml": [
       {
         "hashed_secret": "37c6c57bedf4305ef41249c1794760b5cb8fad17",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 50,
         "type": "Secret Keyword"

--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ group :development, :test do
   gem "dotenv-rails"
   gem "factory_bot_rails"
   gem "i18n-tasks", "~> 0.9.31"
+  gem "pry-rails"
   gem "rspec-rails"
 end
 
@@ -50,6 +51,5 @@ end
 group :development do
   gem "awesome_print"
   gem "listen"
-  gem "pry-rails"
   gem "rubocop-govuk"
 end

--- a/app/assets/stylesheets/accounts.scss
+++ b/app/assets/stylesheets/accounts.scss
@@ -125,3 +125,9 @@ $_current-indicator-width: 4px;
 .accounts-your-account__email {
   margin-bottom: govuk-spacing(7);
 }
+
+.email-reminder {
+  padding: govuk-spacing(3);
+  margin-bottom: govuk-spacing(7);
+  background: govuk-colour("light-grey");
+}

--- a/app/controllers/devise_confirmations_controller.rb
+++ b/app/controllers/devise_confirmations_controller.rb
@@ -23,6 +23,11 @@ class DeviseConfirmationsController < Devise::ConfirmationsController
     end
   end
 
+  def new
+    super
+    @email = current_user&.unconfirmed_email || current_user&.email
+  end
+
   def after_resending_confirmation_instructions_path_for(_resource_name)
     session[:confirmations] = {
       email: resource.unconfirmed_email,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -30,6 +30,12 @@ module ApplicationHelper
     []
   end
 
+  def show_confirmation_reminder?
+    return false unless current_user
+
+    !current_user.confirmed_at? || current_user.unconfirmed_email?
+  end
+
   def has_criteria_keys?(registration_state)
     return false if registration_state.blank?
 

--- a/app/views/account/show.html.erb
+++ b/app/views/account/show.html.erb
@@ -1,6 +1,10 @@
 <% content_for :title, t("account.your_account.heading") %>
 <% content_for :location, "your-account" %>
 
+<% if show_confirmation_reminder? %>
+  <%= render "email-confirmation-reminder" %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-third">
     <%= render "account-navigation", page_is: yield(:location) %>

--- a/app/views/application/_email-confirmation-reminder.html.erb
+++ b/app/views/application/_email-confirmation-reminder.html.erb
@@ -1,0 +1,6 @@
+<section class="email-reminder" aria-label="Notice" role="region">
+  <p class="govuk-body govuk-!-margin-0">
+    <%= sanitize(t("confirm.intro")) %>
+    <a href="<%= new_user_confirmation_path %>" class="govuk-link"><%= t("confirm.link_text") %></a>
+  </p>
+</section>

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -7,6 +7,8 @@
       margin_bottom: 3,
     } %>
 
+    <p class="govuk-body"><%= t("devise.confirmations.resend.instructions") %></p>
+
     <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do %>
       <%= render "devise/shared/error_messages", resource: resource %>
 
@@ -17,7 +19,7 @@
         name: "user[email]",
         type: "email",
         id: "email",
-        value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email),
+        value: @email,
         autocomplete: "email",
       } %>
 

--- a/app/views/manage/show.html.erb
+++ b/app/views/manage/show.html.erb
@@ -1,6 +1,10 @@
 <% content_for :title, t("account.manage.heading") %>
 <% content_for :location, "manage" %>
 
+<% if show_confirmation_reminder? %>
+  <%= render "email-confirmation-reminder" %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-third">
     <%= render "account-navigation", page_is: yield(:location) %>

--- a/app/views/security/show.html.erb
+++ b/app/views/security/show.html.erb
@@ -1,6 +1,10 @@
 <% content_for :title, t("account.security.heading") %>
 <% content_for :location, "security" %>
 
+<% if show_confirmation_reminder? %>
+  <%= render "email-confirmation-reminder" %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-third">
     <%= render "account-navigation", page_is: yield(:location) %>

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -31,8 +31,9 @@ en:
     confirmations:
       confirmed: You’ve successfully confirmed your email address.
       resend:
-        button: Resend confirmation instructions
-        heading: Resend confirmation instructions
+        button: Send confirmation email
+        heading: Resend instructions to confirm your email address
+        instructions: We’ll send you an email with instructions for confirming the email address for your GOV.UK account.
         label: Enter your email address
       send_instructions: You will receive an email with instructions for how to confirm your email address in a few minutes.
       send_paranoid_instructions: If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -78,6 +78,9 @@ en:
   change_password:
     content: Enter the email address you used to create your GOV.UK account. We’ll  send you an email with instructions for changing your password.
     heading: Change your password
+  confirm:
+    intro: "<strong>Confirm your email address</strong> to finish updating your account and email alerts."
+    link_text: Resend confirmation email
   confirmation_sent:
     continue_to_account: Go to your GOV.UK account
     continue_to_service: Go back to %{service_name}

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,8 +5,13 @@ FactoryBot.define do
     password_confirmation { "abcd1234" }
     phone { "+447958123456" }
 
-    factory :confirmed_user do
+    trait :confirmed do
       confirmed_at { Time.zone.now }
+    end
+
+    trait :email_change_requested do
+      unconfirmed_email { "new_email@example.com" }
+      confirmation_token { "abc123" }
     end
   end
 end

--- a/spec/feature/confirm_email_prompt_spec.rb
+++ b/spec/feature/confirm_email_prompt_spec.rb
@@ -1,0 +1,103 @@
+RSpec.feature "Confirm email prompt" do
+  context "For a newly created account" do
+    let(:user) { FactoryBot.create(:user) }
+
+    scenario "Banner is present for user with unconfirmed email address" do
+      given_i_have_logged_in
+      when_i_navigate_to_home
+      then_i_see_the_confirmation_reminder_banner
+      when_i_navigate_to_manage
+      then_i_see_the_confirmation_reminder_banner
+      when_i_navigate_to_security
+      then_i_see_the_confirmation_reminder_banner
+    end
+
+    scenario "Resend form is prefilled on new user signup" do
+      given_i_have_logged_in
+      when_i_navigate_to_home
+      then_i_see_the_confirmation_reminder_banner
+      when_i_click_the_link_on_the_confirmation_banner
+      then_i_see_the_new_confirmaton_page_header
+      and_my_email_address_should_be_prefilled_in_the_form
+    end
+
+    scenario "Banner is not present once user has confirmed email address" do
+      given_i_have_logged_in
+      when_i_navigate_to_home
+      then_i_see_the_confirmation_reminder_banner
+      when_i_confirm_my_email_with_a_confirmation_link
+      when_i_navigate_to_home
+      then_i_do_not_see_the_confirmation_reminder_banner
+    end
+  end
+
+  context "For an existing user requesting to change their email address" do
+    let(:user) { FactoryBot.create(:user, :confirmed, :email_change_requested) }
+
+    scenario "Resend form is prefilled for changed email address" do
+      given_i_have_logged_in
+      when_i_navigate_to_home
+      then_i_see_the_confirmation_reminder_banner
+      when_i_click_the_link_on_the_confirmation_banner
+      then_i_see_the_new_confirmaton_page_header
+      and_my_unconfirmed_email_address_should_be_prefilled
+    end
+
+    scenario "Banner is not present once user has confirmed email address" do
+      given_i_have_logged_in
+      when_i_navigate_to_home
+      then_i_see_the_confirmation_reminder_banner
+      when_i_confirm_my_email_with_a_confirmation_link
+      when_i_navigate_to_home
+      then_i_do_not_see_the_confirmation_reminder_banner
+    end
+  end
+
+  def given_i_have_logged_in
+    visit user_session_path
+    fill_in "email", with: user.email
+    click_on I18n.t("welcome.show.button.label")
+    fill_in "password", with: "abcd1234"
+    click_on I18n.t("devise.sessions.new.fields.submit.label")
+  end
+
+  def when_i_navigate_to_home
+    visit user_root_path
+  end
+
+  def when_i_navigate_to_manage
+    visit account_manage_path
+  end
+
+  def when_i_navigate_to_security
+    visit account_security_path
+  end
+
+  def then_i_see_the_confirmation_reminder_banner
+    expect(page).to have_content(I18n.t("confirm.link_text"))
+  end
+
+  def when_i_click_the_link_on_the_confirmation_banner
+    click_link(I18n.t("confirm.link_text"))
+  end
+
+  def then_i_see_the_new_confirmaton_page_header
+    expect(page).to have_content(I18n.t("devise.confirmations.resend.heading"))
+  end
+
+  def and_my_email_address_should_be_prefilled_in_the_form
+    expect(page).to have_field("Enter your email address", with: user.email)
+  end
+
+  def and_my_unconfirmed_email_address_should_be_prefilled
+    expect(page).to have_field("Enter your email address", with: user.unconfirmed_email)
+  end
+
+  def when_i_confirm_my_email_with_a_confirmation_link
+    visit user_confirmation_path(confirmation_token: user.confirmation_token)
+  end
+
+  def then_i_do_not_see_the_confirmation_reminder_banner
+    expect(page).not_to have_content(I18n.t("confirm.link_text"))
+  end
+end

--- a/spec/jobs/activate_email_subscriptions_job_spec.rb
+++ b/spec/jobs/activate_email_subscriptions_job_spec.rb
@@ -3,7 +3,7 @@ require "gds_api/test_helpers/email_alert_api"
 RSpec.describe ActivateEmailSubscriptionsJob do
   include GdsApi::TestHelpers::EmailAlertApi
 
-  let(:user) { FactoryBot.create(:confirmed_user) }
+  let(:user) { FactoryBot.create(:user, :confirmed) }
 
   # these tests are disabled pending fixing a bug in gds-api-adapters:
   # gds-api-adapters stubs a request which returns a "subscription_id"

--- a/spec/requests/api/v1/transition_checker/emails_spec.rb
+++ b/spec/requests/api/v1/transition_checker/emails_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe "/api/v1/transition-checker/*" do
     let(:new_topic_slug) { "new-topic-slug" }
 
     context "the user has confirmed their email address" do
-      let(:user) { FactoryBot.create(:confirmed_user) }
+      let(:user) { FactoryBot.create(:user, :confirmed) }
 
       context "with an email subscription" do
         let(:subscription) { FactoryBot.create(:email_subscription, user_id: user.id) }


### PR DESCRIPTION
## What

Add a confirmation reminder at the top of the accounts page so users know if they haven't confirmed their email address.

<img width="927" alt="Screenshot 2020-11-23 at 16 16 32" src="https://user-images.githubusercontent.com/861310/99986587-4546fa80-2da7-11eb-8a53-23ee9ba008f9.png">

This should appear only on the three main account pages when logged in - Your account, Manage your account, and Security.

## Why

Users are having issues with confirming their email address.

Trello card: https://trello.com/c/95KuNE24/408-remind-users-they-have-to-confirm-their-account-and-give-them-a-ways-to-send-another-confirmation-email