### PR TITLE
Add frontend for resend unlock instructions screen

### DIFF
--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,14 +1,27 @@
-<h2>Resend unlock instructions</h2>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
 
-<%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("devise.unlocks.heading"),
+      heading_level: 1,
+      font_size: "l",
+      margin_bottom: 4,
+    } %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: t("devise.unlocks.label")
+        },
+        name: "user[email]",
+        id: "user_email",
+        type: "email",
+        error_message: resource.errors.messages[:email][0],
+      } %>
+
+      <%= render "govuk_publishing_components/components/button", {
+        text: t("devise.unlocks.resend")
+      } %>
+    <% end %>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Resend unlock instructions" %>
-  </div>
-<% end %>
+</div>

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -279,6 +279,9 @@ en:
       signed_in: Signed in successfully.
       signed_out: Signed out successfully.
     unlocks:
+      heading: Resend unlock instructions
+      label: Your email address
+      resend: Resend
       send_instructions: You will receive an email with instructions for how to unlock your account in a few minutes.
       send_paranoid_instructions: If your account exists, you will receive an email with instructions for how to unlock it in a few minutes.
       unlocked: Your account has been unlocked successfully. Please sign in to continue.


### PR DESCRIPTION
Improve the frontend for https://www.account.publishing.service.gov.uk/account/unlock/new - looks like it was never styled.

Before:

<img width="357" alt="Screenshot 2020-11-24 at 17 15 30" src="https://user-images.githubusercontent.com/861310/100129210-2ca71500-2e79-11eb-89c5-ec16d59f7ea3.png">

After (showing error state):

<img width="613" alt="Screenshot 2020-11-24 at 17 15 25" src="https://user-images.githubusercontent.com/861310/100129231-316bc900-2e79-11eb-8a46-9b81acb457e7.png">


Note: the text here isn't great, but we'll probably roll this out as is to make it at least look considerably better, then improve the text shortly after.

