### PR TITLE
Add missing component assets

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -3,7 +3,9 @@
 //= require govuk_publishing_components/components/button
 //= require govuk_publishing_components/components/checkboxes
 //= require govuk_publishing_components/components/cookie-banner
+//= require govuk_publishing_components/components/details
 //= require govuk_publishing_components/components/error-summary
+//= require govuk_publishing_components/components/govspeak
 //= require govuk_publishing_components/components/radio
 
 //= require ./analytics-track-form

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,6 +8,7 @@
 @import "govuk_publishing_components/components/error-alert";
 @import "govuk_publishing_components/components/error-message";
 @import "govuk_publishing_components/components/error-summary";
+@import "govuk_publishing_components/components/govspeak";
 @import "govuk_publishing_components/components/heading";
 @import "govuk_publishing_components/components/hint";
 @import "govuk_publishing_components/components/input";
@@ -20,6 +21,7 @@
 @import "govuk_publishing_components/components/phase-banner";
 @import "govuk_publishing_components/components/radio";
 @import "govuk_publishing_components/components/search";
+@import "govuk_publishing_components/components/skip-link";
 @import "govuk_publishing_components/components/success-alert";
 @import "govuk_publishing_components/components/summary-list";
 @import "govuk_publishing_components/components/textarea";

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -1,7 +1,9 @@
 @import "govuk_publishing_components/govuk_frontend_support";
 @import "govuk_publishing_components/components/print/back-link";
 @import "govuk_publishing_components/components/print/button";
+@import "govuk_publishing_components/components/print/govspeak";
 @import "govuk_publishing_components/components/print/layout-footer";
 @import "govuk_publishing_components/components/print/layout-header";
 @import "govuk_publishing_components/components/print/search";
+@import "govuk_publishing_components/components/print/skip-link";
 @import "govuk_publishing_components/components/print/textarea";


### PR DESCRIPTION
Some of the styles/print styles/javascripts for some of the components we're using weren't included in the application, a recent audit uncovered. Probably wasn't causing a huge problem, but it's worth including them.
