### PR TITLE
Only add GOV.UK Docker relevant seed data when using Docker

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -25,9 +25,11 @@ if Rails.env.development?
   )
 
   # Developement Credentials for GOV.UK Docker
-  ApplicationKey.create(
-    application_uid: ENV.fetch("FINDER_FRONTEND_OAUTH_CLIENT_ID"),
-    key_id: ENV.fetch("FINDER_FRONTEND_OAUTH_CLIENT_PUBLIC_KEY_UUID"),
-    pem: ENV.fetch("FINDER_FRONTEND_OAUTH_CLIENT_PUBLIC_KEY"),
-  )
+  if ENV["FINDER_FRONTEND_OAUTH_CLIENT_ID"]
+    ApplicationKey.create(
+      application_uid: ENV.fetch("FINDER_FRONTEND_OAUTH_CLIENT_ID"),
+      key_id: ENV.fetch("FINDER_FRONTEND_OAUTH_CLIENT_PUBLIC_KEY_UUID"),
+      pem: ENV.fetch("FINDER_FRONTEND_OAUTH_CLIENT_PUBLIC_KEY"),
+    )
+  end
 end


### PR DESCRIPTION
If you seed the database outside of GOV.UK Docker (e.g. to run the tests locally), you get an error because the environment variables are not set.