### PR TITLE
Update content for locking accounts, resetting account passwords and MFA failure

### DIFF
--- a/app/views/devise/mailer/reset_password_instructions.text.erb
+++ b/app/views/devise/mailer/reset_password_instructions.text.erb
@@ -1,5 +1,6 @@
 <%= t("devise.mailer.reset_password_instructions.body",
     email: @resource.email,
     link: edit_password_url(@resource, reset_password_token: @token),
+    reset_password_link: reset_password_url,
     feedback_link: feedback_form_url,
 ) %>

--- a/app/views/devise/mailer/unlock_instructions.text.erb
+++ b/app/views/devise/mailer/unlock_instructions.text.erb
@@ -1,5 +1,6 @@
 <%= t("devise.mailer.unlock_instructions.body",
     email: @resource.email,
     link: unlock_url(@resource, unlock_token: @token),
+    reset_password_link: reset_password_url,
     feedback_link: feedback_form_url,
 ) %>

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -109,6 +109,9 @@ en:
           To choose a new password, you need to click on this link:
           %{link}
 
+          This link will expire in 6 hours. You can ask us to send you a new reset password link if you run out of time:
+          %{reset_password_link}
+
           If you’re still having trouble signing in, contact us:
           %{feedback_link}
 

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -39,7 +39,7 @@ en:
       send_paranoid_instructions: If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes.
     failure:
       last_attempt: You will be locked out of your account if you enter the wrong password one more time. You can <a class="govuk-link" href="/account/password/reset">reset your password</a> if you cannot remember it.
-      locked: You’ve been locked out of your account because you entered an incorrect password too many times. We’ve sent you an email with instructions for unlocking your account.
+      locked: You’ve been locked out of your account because you entered the wrong password too many times. We’ve emailed you a link for unlocking your account.
       same_email: Your account is already using this email address. Enter a different email address.
       timeout: Your session has expired. Sign in again to continue using your GOV.UK account.
       unauthenticated: Sign in to your GOV.UK account.
@@ -120,10 +120,13 @@ en:
         body: |
           Hello
 
-          You’ve been locked out of your GOV.UK account because you entered an incorrect password or security code too many times.
+          You’ve been locked out of your GOV.UK account because you entered the wrong password too many times.
 
           To unlock your account you need to click on this link and try to sign in again:
           %{link}
+
+          If you cannot sign in because you’ve forgotten your password, you can reset your password:
+          %{reset_password_link}
 
           If this was not you, contact us:
           %{feedback_link}.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -76,7 +76,7 @@ en:
         link2: Update your results and email alerts
         link2_description: Answer the Brexit transition questions again to update your results.
   change_password:
-    content: Enter the email address you used to create your GOV.UK account. We’ll  send you an email with instructions for changing your password.
+    content: Enter the email address you used to create your GOV.UK account. We’ll email you a link so you can reset your password. The link will expire 6 hours later.
     heading: Change your password
   confirm:
     intro: "<strong>Confirm your email address</strong> to finish updating your account and email alerts."
@@ -174,7 +174,7 @@ en:
         link_text: Security
     user_root_path: Account
   reset_sent:
-    content_with_email: We’ve sent an email to %{email} with instructions for resetting your password.
+    content_with_email: We’ve sent a link for resetting your password to %{email}. The link will expire in 6 hours.
     content_without_email: We’ve sent an email to the address you provided with instructions for changing your password.
     heading: Reset your password - check your email
     subheading: If you did not get the email

--- a/config/locales/mfa.en.yml
+++ b/config/locales/mfa.en.yml
@@ -8,6 +8,7 @@ en:
       phone_code:
         expired: The security code you’ve entered has expired. Security codes expire after 10 minutes. We can <a class="govuk-link" href="%{resend_link}">send a new security code</a>.
         invalid: The security code you’ve entered is not correct. Try entering the code again.
+        too_many_attempts: You’ve entered the wrong security code too many times. You need to <a class="govuk-link" href="%{resend_link}">get a new security code</a>.
     phone:
       code:
         change_heading: Enter your security code

--- a/lib/multi_factor_auth.rb
+++ b/lib/multi_factor_auth.rb
@@ -66,7 +66,7 @@ module MultiFactorAuth
       :invalid
     else
       auth.update!(phone_code: nil)
-      :expired
+      :too_many_attempts
     end
   end
 

--- a/spec/feature/change_phone_spec.rb
+++ b/spec/feature/change_phone_spec.rb
@@ -82,7 +82,7 @@ RSpec.feature "Change Phone" do
         enter_password
         (MultiFactorAuth::ALLOWED_ATTEMPTS + 1).times { enter_incorrect_mfa }
 
-        expect(page).to have_text(Rails::Html::FullSanitizer.new.sanitize(I18n.t("mfa.errors.phone_code.expired")))
+        expect(page).to have_text(Rails::Html::FullSanitizer.new.sanitize(I18n.t("mfa.errors.phone_code.too_many_attempts")))
       end
     end
   end

--- a/spec/feature/login_spec.rb
+++ b/spec/feature/login_spec.rb
@@ -66,7 +66,7 @@ RSpec.feature "Logging in" do
         enter_password
         (MultiFactorAuth::ALLOWED_ATTEMPTS + 1).times { enter_incorrect_mfa }
 
-        expect(page).to have_text(Rails::Html::FullSanitizer.new.sanitize(I18n.t("mfa.errors.phone_code.expired")))
+        expect(page).to have_text(Rails::Html::FullSanitizer.new.sanitize(I18n.t("mfa.errors.phone_code.too_many_attempts")))
       end
     end
   end

--- a/spec/feature/registration_spec.rb
+++ b/spec/feature/registration_spec.rb
@@ -221,7 +221,7 @@ RSpec.feature "Registration" do
         enter_uk_phone_number
         (MultiFactorAuth::ALLOWED_ATTEMPTS + 1).times { enter_incorrect_mfa }
 
-        expect(page).to have_text(Rails::Html::FullSanitizer.new.sanitize(I18n.t("mfa.errors.phone_code.expired")))
+        expect(page).to have_text(Rails::Html::FullSanitizer.new.sanitize(I18n.t("mfa.errors.phone_code.too_many_attempts")))
       end
     end
   end


### PR DESCRIPTION
Makes the changes given in the Google docs linked to from the Trello card:
- the error message and email users get if they use an incorrect password too many times
- the screens users see and the email they get when they reset their password
- the error message users see if they enter the wrong security code too many times

Trello card: https://trello.com/c/9gzjIDna