### PR TITLE
Support international phone numbers without a plus prefix

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,7 @@ class ApplicationController < ActionController::Base
     if TelephoneNumber.valid?(phone_number, :gb)
       TelephoneNumber.parse(phone_number, :gb).e164_number
     else
-      TelephoneNumber.parse(phone_number).e164_number
+      TelephoneNumber.parse(phone_number.gsub(/^00/, "+")).e164_number
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,14 +10,6 @@ class ApplicationController < ActionController::Base
 
   rescue_from Exception, with: :top_level_error_handler
 
-  def e164_number(phone_number)
-    if TelephoneNumber.valid?(phone_number, :gb)
-      TelephoneNumber.parse(phone_number, :gb).e164_number
-    else
-      TelephoneNumber.parse(phone_number.gsub(/^00/, "+")).e164_number
-    end
-  end
-
 protected
 
   def top_level_error_handler(exception = nil)

--- a/app/controllers/devise_registration_controller.rb
+++ b/app/controllers/devise_registration_controller.rb
@@ -67,7 +67,7 @@ class DeviseRegistrationController < Devise::RegistrationsController
       return
     end
 
-    phone_number = e164_number(params[:phone].presence || registration_state.phone)
+    phone_number = MultiFactorAuth.e164_number(params[:phone].presence || registration_state.phone)
 
     registration_state.transaction do
       registration_state.update!(phone: phone_number)

--- a/app/controllers/edit_phone_controller.rb
+++ b/app/controllers/edit_phone_controller.rb
@@ -10,7 +10,7 @@ class EditPhoneController < ApplicationController
     phone_number = current_user.unconfirmed_phone
 
     if params[:phone]
-      phone_number = e164_number(params[:phone])
+      phone_number = MultiFactorAuth.e164_number(params[:phone])
 
       unless current_user.valid_password? params[:current_password]
         @password_error_message = I18n.t("activerecord.errors.models.user.attributes.password.#{params[:current_password].blank? ? 'blank' : 'invalid'}")

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -51,14 +51,4 @@ module ApplicationHelper
     base_url = Rails.env.development? ? Plek.find("collections") : Plek.new.website_root
     "#{base_url}/transition"
   end
-
-  def formatted_phone_number(number)
-    parsed_number = TelephoneNumber.parse(number)
-
-    if parsed_number.country && parsed_number.country.country_id == "GB"
-      parsed_number.national_number
-    else
-      parsed_number.international_number
-    end
-  end
 end

--- a/app/helpers/manage_helper.rb
+++ b/app/helpers/manage_helper.rb
@@ -34,7 +34,7 @@ module ManageHelper
 
     phone = {
       field: t("general.phone"),
-      value: formatted_phone_number(current_user.phone),
+      value: MultiFactorAuth.formatted_phone_number(current_user.phone),
       edit: {
         href: edit_user_registration_phone_url,
         text: t("general.change"),

--- a/app/views/devise/registrations/phone_code.html.erb
+++ b/app/views/devise/registrations/phone_code.html.erb
@@ -10,7 +10,7 @@
       margin_bottom: 3,
     } %>
 
-    <% t("mfa.phone.code.description_with_phone_number", phone_number: formatted_phone_number(@registration_state.phone)).each do |msg| %>
+    <% t("mfa.phone.code.description_with_phone_number", phone_number: MultiFactorAuth.formatted_phone_number(@registration_state.phone)).each do |msg| %>
       <p class="govuk-body"><%= sanitize(msg) %></p>
     <% end %>
 

--- a/app/views/devise/registrations/phone_resend.html.erb
+++ b/app/views/devise/registrations/phone_resend.html.erb
@@ -23,7 +23,7 @@
         <%= render "govuk_publishing_components/components/input", {
           label: { text: t("mfa.phone.resend.fields.phone.label") },
           name: "phone",
-          value: formatted_phone_number(@phone),
+          value: MultiFactorAuth.formatted_phone_number(@phone),
           width: 10,
           autocomplete: "tel",
         } %>

--- a/app/views/edit_phone/code.html.erb
+++ b/app/views/edit_phone/code.html.erb
@@ -7,7 +7,7 @@
       margin_bottom: 3,
     } %>
 
-    <% t("mfa.phone.code.description_with_phone_number", phone_number: formatted_phone_number(current_user.unconfirmed_phone)).each do |msg| %>
+    <% t("mfa.phone.code.description_with_phone_number", phone_number: MultiFactorAuth.formatted_phone_number(current_user.unconfirmed_phone)).each do |msg| %>
       <p class="govuk-body"><%= sanitize(msg) %></p>
     <% end %>
 
@@ -39,7 +39,7 @@
     </p>
 
     <p class="govuk-body">
-      <%= sanitize(t("mfa.phone.code.not_received.change_number_message", link: edit_user_registration_phone_path,  phone_number: formatted_phone_number(current_user.unconfirmed_phone))) %>
+      <%= sanitize(t("mfa.phone.code.not_received.change_number_message", link: edit_user_registration_phone_path,  phone_number: MultiFactorAuth.formatted_phone_number(current_user.unconfirmed_phone))) %>
     </p>
   </div>
 </div>

--- a/app/views/edit_phone/show.html.erb
+++ b/app/views/edit_phone/show.html.erb
@@ -19,7 +19,7 @@
     </p>
 
     <%= render "govuk_publishing_components/components/inset_text", {
-      text: t("mfa.phone.update.start.current", phone_number: formatted_phone_number(current_user.phone))
+      text: t("mfa.phone.update.start.current", phone_number: MultiFactorAuth.formatted_phone_number(current_user.phone))
     } %>
 
     <%= form_with(url: edit_user_registration_phone_code_path, method: :post) do %>

--- a/lib/multi_factor_auth.rb
+++ b/lib/multi_factor_auth.rb
@@ -7,7 +7,7 @@ module MultiFactorAuth
   class NotConfigured < MFAError; end
 
   def self.valid?(phone_number)
-    parsed_number = TelephoneNumber.parse(phone_number)
+    parsed_number = TelephoneNumber.parse(phone_number.gsub(/^00/, "+"))
 
     if TelephoneNumber.valid?(phone_number, :gb, [:mobile])
       true

--- a/spec/feature/registration_spec.rb
+++ b/spec/feature/registration_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Registration" do
   it "creates a user" do
     enter_email_address
     enter_password_and_confirmation
-    enter_phone_number
+    enter_uk_phone_number
     enter_mfa
     provide_consent
 
@@ -32,7 +32,7 @@ RSpec.feature "Registration" do
   it "sends an email" do
     enter_email_address
     enter_password_and_confirmation
-    enter_phone_number
+    enter_uk_phone_number
     enter_mfa
     provide_consent
 
@@ -49,7 +49,7 @@ RSpec.feature "Registration" do
   it "shows the terms & conditions" do
     enter_email_address
     enter_password_and_confirmation
-    enter_phone_number
+    enter_uk_phone_number
     enter_mfa
 
     expect(page).to have_text(I18n.t("devise.registrations.your_information.heading"))
@@ -189,7 +189,7 @@ RSpec.feature "Registration" do
     it "returns an error" do
       enter_email_address
       enter_password_and_confirmation
-      enter_phone_number
+      enter_uk_phone_number
       enter_incorrect_mfa
 
       expect(page).to have_text(I18n.t("mfa.errors.phone_code.invalid"))
@@ -199,7 +199,7 @@ RSpec.feature "Registration" do
       it "expires the code" do
         enter_email_address
         enter_password_and_confirmation
-        enter_phone_number
+        enter_uk_phone_number
         (MultiFactorAuth::ALLOWED_ATTEMPTS + 1).times { enter_incorrect_mfa }
 
         expect(page).to have_text(I18n.t("mfa.errors.phone_code.expired"))
@@ -211,7 +211,7 @@ RSpec.feature "Registration" do
     it "expires the code" do
       enter_email_address
       enter_password_and_confirmation
-      enter_phone_number
+      enter_uk_phone_number
       travel(MultiFactorAuth::EXPIRATION_AGE + 1.second)
       enter_mfa
 
@@ -278,29 +278,29 @@ RSpec.feature "Registration" do
     click_on I18n.t("devise.registrations.start.fields.submit.label")
   end
 
-  def enter_phone_number
-    fill_in "phone", with: phone_number
+  def enter_phone_number(number)
+    fill_in "phone", with: number
     click_on I18n.t("mfa.phone.create.fields.submit.label")
+  end
+
+  def enter_uk_phone_number
+    enter_phone_number(phone_number)
   end
 
   def enter_non_mobile_phone_number
-    fill_in "phone", with: "01234567890"
-    click_on I18n.t("mfa.phone.create.fields.submit.label")
+    enter_phone_number("01234567890")
   end
 
   def enter_invalid_phone_number
-    fill_in "phone", with: "999"
-    click_on I18n.t("mfa.phone.create.fields.submit.label")
+    enter_phone_number("999")
   end
 
   def enter_international_phone_number
-    fill_in "phone", with: "+15417543010"
-    click_on I18n.t("mfa.phone.create.fields.submit.label")
+    enter_phone_number("+15417543010")
   end
 
   def enter_international_phone_number_without_plus
-    fill_in "phone", with: "0015417543010"
-    click_on I18n.t("mfa.phone.create.fields.submit.label")
+    enter_phone_number("0015417543010")
   end
 
   def enter_mfa

--- a/spec/feature/registration_spec.rb
+++ b/spec/feature/registration_spec.rb
@@ -168,6 +168,20 @@ RSpec.feature "Registration" do
       provide_consent
 
       assert_enqueued_jobs 1, only: NotifyDeliveryJob
+      expect(User.last.phone).to eq("+15417543010")
+    end
+  end
+
+  context "when the phone number is international with 00 instead of +" do
+    it "sends an email" do
+      enter_email_address
+      enter_password_and_confirmation
+      enter_international_phone_number_without_plus
+      enter_mfa
+      provide_consent
+
+      assert_enqueued_jobs 1, only: NotifyDeliveryJob
+      expect(User.last.phone).to eq("+15417543010")
     end
   end
 
@@ -281,6 +295,11 @@ RSpec.feature "Registration" do
 
   def enter_international_phone_number
     fill_in "phone", with: "+15417543010"
+    click_on I18n.t("mfa.phone.create.fields.submit.label")
+  end
+
+  def enter_international_phone_number_without_plus
+    fill_in "phone", with: "0015417543010"
     click_on I18n.t("mfa.phone.create.fields.submit.label")
   end
 


### PR DESCRIPTION
Some users enter their international dialing code with 00 instead of a + (e.g. 00353 instead of +353 for Republic of Ireland). This is because that is how the number is dialled on a landline telephone.

This format was not considered valid by the telephone_number gem, so we need to manually substitute the 00 prefix with a + in these cases.

Trello card: https://trello.com/c/DyVBdbBz