### PR TITLE
Do not double-count MFA logins

### DIFF
--- a/lib/devise/strategies/multi_factor_authenticatable.rb
+++ b/lib/devise/strategies/multi_factor_authenticatable.rb
@@ -10,6 +10,7 @@ module Devise
         if validate(resource) { hashed = true; resource.valid_password?(password) } # rubocop:disable Style/Semicolon
           env["warden.mfa.required"] = MultiFactorAuth.is_enabled? && resource.needs_mfa?
           if env["warden.mfa.required"]
+            env["devise.skip_trackable"] = true
             env["warden"].set_user(resource, store: false)
           else
             remember_me(resource)


### PR DESCRIPTION
If the user successfully enters their password, we should not count
that as a login event if they then need to go through MFA.

See: lib/devise/hooks/trackable.rb @ github.com/heartcombo/devise

---

[Trello card](https://trello.com/c/r9V0JIQs/571-review-our-login-reporting)