### PR TITLE
Push login_state_id and registration_state_id into the session

### DIFF
--- a/app/controllers/devise_registration_controller.rb
+++ b/app/controllers/devise_registration_controller.rb
@@ -265,6 +265,10 @@ protected
   end
 
   def check_registration_state
+    if session[:registration_state_id].nil? && params[:registration_state_id]
+      session[:registration_state_id] = params[:registration_state_id]
+    end
+
     @registration_state_id = session[:registration_state_id]
     redirect_to new_user_session_path unless registration_state
   end

--- a/app/controllers/devise_registration_controller.rb
+++ b/app/controllers/devise_registration_controller.rb
@@ -46,7 +46,7 @@ class DeviseRegistrationController < Devise::RegistrationsController
         state: MultiFactorAuth.is_enabled? ? :phone : :your_information,
         password: password,
       )
-      redirect_to new_user_registration_phone_path(registration_state_id: @registration_state_id)
+      redirect_to new_user_registration_phone_path
     else
       @resource_error_messages = {
         password: [ # pragma: allowlist secret
@@ -92,9 +92,9 @@ class DeviseRegistrationController < Devise::RegistrationsController
     state = MultiFactorAuth.verify_code(registration_state, params[:phone_code])
     if state == :ok
       registration_state.update!(state: :your_information)
-      redirect_to new_user_registration_your_information_path(registration_state_id: @registration_state_id)
+      redirect_to new_user_registration_your_information_path
     else
-      @phone_code_error_message = I18n.t("mfa.errors.phone_code.#{state}", resend_link: new_user_registration_phone_resend_path(registration_state_id: @registration_state_id))
+      @phone_code_error_message = I18n.t("mfa.errors.phone_code.#{state}", resend_link: new_user_registration_phone_resend_path)
       render :phone_code
     end
   end
@@ -143,9 +143,9 @@ class DeviseRegistrationController < Devise::RegistrationsController
       email_topic_slug = registration_state.jwt_payload&.dig("attributes", "transition_checker_state", "email_topic_slug")
       if email_topic_slug
         registration_state.update!(state: :transition_emails)
-        redirect_to new_user_registration_transition_emails_path(registration_state_id: @registration_state_id)
+        redirect_to new_user_registration_transition_emails_path
       else
-        redirect_to new_user_registration_finish_path(registration_state_id: @registration_state_id)
+        redirect_to new_user_registration_finish_path
       end
       return
     end
@@ -167,7 +167,7 @@ class DeviseRegistrationController < Devise::RegistrationsController
         state: :finish,
         yes_to_emails: decision == "yes",
       )
-      redirect_to new_user_registration_finish_path(registration_state_id: @registration_state_id)
+      redirect_to new_user_registration_finish_path
       return
     end
 
@@ -190,6 +190,7 @@ class DeviseRegistrationController < Devise::RegistrationsController
 
       @previous_url = registration_state.previous_url
       registration_state.destroy!
+      session.delete(:registration_state_id)
     end
     flash.clear
   end
@@ -264,7 +265,7 @@ protected
   end
 
   def check_registration_state
-    @registration_state_id = params[:registration_state_id]
+    @registration_state_id = session[:registration_state_id]
     redirect_to new_user_session_path unless registration_state
   end
 
@@ -300,13 +301,13 @@ protected
   def url_for_state
     case registration_state.state
     when "phone"
-      new_user_registration_phone_path(registration_state_id: @registration_state_id)
+      new_user_registration_phone_path
     when "your_information"
-      new_user_registration_your_information_path(registration_state_id: @registration_state_id)
+      new_user_registration_your_information_path
     when "transition_emails"
-      new_user_registration_transition_emails_path(registration_state_id: @registration_state_id)
+      new_user_registration_transition_emails_path
     when "finish"
-      new_user_registration_finish_path(registration_state_id: @registration_state_id)
+      new_user_registration_finish_path
     else
       new_user_session_path
     end

--- a/app/controllers/devise_sessions_controller.rb
+++ b/app/controllers/devise_sessions_controller.rb
@@ -87,6 +87,10 @@ protected
   def verify_signed_out_user; end
 
   def check_login_state
+    if session[:login_state_id].nil? && params[:login_state_id]
+      session[:login_state_id] = params[:login_state_id]
+    end
+
     @login_state_id = session[:login_state_id]
     redirect_to new_user_session_path unless login_state
   end

--- a/app/controllers/devise_sessions_controller.rb
+++ b/app/controllers/devise_sessions_controller.rb
@@ -57,8 +57,9 @@ class DeviseSessionsController < Devise::SessionsController
       do_sign_in
       login_state.user.update!(last_mfa_success: Time.zone.now)
       login_state.destroy!
+      session.delete(:login_state_id)
     else
-      @phone_code_error_message = I18n.t("mfa.errors.phone_code.#{state}", resend_link: user_session_phone_resend_path(login_state_id: @login_state_id))
+      @phone_code_error_message = I18n.t("mfa.errors.phone_code.#{state}", resend_link: user_session_phone_resend_path)
       render :phone_code
     end
   end
@@ -86,12 +87,12 @@ protected
   def verify_signed_out_user; end
 
   def check_login_state
-    @login_state_id = params[:login_state_id]
+    @login_state_id = session[:login_state_id]
     redirect_to new_user_session_path unless login_state
   end
 
   def check_password_ok
-    redirect_to user_session_path(login_state_id: params[:login_state_id]) unless login_state.password_ok
+    redirect_to user_session_path unless login_state.password_ok
   end
 
   def login_state

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -20,11 +20,13 @@ class WelcomeController < ApplicationController
 
       if User.exists?(email: @email)
         login_state = create_login_state(payload, @email)
-        redirect_to user_session_path(login_state_id: login_state.id)
+        session[:login_state_id] = login_state.id
+        redirect_to user_session_path
       elsif Rails.configuration.enable_registration
         if payload || !Rails.configuration.force_jwt_at_registration
           registration_state = create_registration_state(payload, @email)
-          redirect_to new_user_registration_start_path(registration_state_id: registration_state.id)
+          session[:registration_state_id] = registration_state.id
+          redirect_to new_user_registration_start_path
         else
           render "devise/registrations/transition_checker"
         end

--- a/app/views/devise/registrations/phone.html.erb
+++ b/app/views/devise/registrations/phone.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with(url: new_user_registration_phone_code_path(registration_state_id: @registration_state_id), method: :post, class: "mfa-phone-create") do %>
+    <%= form_with(url: new_user_registration_phone_code_path, method: :post, class: "mfa-phone-create") do %>
       <%= render "govuk_publishing_components/components/input", {
         label: { text: yield(:title), },
         hint: sanitize(t("mfa.phone.create.fields.phone.hint")),

--- a/app/views/devise/registrations/phone_code.html.erb
+++ b/app/views/devise/registrations/phone_code.html.erb
@@ -14,7 +14,7 @@
       <p class="govuk-body"><%= sanitize(msg) %></p>
     <% end %>
 
-    <%= form_with(url: new_user_registration_phone_verify_path(registration_state_id: @registration_state_id), method: :post, html: { autocomplete: "off" }) do %>
+    <%= form_with(url: new_user_registration_phone_verify_path, method: :post, html: { autocomplete: "off" }) do %>
       <%= render "govuk_publishing_components/components/input", {
         label: { text: t("mfa.phone.code.fields.phone_code.label") },
         name: "phone_code",
@@ -44,7 +44,7 @@
     } %>
 
     <p class="govuk-body">
-      <%= sanitize(t("mfa.phone.code.not_received.sign_up_message", link: new_user_registration_phone_resend_path(registration_state_id: @registration_state_id))) %>
+      <%= sanitize(t("mfa.phone.code.not_received.sign_up_message", link: new_user_registration_phone_resend_path)) %>
     </p>
   </div>
 </div>

--- a/app/views/devise/registrations/phone_resend.html.erb
+++ b/app/views/devise/registrations/phone_resend.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/back_link", {
-      href: new_user_registration_phone_code_path(registration_state_id: @registration_state_id)
+      href: new_user_registration_phone_code_path
     } %>
 
     <%= render "govuk_publishing_components/components/heading", {
@@ -16,7 +16,7 @@
 
     <p class="govuk-body"><%= t("mfa.phone.resend.description") %></p>
 
-    <%= form_with(url: new_user_registration_phone_code_path(registration_state_id: @registration_state_id), method: :post) do %>
+    <%= form_with(url: new_user_registration_phone_code_path, method: :post) do %>
       <%= render "govuk_publishing_components/components/details", {
         title: t("mfa.phone.resend.change_phone")
       } do %>

--- a/app/views/devise/registrations/start.html.erb
+++ b/app/views/devise/registrations/start.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with(url: new_user_registration_start_path(registration_state_id: @registration_state_id), method: :post) do %>
+    <%= form_with(url: new_user_registration_start_path, method: :post) do %>
       <% if resource || @resource_error_messages %>
         <%= render "devise/shared/error_messages", resource: resource, resource_error_messages: @resource_error_messages %>
       <% end %>

--- a/app/views/devise/registrations/transition_emails.html.erb
+++ b/app/views/devise/registrations/transition_emails.html.erb
@@ -9,7 +9,7 @@
     } %>
 
     <%= form_with(
-      url: new_user_registration_transition_emails_path(registration_state_id: @registration_state_id),
+      url: new_user_registration_transition_emails_path,
       method: :post,
       data: {
         module: "track-form",

--- a/app/views/devise/registrations/your_information.html.erb
+++ b/app/views/devise/registrations/your_information.html.erb
@@ -29,7 +29,7 @@
     <%= sanitize(t("devise.registrations.your_information.data_choice_description")) %>
 
     <%= form_with(
-      url: new_user_registration_your_information_path(registration_state_id: @registration_state_id),
+      url: new_user_registration_your_information_path,
       method: :post,
       data: {
         module: "track-form",

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -10,7 +10,7 @@
       margin_bottom: 3,
     } %>
 
-    <%= form_with(url: user_session_path(login_state_id: @login_state_id)) do %>
+    <%= form_with(url: user_session_path) do %>
       <% if resource %>
         <%= render "devise/shared/error_messages", resource: resource %>
       <% end %>

--- a/app/views/devise/sessions/phone_code.html.erb
+++ b/app/views/devise/sessions/phone_code.html.erb
@@ -12,7 +12,7 @@
       <p class="govuk-body"><%= msg %></p>
     <% end %>
 
-    <%= form_with(url: user_session_phone_verify_path(login_state_id: @login_state_id), method: :post, html: { autocomplete: "off" }) do %>
+    <%= form_with(url: user_session_phone_verify_path, method: :post, html: { autocomplete: "off" }) do %>
       <%= render "govuk_publishing_components/components/input", {
         label: { text: t("mfa.phone.code.fields.phone_code.label") },
         name: "phone_code",
@@ -42,7 +42,7 @@
     } %>
 
     <p class="govuk-body">
-      <%= sanitize(t("mfa.phone.code.not_received.sign_in_message", link: user_session_phone_resend_path(login_state_id: @login_state_id))) %>
+      <%= sanitize(t("mfa.phone.code.not_received.sign_in_message", link: user_session_phone_resend_path)) %>
     </p>
   </div>
 </div>

--- a/app/views/devise/sessions/phone_resend.html.erb
+++ b/app/views/devise/sessions/phone_resend.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/back_link", {
-      href: user_session_phone_code_path(login_state_id: @login_state_id)
+      href: user_session_phone_code_path
     } %>
 
     <%= render "govuk_publishing_components/components/heading", {
@@ -14,7 +14,7 @@
 
     <p class="govuk-body"><%= t("mfa.phone.resend.description") %></p>
 
-    <%= form_with(url: user_session_phone_code_path(login_state_id: @login_state_id), method: :post) do %>
+    <%= form_with(url: user_session_phone_code_path, method: :post) do %>
       <%= render "govuk_publishing_components/components/button", {
         text: t("mfa.phone.resend.fields.submit.label"),
         margin_bottom: true,


### PR DESCRIPTION
If we're using the session, I think we should remove these models entirely and use the session for all the fields, but that'll be a later change.

To avoid breaking journeys of users who are half-way through signing up or signing in when this PR is deployed, the ID will be fetched from the params if it's not in the session.

---

[Trello card](https://trello.com/c/tjloh5zV/424-stream-application-logs-to-splunk)