### PR TITLE
Push confirmation parameters into session

### DIFF
--- a/app/controllers/devise_confirmations_controller.rb
+++ b/app/controllers/devise_confirmations_controller.rb
@@ -1,12 +1,13 @@
 class DeviseConfirmationsController < Devise::ConfirmationsController
   def sent
-    # if the user is new they have an 'email' but not an
-    # 'unconfirmed_email', even though it's not been confirmed.
-    @email = params[:email] || current_user&.unconfirmed_email || current_user&.email
-    @user_is_confirmed = params.fetch(:user_is_confirmed, current_user&.confirmed?)
-    @user_is_new = params.fetch(:new_user, false)
-
-    redirect_to "/" unless @email
+    if session[:confirmations]
+      @email = session[:confirmations]["email"]
+      @user_is_confirmed = session[:confirmations].fetch("user_is_confirmed", false)
+      @user_is_new = session[:confirmations].fetch("user_is_new", false)
+      session.delete(:confirmations)
+    else
+      redirect_to "/"
+    end
   end
 
   def show
@@ -23,6 +24,10 @@ class DeviseConfirmationsController < Devise::ConfirmationsController
   end
 
   def after_resending_confirmation_instructions_path_for(_resource_name)
-    confirmation_email_sent_path(email: resource.unconfirmed_email, user_is_confirmed: resource.confirmed?)
+    session[:confirmations] = {
+      email: resource.unconfirmed_email,
+      user_is_confirmed: resource.confirmed?,
+    }
+    confirmation_email_sent_path
   end
 end


### PR DESCRIPTION
The email confirmation sent page is reached from three places:

- At the end of the registration journey
- After changing your email address
- From resending a confirmation email

The benefit of having a single controller / view is that the pages
don't get out of sync.  But it does mean that this page needs to know
whether it should display the email address of the current user, or
something else.

Previously this was done through query params.  Now it's done through
session variables.  This removes the email, user_is_confirmed, and
new_user query params.

---

[Trello card](https://trello.com/c/tjloh5zV/424-stream-application-logs-to-splunk)