### PR TITLE
Deduplicate historic login events & remove deduplication logic

### DIFF
--- a/app/controllers/security_controller.rb
+++ b/app/controllers/security_controller.rb
@@ -2,8 +2,7 @@ class SecurityController < ApplicationController
   before_action :authenticate_user!
 
   def show
-    @activity = dedup_nearby(current_user.security_activities.order(created_at: :desc))
-      .compact
+    @activity = current_user.security_activities.order(created_at: :desc)
     @data_exchanges = dedup_nearby(current_user.data_activities.where.not(oauth_application_id: AccountManagerApplication.application.id).order(created_at: :desc))
       .compact
       .map { |a| activity_to_exchange(a) }

--- a/app/models/security_activity.rb
+++ b/app/models/security_activity.rb
@@ -56,15 +56,4 @@ class SecurityActivity < ApplicationRecord
       Doorkeeper::Application.find(oauth_application_id).name
     end
   end
-
-  def very_similar_to(other)
-    return false unless event_type == other.event_type
-    return false unless user_id == other.user_id
-    return false unless ip_address == other.ip_address
-    return false unless oauth_application_id == other.oauth_application_id
-
-    a_minute_ago = created_at.to_i - 60
-    a_minute_hence = created_at.to_i + 60
-    (a_minute_ago..a_minute_hence).include? other.created_at.to_i
-  end
 end

--- a/db/migrate/20201202114841_deduplicate_login_activities.rb
+++ b/db/migrate/20201202114841_deduplicate_login_activities.rb
@@ -1,0 +1,27 @@
+class DeduplicateLoginActivities < ActiveRecord::Migration[6.0]
+  def up
+    User.find_each do |user|
+      activities = user.security_activities.where(event_type: "login").order(created_at: :desc)
+
+      last_activity = nil
+      activities.map do |activity|
+        if last_activity.nil? || !very_similar_to(activity, last_activity)
+          last_activity = activity
+        else
+          activity.destroy!
+        end
+      end
+    end
+  end
+
+  def very_similar_to(activity1, activity2)
+    return false unless activity1.event_type == activity2.event_type
+    return false unless activity1.user_id == activity2.user_id
+    return false unless activity1.ip_address == activity2.ip_address
+    return false unless activity1.oauth_application_id == activity2.oauth_application_id
+
+    a_minute_ago = activity1.created_at.to_i - 60
+    a_minute_hence = activity1.created_at.to_i + 60
+    (a_minute_ago..a_minute_hence).include? activity2.created_at.to_i
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_27_135533) do
+ActiveRecord::Schema.define(version: 2020_12_02_114841) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/lib/tasks/statistics.rake
+++ b/lib/tasks/statistics.rake
@@ -75,13 +75,10 @@ namespace :statistics do
       .uniq
     results += "Accounts logged in between #{args.start_date} and #{args.end_date}: \n#{user_logins.count}\n\n"
 
-    all_login_frequency = dedup_nearby(
-      SecurityActivity
-        .where(event_type: "login")
-        .where(oauth_application_id: nil)
-        .where("created_at < ?", args.end_date),
-    )
-    .reject(&:nil?)
+    all_login_frequency = SecurityActivity
+    .where(event_type: "login")
+    .where(oauth_application_id: nil)
+    .where("created_at < ?", args.end_date)
     .pluck(:user_id)
     .tally
     .values
@@ -93,13 +90,10 @@ namespace :statistics do
     end
     results += "\n"
 
-    login_frequency = dedup_nearby(
-      SecurityActivity
-        .where(event_type: "login")
-        .where(oauth_application_id: nil)
-        .where("created_at BETWEEN ? AND ?", args.start_date, args.end_date),
-    )
-    .reject(&:nil?)
+    login_frequency = SecurityActivity
+    .where(event_type: "login")
+    .where(oauth_application_id: nil)
+    .where("created_at BETWEEN ? AND ?", args.start_date, args.end_date)
     .pluck(:user_id)
     .tally
     .values
@@ -116,15 +110,5 @@ namespace :statistics do
     }]
 
     puts output.to_json
-  end
-end
-
-def dedup_nearby(activities)
-  last_activity = nil
-  activities.map do |activity|
-    if last_activity.nil? || !activity.very_similar_to(last_activity)
-      last_activity = activity
-      activity
-    end
   end
 end


### PR DESCRIPTION
The data exchange deduplication is still needed because we don't
have (eg) an endpoint on the attribute manager to batch-update
attributes, so a service may make many update requests in quick
succession.

---

[Trello card](https://trello.com/c/r9V0JIQs/487-review-our-login-reporting)