### PR TITLE
Do not fetch *_state_id from params

### DIFF
--- a/app/controllers/devise_registration_controller.rb
+++ b/app/controllers/devise_registration_controller.rb
@@ -275,10 +275,6 @@ protected
   end
 
   def check_registration_state
-    if session[:registration_state_id].nil? && params[:registration_state_id]
-      session[:registration_state_id] = params[:registration_state_id]
-    end
-
     @registration_state_id = session[:registration_state_id]
     redirect_to new_user_session_path unless registration_state
   end

--- a/app/controllers/devise_sessions_controller.rb
+++ b/app/controllers/devise_sessions_controller.rb
@@ -25,7 +25,7 @@ class DeviseSessionsController < Devise::SessionsController
       login_state.update!(password_ok: true)
       if request.env["warden.mfa.required"]
         MultiFactorAuth.generate_and_send_code(resource)
-        redirect_to user_session_phone_code_path(login_state_id: @login_state_id)
+        redirect_to user_session_phone_code_path
       else
         do_sign_in
       end

--- a/app/controllers/devise_sessions_controller.rb
+++ b/app/controllers/devise_sessions_controller.rb
@@ -87,10 +87,6 @@ protected
   def verify_signed_out_user; end
 
   def check_login_state
-    if session[:login_state_id].nil? && params[:login_state_id]
-      session[:login_state_id] = params[:login_state_id]
-    end
-
     @login_state_id = session[:login_state_id]
     redirect_to new_user_session_path unless login_state
   end

--- a/spec/feature/login_spec.rb
+++ b/spec/feature/login_spec.rb
@@ -154,7 +154,7 @@ RSpec.feature "Logging in" do
   end
 
   def go_straight_to_mfa_page
-    visit user_session_phone_code_path(login_state_id: LoginState.last.id)
+    visit user_session_phone_code_path
   end
 
   def go_straight_to_account_page


### PR DESCRIPTION
This was a temporary measure so we didn't serve an error to users who
were part-way through registering or logging in when the commit which
pushed those fields into the session was deployed.