### PR TITLE
Add error message for invalid confirmation token

### DIFF
--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -5,6 +5,8 @@ en:
       models:
         user:
           attributes:
+            confirmation_token:
+              invalid: This email confirmation link is not valid. Try using the link that was emailed to you again. If that does not work, ask us to send you another confirmation email.
             cookie_consent_decision:
               invalid: Choose whether or not you agree to analytics cookies while you’re signed in to your account.
             current_password:

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -36,7 +36,7 @@ en:
         button: Send confirmation email
         heading: Resend instructions to confirm your email address
         instructions: We’ll send you an email with instructions for confirming the email address for your GOV.UK account.
-        label: Enter your email address
+        label: Email
       send_instructions: You will receive an email with instructions for how to confirm your email address in a few minutes.
       send_paranoid_instructions: If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes.
     failure:

--- a/spec/feature/confirm_email_prompt_spec.rb
+++ b/spec/feature/confirm_email_prompt_spec.rb
@@ -86,11 +86,11 @@ RSpec.feature "Confirm email prompt" do
   end
 
   def and_my_email_address_should_be_prefilled_in_the_form
-    expect(page).to have_field("Enter your email address", with: user.email)
+    expect(page).to have_field(I18n.t("devise.confirmations.resend.label"), with: user.email)
   end
 
   def and_my_unconfirmed_email_address_should_be_prefilled
-    expect(page).to have_field("Enter your email address", with: user.unconfirmed_email)
+    expect(page).to have_field(I18n.t("devise.confirmations.resend.label"), with: user.unconfirmed_email)
   end
 
   def when_i_confirm_my_email_with_a_confirmation_link


### PR DESCRIPTION
## What

When the user provides a confirmation token that does not match what we're expecting (e.g. if a user copy and pastes only part of the link), ActiveRecord will throw an `invalid` error.
This looks rather ugly:

![image](https://user-images.githubusercontent.com/3694062/101492856-2a56b780-395d-11eb-8bd2-d792d6588adf.png)

This PR updates the error and some other content on the resend confirmation email form:
![Screenshot 2020-12-10 at 10 18 39](https://user-images.githubusercontent.com/6329861/101759325-5b57f900-3ad1-11eb-97e0-9130ed035d62.png)

## Why

Error messages are a chance to help the user along, our content wizards can make this better!

[Trello](https://trello.com/c/YbIblvxG/475-snag-%F0%9F%8C%AD-one-last-pesky-error-message)