### PR TITLE
Prevent sending two checker confirmation emails

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,7 +122,7 @@ GEM
     fugit (1.3.9)
       et-orbi (~> 1.1, >= 1.1.8)
       raabro (~> 1.3)
-    gds-api-adapters (67.1.1)
+    gds-api-adapters (67.2.0)
       addressable
       link_header
       null_logger

--- a/app/models/email_subscription.rb
+++ b/app/models/email_subscription.rb
@@ -14,6 +14,7 @@ class EmailSubscription < ApplicationRecord
       subscriber_list_id: subscriber_list.to_hash.dig("subscriber_list", "id"),
       address: user.email,
       frequency: "daily",
+      skip_confirmation_email: true,
     )
 
     update!(subscription_id: subscription.to_hash.dig("id"))

--- a/spec/jobs/activate_email_subscriptions_job_spec.rb
+++ b/spec/jobs/activate_email_subscriptions_job_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ActivateEmailSubscriptionsJob do
 
     it "calls email-alert-api to create the subscription" do
       stub_subscriber_list = stub_email_alert_api_has_subscriber_list_by_slug(slug: subscription.topic_slug, returned_attributes: { id: "list-id" })
-      stub_activate = stub_email_alert_api_creates_a_subscription("list-id", user.email, "daily", "subscription-id")
+      stub_activate = stub_email_alert_api_creates_a_subscription("list-id", user.email, "daily", "subscription-id", skip_confirmation_email: true)
 
       described_class.perform_now user.id
 
@@ -24,7 +24,7 @@ RSpec.describe ActivateEmailSubscriptionsJob do
 
       it "recreates the subscription" do
         stub_subscriber_list = stub_email_alert_api_has_subscriber_list_by_slug(slug: subscription.topic_slug, returned_attributes: { id: "list-id" })
-        stub_activate = stub_email_alert_api_creates_a_subscription("list-id", user.email, "daily", "subscription-id")
+        stub_activate = stub_email_alert_api_creates_a_subscription("list-id", user.email, "daily", "subscription-id", skip_confirmation_email: true)
         stub_deactivate = stub_email_alert_api_unsubscribes_a_subscription(subscription.subscription_id)
 
         described_class.perform_now user.id

--- a/spec/requests/api/v1/transition_checker/emails_spec.rb
+++ b/spec/requests/api/v1/transition_checker/emails_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe "/api/v1/transition-checker/*" do
 
         it "deactivates the old subscription and activates the new subscription" do
           stub_subscriber_list = stub_email_alert_api_has_subscriber_list_by_slug(slug: new_topic_slug, returned_attributes: { id: "list-id" })
-          stub_activate = stub_email_alert_api_creates_a_subscription("list-id", user.email, "daily", "subscription-id")
+          stub_activate = stub_email_alert_api_creates_a_subscription("list-id", user.email, "daily", "subscription-id", skip_confirmation_email: true)
           stub_deactivate = stub_email_alert_api_unsubscribes_a_subscription(subscription.subscription_id)
           post api_v1_transition_checker_email_subscription_path, headers: headers, params: params
           expect(user.reload.email_subscriptions&.first&.topic_slug).to eq(new_topic_slug)
@@ -107,7 +107,7 @@ RSpec.describe "/api/v1/transition-checker/*" do
       context "without an email subscription" do
         it "activates the new subscription" do
           stub_subscriber_list = stub_email_alert_api_has_subscriber_list_by_slug(slug: new_topic_slug, returned_attributes: { id: "list-id" })
-          stub_activate = stub_email_alert_api_creates_a_subscription("list-id", user.email, "daily", "subscription-id")
+          stub_activate = stub_email_alert_api_creates_a_subscription("list-id", user.email, "daily", "subscription-id", skip_confirmation_email: true)
           post api_v1_transition_checker_email_subscription_path, headers: headers, params: params
           expect(user.reload.email_subscriptions&.first&.topic_slug).to eq(new_topic_slug)
           expect(stub_subscriber_list).to have_been_made


### PR DESCRIPTION
https://trello.com/c/gbYVX8lK/690-send-users-a-link-to-their-results-as-part-of-subscribing-to-the-checker

Depends on: https://github.com/alphagov/gds-api-adapters/pull/1011

We are going to reinstate sending the user a confirmation email,
which contains a link to their Brexit Checker results. However, this
would conflict with the email sent by accounts, and it was only a
coincidence that we removed it just before accounts launched [1].
Since the email sent by this app is more relevant for a subscription
created via an account, this modifies the "subscribe" API call to
instruct the email system not to send its own confirmation email.

[1]: https://github.com/alphagov/email-alert-api/pull/1465