### PR TITLE
Set SameSite=Strict for the session cookie

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,4 @@
 GovukAccountManagerPrototype::Application.config.session_store :cookie_store,
                                                                key: "_govuk_account_manager_prototype_session",
+                                                               same_site: :strict,
                                                                secure: Rails.env.production?


### PR DESCRIPTION
This prevents the cookie being sent with any cross-origin requests.

---

[Trello card](https://trello.com/c/iAGNSKI7/492-only-send-account-session-cookie-on-first-party-requests)