### PR TITLE
Treat Crown Dependency phone numbers as UK numbers

### DIFF
--- a/spec/feature/registration_spec.rb
+++ b/spec/feature/registration_spec.rb
@@ -159,6 +159,25 @@ RSpec.feature "Registration" do
     end
   end
 
+  context "when the phone number is from the Crown Dependencies" do
+    valid_numbers = %w[07624123456 07797987654 07700123456 07829123456 07781123456 07839123456 07911123456]
+
+    valid_numbers.each do |valid_number|
+      context "with example number #{valid_number}" do
+        it "sends an email" do
+          enter_email_address
+          enter_password_and_confirmation
+          enter_phone_number(valid_number)
+          enter_mfa
+          provide_consent
+
+          assert_enqueued_jobs 1, only: NotifyDeliveryJob
+          expect(User.last.phone).to eq("+44#{valid_number.gsub(/^0/, '')}")
+        end
+      end
+    end
+  end
+
   context "when the phone number is international" do
     it "sends an email" do
       enter_email_address


### PR DESCRIPTION
The Crown Dependencies (Guernsey, Isle of Man and Jersey) use the UK country code (+44) but have their own area codes and are treated as international numbers. Because of this, they currently fail our validation and are not accepted.

This change will allow us to treat Crown Dependency mobile numbers as if they are UK numbers.

Trello card: https://trello.com/c/4LcapsZ1/482-support-mobile-numbers-from-the-crown-dependencies-%F0%9F%87%AE%F0%9F%87%B2-%F0%9F%87%AF%F0%9F%87%AA-%F0%9F%87%AC%F0%9F%87%AC