### PR TITLE
Add guard clause to catch empty phone number

### DIFF
--- a/app/controllers/devise_registration_controller.rb
+++ b/app/controllers/devise_registration_controller.rb
@@ -61,7 +61,7 @@ class DeviseRegistrationController < Devise::RegistrationsController
   def phone_code_send
     redirect_to url_for_state and return unless registration_state.state == "phone"
 
-    if params[:phone] && !MultiFactorAuth.valid?(params[:phone].presence)
+    unless MultiFactorAuth.valid?(params[:phone].presence)
       @phone_error_message = I18n.t("mfa.errors.phone.invalid")
       render :phone
       return

--- a/lib/multi_factor_auth.rb
+++ b/lib/multi_factor_auth.rb
@@ -8,6 +8,8 @@ module MultiFactorAuth
   class NotConfigured < MFAError; end
 
   def self.valid?(phone_number)
+    return false unless phone_number
+
     parsed_number = TelephoneNumber.parse(phone_number.gsub(INTERNATIONAL_CODE_REGEX, "+"))
 
     if TelephoneNumber.valid?(phone_number, :gb, [:mobile])


### PR DESCRIPTION
Users were getting a 500 error if they entered nothing in the phone number field. This will ensure the error is handled and they are shown a friendly message.

Trello card: https://trello.com/c/DyVBdbBz