### PR TITLE
Set 'secure' flag for session cookie in production

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,3 @@
+GovukAccountManagerPrototype::Application.config.session_store :cookie_store,
+                                                               key: "_govuk_account_manager_prototype_session",
+                                                               secure: Rails.env.production?


### PR DESCRIPTION
This ensures that the session cookie isn't sent over HTTP.  PaaS
upgrades requests to HTTPS, so that won't happen normally.

---

[Trello card](https://trello.com/c/ei6DBtLa/490-make-account-session-cookie-only-available-over-https)