### PR TITLE
Filter sensitive POST and GET params from logs.

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -3,4 +3,14 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += %i[
+  _ga
+  code
+  email
+  jwt
+  login_state_id
+  password
+  phone
+  registration_state_id
+  reset_password_token
+]


### PR DESCRIPTION
Last time we tried this, it didn't go quite to plan [(1)][1] [(2)][2]. So this time
around I'm going to try something a bit more gradual.

This will be phase 1. Which is to just keep our existing logs in the
same format as currently but redact out any potentally sensitive PII.

In step 2 we will start streaming these to Splunk for auditing.
Filtering is so that they only see the information required.

As a final step 3, I will return to trying to format the logs as JSON,
this should make it easier for the cyber folks to query what is going
on. This, via a gem was the step that seemed to be causing issues last
time around.

[1]: https://github.com/alphagov/govuk-account-manager-prototype/pull/430
[2]: https://github.com/alphagov/govuk-account-manager-prototype/pull/437