### PR TITLE
Add some more files to the detect-secrets ignore list

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,7 +1,7 @@
 {
   "custom_plugin_paths": [],
   "exclude": {
-    "files": "^.secrets.baseline$",
+    "files": "^(.secrets.baseline|.env.example|.github/workflows/ci.yml|README.md|config/brakeman.ignore|config/i18n-tasks.yml|config/locales/.*.yml)$",
     "lines": null
   },
   "generated_at": "2020-12-08T11:26:51Z",
@@ -59,54 +59,6 @@
     }
   ],
   "results": {
-    ".env.example": [
-      {
-        "hashed_secret": "745233cd45eaa8b050f60165b863ac973a2152e6",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 6,
-        "type": "Secret Keyword"
-      }
-    ],
-    ".github/workflows/ci.yml": [
-      {
-        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 18,
-        "type": "Secret Keyword"
-      },
-      {
-        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 45,
-        "type": "Basic Auth Credentials"
-      }
-    ],
-    "README.md": [
-      {
-        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 136,
-        "type": "Secret Keyword"
-      },
-      {
-        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 142,
-        "type": "Basic Auth Credentials"
-      },
-      {
-        "hashed_secret": "491c5414edf678e36506389b7cdcd1d35dae8918",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 199,
-        "type": "Secret Keyword"
-      }
-    ],
     "app/views/devise/sessions/new.html.erb": [
       {
         "hashed_secret": "06062101a81dd812ca9902fdf5f27ed472079d75",
@@ -141,63 +93,6 @@
         "is_verified": false,
         "line_number": 6,
         "type": "Hex High Entropy String"
-      }
-    ],
-    "config/brakeman.ignore": [
-      {
-        "hashed_secret": "8a4491fe14bc4029077cde22ddd1fa6c28337a43",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 6,
-        "type": "Hex High Entropy String"
-      },
-      {
-        "hashed_secret": "6bb0f8e469ccbf7c21d5ce9a7eaf15cbafc23c22",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 26,
-        "type": "Hex High Entropy String"
-      }
-    ],
-    "config/i18n-tasks.yml": [
-      {
-        "hashed_secret": "3d9221c542029ecf9d3f1a9fbb7d02db052510b8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 90,
-        "type": "Secret Keyword"
-      },
-      {
-        "hashed_secret": "d907a1d005ac32bceeff3e619ba7075b4c857004",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 93,
-        "type": "Secret Keyword"
-      }
-    ],
-    "config/locales/devise.en.yml": [
-      {
-        "hashed_secret": "7550b672e162c224c309bdea5d48ca975081a904",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 188,
-        "type": "Secret Keyword"
-      },
-      {
-        "hashed_secret": "0be7a248fb840ae80587ee2cafee5388126e543c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 273,
-        "type": "Secret Keyword"
-      }
-    ],
-    "config/locales/en.yml": [
-      {
-        "hashed_secret": "37c6c57bedf4305ef41249c1794760b5cb8fad17",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 50,
-        "type": "Secret Keyword"
       }
     ],
     "config/secrets.yml": [


### PR DESCRIPTION
The list is now:

- .secrets.baseline: this is autogenerated and so won't contain any
real secrets

- .env.example: this is example, not production, configuration

- .github/workflows/ci.yml: this is test, not production,
configuration

- README.md: this is example / test, not production, configuration.

- config/brakeman.ignore: this *does* contain real code snippets, but
if those were secrets, detect-secrets would pick them up
separately (it's actually picking up the fingerprints)

- config/i18n-tasks.yml: this is a config file we've not changed much

- config/locales/*.yml: this can only expose any secrets which we pass
into it via parameterised locale entries, and those would be runtime
values, not hard-coded ones.