### PR TITLE
Implement account-manager side of cross-domain _ga handling

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -8,6 +8,7 @@
 //= require govuk_publishing_components/components/govspeak
 //= require govuk_publishing_components/components/header
 //= require govuk_publishing_components/components/radio
+//= require govuk_publishing_components/analytics/explicit-cross-domain-links
 
 //= require ./analytics-track-form
 //= require ./analytics

--- a/app/controllers/api/v1/ephemeral_state_controller.rb
+++ b/app/controllers/api/v1/ephemeral_state_controller.rb
@@ -1,0 +1,19 @@
+class Api::V1::EphemeralStateController < Doorkeeper::ApplicationController
+  before_action :doorkeeper_authorize!
+
+  def show
+    ephemeral_state = EphemeralState.find_by(token: doorkeeper_token.token)
+
+    unless ephemeral_state
+      # if we're here the token is valid, so the EphemeralState did
+      # exist once, but now it's gone - so a 410 is more appropriate
+      # than a 404.
+      head 410
+      return
+    end
+
+    out = ephemeral_state.to_hash
+    ephemeral_state.destroy!
+    render json: out
+  end
+end

--- a/app/controllers/devise_sessions_controller.rb
+++ b/app/controllers/devise_sessions_controller.rb
@@ -1,6 +1,7 @@
 class DeviseSessionsController < Devise::SessionsController
   include ApplicationHelper
   include CookiesHelper
+  include UrlHelper
 
   before_action :check_login_state, only: %i[
     create
@@ -108,7 +109,8 @@ protected
     response["Set-Cookie"] = cookies_policy_header(login_state.user)
 
     sign_in(resource_name, login_state.user)
-    redirect_to login_state.redirect_path
+
+    redirect_to add_param_to_url(login_state.redirect_path, "_ga", params[:_ga])
   end
 
   def after_sign_out_path_for(_resource)

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,10 +1,15 @@
 class WelcomeController < ApplicationController
+  include UrlHelper
+
   skip_before_action :verify_authenticity_token, only: [:show]
 
   def show
     payload = ApplicationKey.validate_jwt!(params[:jwt]) if params[:jwt]
 
-    redirect_to after_login_path(payload, current_user) and return if current_user
+    if current_user
+      redirect_to add_param_to_url(after_login_path(payload, current_user), "_ga", params[:_ga])
+      return
+    end
 
     @email = params.dig(:user, :email)
     if @email

--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -1,0 +1,11 @@
+module UrlHelper
+  def add_param_to_url(url, name, value)
+    return url if value.blank?
+
+    if url.include? "?"
+      "#{url}&#{name}=#{value}"
+    else
+      "#{url}?#{name}=#{value}"
+    end
+  end
+end

--- a/app/jobs/expire_ephemeral_state_job.rb
+++ b/app/jobs/expire_ephemeral_state_job.rb
@@ -1,0 +1,7 @@
+class ExpireEphemeralStateJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    EphemeralState.where("created_at < ?", 60.minutes.ago).delete_all
+  end
+end

--- a/app/models/ephemeral_state.rb
+++ b/app/models/ephemeral_state.rb
@@ -1,0 +1,10 @@
+class EphemeralState < ApplicationRecord
+  belongs_to :user
+
+  def to_hash
+    {
+      _ga: ga_client_id,
+      cookie_consent: user.cookie_consent,
+    }.compact
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,6 +35,9 @@ class User < ApplicationRecord
   has_many :login_states,
            dependent: :destroy
 
+  has_many :ephemeral_states,
+           dependent: :destroy
+
   after_commit :update_remote_user_info, on: %i[create update]
 
   # this has to happen before the record is actually destroyed because

--- a/app/views/devise/confirmations/sent.html.erb
+++ b/app/views/devise/confirmations/sent.html.erb
@@ -32,19 +32,17 @@
       } %>
     <% end %>
 
-    <% if service %>
-      <p class="govuk-body">
-        <a class="govuk-link" href="<%= service[:url] %>" data-module="gem-track-click" data-track-category="account-create" data-track-action="confirm-email" data-track-label="<%= service[:name] %>">
+    <p class="govuk-body" data-module="gem-track-click">
+      <% if service %>
+        <a class="govuk-link" href="<%= service[:url] %>" data-module="explicit-cross-domain-links" data-track-category="account-create" data-track-action="confirm-email" data-track-label="<%= service[:name] %>">
           <%= t("confirmation_sent.continue_to_service", service_name: service[:name]) %>
         </a>
-      </p>
-    <% else %>
-      <p class="govuk-body">
-        <a class="govuk-link" href="<%= user_root_path %>" data-module="gem-track-click" data-track-category="account-create" data-track-action="confirm-email" data-track-label="Account">
+      <% else %>
+        <a class="govuk-link" href="<%= user_root_path %>" data-track-category="account-create" data-track-action="confirm-email" data-track-label="Account">
           <%= t("confirmation_sent.continue_to_account") %>
         </a>
-      </p>
-    <% end %>
+      <% end %>
+    </p>
 
     <%= render "govuk_publishing_components/components/heading", {
       text: t("confirmation_sent.re_register_subtitle"),

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -10,7 +10,7 @@
       margin_bottom: 3,
     } %>
 
-    <%= form_with(url: user_session_path) do %>
+    <%= form_with url: user_session_path, html: { "data-module" => "explicit-cross-domain-links" } do %>
       <% if resource %>
         <%= render "devise/shared/error_messages", resource: resource %>
       <% end %>

--- a/app/views/devise/sessions/phone_code.html.erb
+++ b/app/views/devise/sessions/phone_code.html.erb
@@ -12,7 +12,7 @@
       <p class="govuk-body"><%= msg %></p>
     <% end %>
 
-    <%= form_with(url: user_session_phone_verify_path, method: :post, html: { autocomplete: "off" }) do %>
+    <%= form_with url: user_session_phone_verify_path, method: :post, html: { autocomplete: "off", "data-module" => "explicit-cross-domain-links" } do %>
       <%= render "govuk_publishing_components/components/input", {
         label: { text: t("mfa.phone.code.fields.phone_code.label") },
         name: "phone_code",

--- a/app/views/doorkeeper/authorizations/new.html.erb
+++ b/app/views/doorkeeper/authorizations/new.html.erb
@@ -23,7 +23,7 @@
     <% end %>
 
   <div class="actions">
-    <%= form_tag oauth_authorization_path, method: :post do %>
+    <%= form_tag oauth_authorization_path, method: :post, :"data-module" => "explicit-cross-domain-links" do %>
       <%= hidden_field_tag :client_id, @pre_auth.client.uid %>
       <%= hidden_field_tag :redirect_uri, @pre_auth.redirect_uri %>
       <%= hidden_field_tag :state, @pre_auth.state %>
@@ -37,7 +37,7 @@
         text: t("doorkeeper.authorizations.buttons.authorize")
       } %>
     <% end %>
-    <%= form_tag oauth_authorization_path, method: :delete do %>
+    <%= form_tag oauth_authorization_path, method: :delete, :"data-module" => "explicit-cross-domain-links" do %>
       <%= hidden_field_tag :client_id, @pre_auth.client.uid %>
       <%= hidden_field_tag :redirect_uri, @pre_auth.redirect_uri %>
       <%= hidden_field_tag :state, @pre_auth.state %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,6 +102,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get "/deanonymise-token", to: "deanonymise_token#show"
+      get "/ephemeral-state", to: "ephemeral_state#show"
 
       scope "transition-checker", module: :transition_checker, as: :transition_checker do
         get "/email-subscription", to: "emails#show"

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -9,3 +9,6 @@
   expire_login_state:
     cron: "0 */15 * * * *"
     class: ExpireLoginStateJob
+  expire_ephemeral_state:
+    cron: "0 */15 * * * *"
+    class: ExpireEphemeralStateJob

--- a/db/migrate/20201208161509_create_ephemeral_state.rb
+++ b/db/migrate/20201208161509_create_ephemeral_state.rb
@@ -1,0 +1,14 @@
+class CreateEphemeralState < ActiveRecord::Migration[6.0]
+  def change
+    create_table :ephemeral_states do |t|
+      t.references :user, null: false
+      t.string :grant
+      t.string :token
+      t.string :ga_client_id
+
+      t.timestamps null: false
+    end
+
+    add_foreign_key :ephemeral_states, :users, column: :user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_02_114841) do
+ActiveRecord::Schema.define(version: 2020_12_08_161509) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -39,6 +39,16 @@ ActiveRecord::Schema.define(version: 2020_12_02_114841) do
     t.string "topic_slug", null: false
     t.string "subscription_id"
     t.index ["user_id"], name: "index_email_subscriptions_on_user_id"
+  end
+
+  create_table "ephemeral_states", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "grant"
+    t.string "token"
+    t.string "ga_client_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_ephemeral_states_on_user_id"
   end
 
   create_table "login_states", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -170,6 +180,7 @@ ActiveRecord::Schema.define(version: 2020_12_02_114841) do
   add_foreign_key "data_activities", "oauth_applications"
   add_foreign_key "data_activities", "users"
   add_foreign_key "email_subscriptions", "users"
+  add_foreign_key "ephemeral_states", "users"
   add_foreign_key "login_states", "users"
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_grants", "users", column: "resource_owner_id"

--- a/spec/helpers/url_helper_spec.rb
+++ b/spec/helpers/url_helper_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe UrlHelper do
+  describe "#add_param_to_url" do
+    it "returns the url unchanged if the value is missing" do
+      expect(add_param_to_url("http://www.example.com", "foo", "")).to eq("http://www.example.com")
+    end
+
+    it "uses a ? if the url doesn't already have a query string" do
+      expect(add_param_to_url("http://www.example.com", "foo", "bar")).to eq("http://www.example.com?foo=bar")
+    end
+
+    it "uses a & if the url already has a query string" do
+      expect(add_param_to_url("http://www.example.com?1=2", "foo", "bar")).to eq("http://www.example.com?1=2&foo=bar")
+    end
+  end
+end

--- a/spec/jobs/expire_ephemeral_state_job_spec.rb
+++ b/spec/jobs/expire_ephemeral_state_job_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe ExpireEphemeralStateJob do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let!(:user) { FactoryBot.create(:user) }
+
+  it "deletes hour-old state" do
+    freeze_time do
+      EphemeralState.create!(created_at: 61.minutes.ago, user_id: user.id, token: "old")
+      EphemeralState.create!(created_at: 30.minutes.ago, user_id: user.id, token: "new")
+
+      described_class.perform_now
+
+      expect(EphemeralState.count).to eq(1)
+      expect(EphemeralState.pluck(:token)).to eq(%w[new])
+    end
+  end
+end

--- a/spec/requests/api/v1/ephemeral_state_spec.rb
+++ b/spec/requests/api/v1/ephemeral_state_spec.rb
@@ -1,0 +1,50 @@
+RSpec.describe "/api/v1/ephemeral-state" do
+  let(:user) { FactoryBot.create(:user) }
+
+  let(:application) do
+    FactoryBot.create(
+      :oauth_application,
+      name: "Some Other Government Service",
+      redirect_uri: "https://www.gov.uk",
+      scopes: %i[openid],
+    )
+  end
+
+  let(:token) do
+    FactoryBot.create(
+      :oauth_access_token,
+      resource_owner_id: user.id,
+      application_id: application.id,
+      scopes: %i[deanonymise_tokens],
+    )
+  end
+
+  let(:headers) do
+    {
+      Accept: "application/json",
+      Authorization: "Bearer #{token.token}",
+    }
+  end
+
+  it "returns the ephemeral state" do
+    EphemeralState.create!(user: user, token: token.token, ga_client_id: "hello world")
+    get api_v1_ephemeral_state_path, headers: headers
+    expect(JSON.parse(response.body).symbolize_keys).to eq({
+      _ga: "hello world",
+      cookie_consent: user.cookie_consent,
+    })
+  end
+
+  it "deletes the state after returning it" do
+    EphemeralState.create!(user: user, token: token.token, ga_client_id: "hello world")
+    get api_v1_ephemeral_state_path, headers: headers
+    expect(EphemeralState.count).to eq(0)
+  end
+
+  it "returns a 410 if the state is missing" do
+    EphemeralState.create!(user: user, token: token.token, ga_client_id: "hello world")
+    get api_v1_ephemeral_state_path, headers: headers
+    get api_v1_ephemeral_state_path, headers: headers
+    expect(response).to have_http_status(410)
+  end
+end

--- a/spec/requests/oauth_authorization_spec.rb
+++ b/spec/requests/oauth_authorization_spec.rb
@@ -44,5 +44,12 @@ RSpec.describe "/oauth/authorize" do
 
       expect(response.redirect_url).not_to be_nil
     end
+
+    it "records the _ga parameter" do
+      get authorization_endpoint_url(client: application, scope: "openid transition_checker", _ga: "foo")
+
+      expect(EphemeralState.last).to_not be_nil
+      expect(EphemeralState.last.ga_client_id).to eq("foo")
+    end
   end
 end

--- a/spec/support/helpers/url_helper.rb
+++ b/spec/support/helpers/url_helper.rb
@@ -8,6 +8,7 @@ module UrlHelper
       state: options[:state],
       code_challenge: options[:code_challenge],
       code_challenge_method: options[:code_challenge_method],
+      _ga: options[:_ga],
     }.reject { |_, v| v.blank? }
     "/oauth/authorize?#{parameters.to_query}"
   end


### PR DESCRIPTION
Depends on https://github.com/alphagov/govuk_publishing_components/pull/1811

---

If the user is sent from another service to the accounts domain for
OAuth, there are three cases:

1. The user already has a session.

2. The user does not have a session, and signs up: in which case we
add the `_ga` param to the "return to service" link on the confirmation
page.

3. The user does not have a session, and signs in: in which case we
add the `_ga` param to the sign in form target, and then append it to
the `redirect_path` in the controller.

In all three cases, the user then ends up in the Doorkeeper
authorizations controller, which will do one of two things:

1. Automatically consent.

2. Display a consent page: in which case we add the `_ga` param to the
form targets.

When consent is granted, the `_ga` parameter gets saved in an
`EphemeralState` record, which the service can request with the
newly-issued OAuth token.

---

[Trello card](https://trello.com/c/ISYymNsg/426-fix-cross-domain-tracking-on-redirects)