### PR TITLE
Set samesite=lax, expire_after=30.minutes, secure=true for session cookie

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,4 +1,4 @@
 GovukAccountManagerPrototype::Application.config.session_store :cookie_store,
                                                                key: "_govuk_account_manager_prototype_session",
-                                                               same_site: :strict,
+                                                               same_site: :lax,
                                                                secure: Rails.env.production?

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,4 +1,5 @@
 GovukAccountManagerPrototype::Application.config.session_store :cookie_store,
                                                                key: "_govuk_account_manager_prototype_session",
+                                                               expire_after: 30.minutes,
                                                                same_site: :lax,
                                                                secure: Rails.env.production?

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,4 @@
+GovukAccountManagerPrototype::Application.config.session_store :cookie_store,
+                                                               key: "_govuk_account_manager_prototype_session",
+                                                               same_site: :strict,
+                                                               secure: Rails.env.production?


### PR DESCRIPTION
`SameSite=lax` is the default in most browsers these days but, as we
just caused a bug by setting it to `SameSite=strict`, I think it's worth
explicitly setting this and documenting why in a commit message.

The `SameSite` attribute is defined in [1], a new draft of RFC
6265 ("Cookies: HTTP State Management"), and is intended to help
mitigate CSRF attacks.

There are three options:

- Strict: the cookie is sent only TO requests on the same site, from
requests originating FROM the same site.

- Lax: like strict, but the cookie is also sent on requests
originating from a different site if the HTTP method is "safe" (in the
sense of RFC 7231 [2] ("HTTP/1.1: Semantics and Content")),
specifically GET, HEAD, OPTIONS, and TRACE.

- None: the cookie is sent in all contexts.

We set `SameSite=strict`, which broke trying to navigate back to the
accounts domain from the transition checker:

1. The user logs into the transition checker (setting a session cookie
on both domains).

2. The user clicks the "Account" link in the header of the transition
checker.

3. The account session cookie is NOT sent, because this is a
cross-site GET request.

4. The accounts domain sets a new session cookie.

5. The user is now logged out.

So instead, set it to lax, which is what we want.

The session cookie isn't sent in POST requests, which means it's not
sent along in our JWT journey; but the JWT is only sent when the user
clicks a big green button saying they want to register, so it's not
too confusing to require them to log in at that point (and that's been
happening from the beginning anyway).

[1]: https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03
[2]: https://tools.ietf.org/html/rfc7231