### PR TITLE
Do not show "you have signed up" message after signing up

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -4,7 +4,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2020-11-13T11:14:32Z",
+  "generated_at": "2020-11-27T09:06:45Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -182,7 +182,7 @@
       {
         "hashed_secret": "0be7a248fb840ae80587ee2cafee5388126e543c",
         "is_verified": false,
-        "line_number": 275,
+        "line_number": 271,
         "type": "Secret Keyword"
       }
     ],

--- a/app/controllers/devise_registration_controller.rb
+++ b/app/controllers/devise_registration_controller.rb
@@ -191,6 +191,7 @@ class DeviseRegistrationController < Devise::RegistrationsController
       @previous_url = registration_state.previous_url
       registration_state.destroy!
     end
+    flash.clear
   end
 
   # from https://github.com/heartcombo/devise/blob/f5cc775a5feea51355036175994edbcb5e6af13c/app/controllers/devise/registrations_controller.rb#L46

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -185,10 +185,6 @@ en:
         heading_email: Change your email address
         heading_password: Change your password
         success: You’ve successfully updated the password for your GOV.UK account.
-      signed_up: Welcome! You have signed up successfully.
-      signed_up_but_inactive: You have signed up successfully. However, we could not sign you in because your account is not yet activated.
-      signed_up_but_locked: You have signed up successfully. However, we could not sign you in because your account is locked.
-      signed_up_but_unconfirmed: A message with a confirmation link has been sent to your email address. Please follow the link to activate your account.
       start:
         fields:
           email:


### PR DESCRIPTION
A flash message appears when you click the confirmation link in the signup email. This is inconsistent with the language used elsewhere, where we talk about "logging in".

This message was not included in the recent error/success message content review, so we missed removing this.  The information conveyed by this flash message is already presented to the user in another confirmation screen after creating their account anyway.

Example of what it looked like (the flash message has now been completely removed):
![Screenshot 2020-11-26 at 17 10 13](https://user-images.githubusercontent.com/6329861/100433694-55a2f200-3093-11eb-8ee3-267fe4540c26.png)
