### PR TITLE
Record more security events a la Signon

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -115,7 +115,7 @@
       {
         "hashed_secret": "efa245831a7d955cad1c630beb4c67ae6819dec7",
         "is_verified": false,
-        "line_number": 181,
+        "line_number": 189,
         "type": "Secret Keyword"
       }
     ]

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,16 @@ class ApplicationController < ActionController::Base
 
   rescue_from Exception, with: :top_level_error_handler
 
+  def record_security_event(event, options = {})
+    SecurityActivity.record_event(
+      event,
+      {
+        ip_address: request.remote_ip,
+        user_agent_name: request.user_agent,
+      }.merge(options),
+    )
+  end
+
 protected
 
   def get_payload(payload = nil)

--- a/app/controllers/devise_confirmations_controller.rb
+++ b/app/controllers/devise_confirmations_controller.rb
@@ -12,7 +12,9 @@ class DeviseConfirmationsController < Devise::ConfirmationsController
 
   def show
     super do
-      if resource.errors.details[:email].first&.dig(:error) == :already_confirmed
+      if resource.errors.empty?
+        record_security_event(SecurityActivity::EMAIL_CHANGED, user: resource)
+      elsif resource.errors.details[:email].first&.dig(:error) == :already_confirmed
         if current_user
           redirect_to user_root_path
         else

--- a/app/controllers/devise_confirmations_controller.rb
+++ b/app/controllers/devise_confirmations_controller.rb
@@ -13,7 +13,7 @@ class DeviseConfirmationsController < Devise::ConfirmationsController
   def show
     super do
       if resource.errors.empty?
-        record_security_event(SecurityActivity::EMAIL_CHANGED, user: resource)
+        record_security_event(SecurityActivity::EMAIL_CHANGED, user: resource, notes: "to #{resource.email}")
       elsif resource.errors.details[:email].first&.dig(:error) == :already_confirmed
         if current_user
           redirect_to user_root_path

--- a/app/controllers/devise_passwords_controller.rb
+++ b/app/controllers/devise_passwords_controller.rb
@@ -1,4 +1,13 @@
 class DevisePasswordsController < Devise::PasswordsController
+  # POST /resource/password
+  def create
+    super do |resource|
+      next unless successfully_sent? resource
+
+      record_security_event(SecurityActivity::PASSWORD_RESET_REQUEST, user: resource)
+    end
+  end
+
   # GET /resource/password/edit?reset_password_token=<token>
   def edit
     super
@@ -11,7 +20,9 @@ class DevisePasswordsController < Devise::PasswordsController
   # PUT /resource/password
   def update
     super do |resource|
-      SecurityActivity.change_password!(resource, request.remote_ip) if resource.errors.empty?
+      next unless resource.errors.empty?
+
+      record_security_event(SecurityActivity::PASSWORD_RESET_SUCCESS, user: resource)
     end
   end
 

--- a/app/controllers/devise_registration_controller.rb
+++ b/app/controllers/devise_registration_controller.rb
@@ -243,6 +243,8 @@ class DeviseRegistrationController < Devise::RegistrationsController
     self.resource = resource_class.to_adapter.get!(send(:"current_#{resource_name}").to_key)
     prev_unconfirmed_email = resource.unconfirmed_email if resource.respond_to?(:unconfirmed_email)
 
+    old_email = resource.email
+
     new_email = params.dig(:user, :email)
     new_password = params.dig(:user, :password) # pragma: allowlist secret
 
@@ -264,7 +266,7 @@ class DeviseRegistrationController < Devise::RegistrationsController
     end
 
     if resource_updated
-      record_security_event(SecurityActivity::EMAIL_CHANGE_REQUESTED, user: resource) if new_email
+      record_security_event(SecurityActivity::EMAIL_CHANGE_REQUESTED, user: resource, notes: "from #{old_email} to #{new_email}") if new_email
       record_security_event(SecurityActivity::PASSWORD_CHANGED, user: resource) if new_password
 
       set_flash_message_for_update(resource, prev_unconfirmed_email)

--- a/app/controllers/devise_registration_controller.rb
+++ b/app/controllers/devise_registration_controller.rb
@@ -264,8 +264,8 @@ class DeviseRegistrationController < Devise::RegistrationsController
     end
 
     if resource_updated
-      SecurityActivity.change_email!(resource, request.remote_ip) if new_email
-      SecurityActivity.change_password!(resource, request.remote_ip) if new_password
+      record_security_event(SecurityActivity::EMAIL_CHANGE_REQUESTED, user: resource) if new_email
+      record_security_event(SecurityActivity::PASSWORD_CHANGED, user: resource) if new_password
 
       set_flash_message_for_update(resource, prev_unconfirmed_email)
       bypass_sign_in resource, scope: resource_name if sign_in_after_change_password?

--- a/app/controllers/devise_sessions_controller.rb
+++ b/app/controllers/devise_sessions_controller.rb
@@ -77,13 +77,13 @@ class DeviseSessionsController < Devise::SessionsController
   def phone_verify
     state = MultiFactorAuth.verify_code(login_state.user, params[:phone_code])
     if state == :ok
-      record_security_event(SecurityActivity::ADDITIONAL_FACTOR_VERIFICATION_SUCCESS, user: login_state.user)
+      record_security_event(SecurityActivity::ADDITIONAL_FACTOR_VERIFICATION_SUCCESS, user: login_state.user, factor: :sms)
       do_sign_in
       login_state.user.update!(last_mfa_success: Time.zone.now)
       login_state.destroy!
       session.delete(:login_state_id)
     else
-      record_security_event(SecurityActivity::ADDITIONAL_FACTOR_VERIFICATION_FAILURE, user: login_state.user)
+      record_security_event(SecurityActivity::ADDITIONAL_FACTOR_VERIFICATION_FAILURE, user: login_state.user, factor: :sms)
       @phone_code_error_message = I18n.t("mfa.errors.phone_code.#{state}", resend_link: user_session_phone_resend_path)
       render :phone_code
     end

--- a/app/controllers/devise_sessions_controller.rb
+++ b/app/controllers/devise_sessions_controller.rb
@@ -47,6 +47,8 @@ class DeviseSessionsController < Devise::SessionsController
       user = User.find_by(email: @email)
       user_exists = user.present?
 
+      record_security_event(SecurityActivity::LOGIN_FAILURE, user: user) if user_exists
+
       if user_exists && !user.active_for_authentication? && !user.access_locked?
         @resource_error_messages[:email] = [I18n.t("devise.failure.unconfirmed")]
       elsif user_exists && params.dig(:user, :password).present?
@@ -75,11 +77,13 @@ class DeviseSessionsController < Devise::SessionsController
   def phone_verify
     state = MultiFactorAuth.verify_code(login_state.user, params[:phone_code])
     if state == :ok
+      record_security_event(SecurityActivity::ADDITIONAL_FACTOR_VERIFICATION_SUCCESS, user: login_state.user)
       do_sign_in
       login_state.user.update!(last_mfa_success: Time.zone.now)
       login_state.destroy!
       session.delete(:login_state_id)
     else
+      record_security_event(SecurityActivity::ADDITIONAL_FACTOR_VERIFICATION_FAILURE, user: login_state.user)
       @phone_code_error_message = I18n.t("mfa.errors.phone_code.#{state}", resend_link: user_session_phone_resend_path)
       render :phone_code
     end
@@ -132,6 +136,8 @@ protected
   end
 
   def do_sign_in
+    record_security_event(SecurityActivity::LOGIN_SUCCESS, user: login_state.user)
+
     cookies[:cookies_preferences_set] = "true"
     response["Set-Cookie"] = cookies_policy_header(login_state.user)
 

--- a/app/controllers/devise_unlocks_controller.rb
+++ b/app/controllers/devise_unlocks_controller.rb
@@ -12,4 +12,12 @@ class DeviseUnlocksController < Devise::UnlocksController
       end
     end
   end
+
+  def show
+    super do
+      next unless resource.errors.empty?
+
+      record_security_event(SecurityActivity::MANUAL_ACCOUNT_UNLOCK, user: resource)
+    end
+  end
 end

--- a/app/controllers/edit_phone_controller.rb
+++ b/app/controllers/edit_phone_controller.rb
@@ -43,10 +43,7 @@ class EditPhoneController < ApplicationController
         unconfirmed_phone: nil,
         last_mfa_success: Time.zone.now,
       )
-      SecurityActivity.change_phone!(
-        current_user,
-        request.remote_ip,
-      )
+      record_security_event(SecurityActivity::PHONE_CHANGED, user: current_user)
       UserMailer.with(user: current_user).change_phone_email.deliver_later
       redirect_to account_manage_path
     else

--- a/app/controllers/security_controller.rb
+++ b/app/controllers/security_controller.rb
@@ -2,7 +2,7 @@ class SecurityController < ApplicationController
   before_action :authenticate_user!
 
   def show
-    @activity = current_user.security_activities.order(created_at: :desc)
+    @activity = current_user.security_activities.show_on_security_page.order(created_at: :desc)
     @data_exchanges = dedup_nearby(current_user.data_activities.where.not(oauth_application_id: AccountManagerApplication.application.id).order(created_at: :desc))
       .compact
       .map { |a| activity_to_exchange(a) }

--- a/app/models/log_entry.rb
+++ b/app/models/log_entry.rb
@@ -1,11 +1,12 @@
 class LogEntry
   attr_reader :id, :name
 
-  def initialize(id:, name:, require_user: false, require_application: false)
+  def initialize(id:, name:, require_user: false, require_application: false, require_factor: false)
     @id = id
     @name = name
     @require_user = require_user
     @require_application = require_application
+    @require_factor = require_factor
   end
 
   def require_user?
@@ -14,5 +15,9 @@ class LogEntry
 
   def require_application?
     @require_application
+  end
+
+  def require_factor?
+    @require_factor
   end
 end

--- a/app/models/log_entry.rb
+++ b/app/models/log_entry.rb
@@ -1,0 +1,18 @@
+class LogEntry
+  attr_reader :id, :name
+
+  def initialize(id:, name:, require_user: false, require_application: false)
+    @id = id
+    @name = name
+    @require_user = require_user
+    @require_application = require_application
+  end
+
+  def require_user?
+    @require_user
+  end
+
+  def require_application?
+    @require_application
+  end
+end

--- a/app/models/security_activity.rb
+++ b/app/models/security_activity.rb
@@ -25,7 +25,7 @@ class SecurityActivity < ApplicationRecord
   EVENTS_REQUIRING_USER = EVENTS.select(&:require_user?)
   EVENTS_REQUIRING_APPLICATION = EVENTS.select(&:require_application?)
 
-  VALID_OPTIONS = %i[user user_id oauth_application oauth_application_id ip_address user_agent user_agent_id].freeze
+  VALID_OPTIONS = %i[user user_id oauth_application oauth_application_id ip_address user_agent user_agent_id notes].freeze
 
   validates :user_id, presence: { if: proc { |event_log| EVENTS_REQUIRING_USER.include? event_log.event } }
   validates :oauth_application_id, presence: { if: proc { |event_log| EVENTS_REQUIRING_APPLICATION.include? event_log.event } }

--- a/app/models/security_activity.rb
+++ b/app/models/security_activity.rb
@@ -1,5 +1,4 @@
 class SecurityActivity < ApplicationRecord
-  # TODO: decide which of these to show on the security page
   EVENTS = [
     # logging in
     ACCOUNT_LOCKED = LogEntry.new(id: 5, name: :account_locked, require_user: true),
@@ -16,8 +15,8 @@ class SecurityActivity < ApplicationRecord
     PASSWORD_RESET_SUCCESS = LogEntry.new(id: 4, name: :password_reset_success, require_user: true),
 
     # update
-    EMAIL_CHANGE_REQUESTED = LogEntry.new(id: 11, name: :email_change_requested, require_user: true),
-    EMAIL_CHANGED = LogEntry.new(id: 1, name: :email_changed, require_user: true),
+    EMAIL_CHANGE_REQUESTED = LogEntry.new(id: 1, name: :email_change_requested, require_user: true),
+    EMAIL_CHANGED = LogEntry.new(id: 11, name: :email_changed, require_user: true),
     PHONE_CHANGED = LogEntry.new(id: 2, name: :phone_changed, require_user: true),
     PASSWORD_CHANGED = LogEntry.new(id: 3, name: :password_changed, require_user: true),
   ].freeze
@@ -29,6 +28,8 @@ class SecurityActivity < ApplicationRecord
   VALID_OPTIONS = %i[user user_id oauth_application oauth_application_id ip_address user_agent user_agent_id factor notes].freeze
 
   VALID_FACTORS = %w[sms].freeze
+
+  scope :show_on_security_page, -> { where(event_type: EVENTS.select { |e| I18n.exists?("account.security.event.#{e.name}") }.map(&:id)) }
 
   validates :user_id, presence: { if: proc { |event_log| EVENTS_REQUIRING_USER.include? event_log.event } }
   validates :oauth_application_id, presence: { if: proc { |event_log| EVENTS_REQUIRING_APPLICATION.include? event_log.event } }

--- a/app/models/security_activity.rb
+++ b/app/models/security_activity.rb
@@ -1,52 +1,67 @@
 class SecurityActivity < ApplicationRecord
-  enum event_type: {
-    login: 0,
-    change_email: 1,
-    change_phone: 2,
-    change_password: 3, # pragma: allowlist secret
-  }
+  # TODO: decide which of these to show on the security page
+  EVENTS = [
+    # logging in
+    ACCOUNT_LOCKED = LogEntry.new(id: 5, name: :account_locked, require_user: true),
+    MANUAL_ACCOUNT_UNLOCK = LogEntry.new(id: 6, name: :manual_account_unlock, require_user: true),
 
-  belongs_to :user
+    ADDITIONAL_FACTOR_VERIFICATION_SUCCESS = LogEntry.new(id: 7, name: :additional_factor_verification_success, require_user: true),
+    ADDITIONAL_FACTOR_VERIFICATION_FAILURE = LogEntry.new(id: 8, name: :additional_factor_verification_failure, require_user: true),
 
-  def self.login!(user, ip_address)
-    new(
-      event_type: :login,
-      user_id: user.id,
-      ip_address: ip_address,
-    ).save!
+    LOGIN_SUCCESS = LogEntry.new(id: 0, name: :login_success, require_user: true),
+    LOGIN_FAILURE = LogEntry.new(id: 9, name: :login_failure, require_user: true),
+
+    # recovery
+    PASSWORD_RESET_REQUEST = LogEntry.new(id: 10, name: :password_reset_request, require_user: true),
+    PASSWORD_RESET_SUCCESS = LogEntry.new(id: 4, name: :password_reset_success, require_user: true),
+
+    # update
+    EMAIL_CHANGE_REQUESTED = LogEntry.new(id: 11, name: :email_change_requested, require_user: true),
+    EMAIL_CHANGED = LogEntry.new(id: 1, name: :email_changed, require_user: true),
+    PHONE_CHANGED = LogEntry.new(id: 2, name: :phone_changed, require_user: true),
+    PASSWORD_CHANGED = LogEntry.new(id: 3, name: :password_changed, require_user: true),
+  ].freeze
+
+  EVENTS_REQUIRING_USER = EVENTS.select(&:require_user?)
+  EVENTS_REQUIRING_APPLICATION = EVENTS.select(&:require_application?)
+
+  VALID_OPTIONS = %i[user user_id oauth_application oauth_application_id ip_address user_agent user_agent_id].freeze
+
+  validates :user_id, presence: { if: proc { |event_log| EVENTS_REQUIRING_USER.include? event_log.event } }
+  validates :oauth_application_id, presence: { if: proc { |event_log| EVENTS_REQUIRING_APPLICATION.include? event_log.event } }
+
+  # account locking is done in the model, not the controller, so it
+  # doesn't have access to the request env: no ip address, no user
+  # agent.
+  validates :ip_address, presence: { if: proc { |event_log| event_log.event != ACCOUNT_LOCKED } }
+
+  validates :event_type, presence: true
+  validate :validate_event_mappable
+
+  belongs_to :user, optional: true
+  belongs_to :oauth_application, class_name: "Doorkeeper::Application", optional: true
+  belongs_to :user_agent, optional: true
+
+  delegate :name, to: :event
+
+  def self.record_event(event, options = {})
+    attributes = {
+      event_type: event.id,
+    }.merge(options.slice(*VALID_OPTIONS))
+
+    if options[:user_agent_name]
+      attributes.merge!(user_agent_id: UserAgent.find_or_create_by!(name: options[:user_agent_name]).id)
+    end
+
+    SecurityActivity.create!(attributes)
   end
 
-  def self.login_with!(user, oauth_application, ip_address)
-    new(
-      event_type: :login,
-      user_id: user.id,
-      oauth_application_id: oauth_application.id,
-      ip_address: ip_address,
-    ).save!
+  def self.of_type(event)
+    where(event_type: event.id)
   end
 
-  def self.change_email!(user, ip_address)
-    new(
-      event_type: :change_email,
-      user_id: user.id,
-      ip_address: ip_address,
-    ).save!
-  end
-
-  def self.change_password!(user, ip_address)
-    new(
-      event_type: :change_password,
-      user_id: user.id,
-      ip_address: ip_address,
-    ).save!
-  end
-
-  def self.change_phone!(user, ip_address)
-    new(
-      event_type: :change_phone,
-      user_id: user.id,
-      ip_address: ip_address,
-    ).save!
+  def event
+    EVENTS.detect { |event| event.id == event_type }
   end
 
   def client
@@ -54,6 +69,14 @@ class SecurityActivity < ApplicationRecord
       AccountManagerApplication::NAME
     else
       Doorkeeper::Application.find(oauth_application_id).name
+    end
+  end
+
+protected
+
+  def validate_event_mappable
+    unless event
+      errors.add(:event_type, "must have a corresponding `LogEntry` for #{event_type}")
     end
   end
 end

--- a/app/models/user_agent.rb
+++ b/app/models/user_agent.rb
@@ -1,0 +1,2 @@
+class UserAgent < ApplicationRecord
+end

--- a/app/views/security/show.html.erb
+++ b/app/views/security/show.html.erb
@@ -73,7 +73,7 @@
         <% @activity.each do |activity| %>
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">
-              <%= t("account.security.event.#{activity.event_type}") %>
+              <%= t("account.security.event.#{activity.name}") %>
             </dt>
             <dd class="govuk-summary-list__value">
               <span class="date-text">
@@ -86,7 +86,7 @@
               <br>
                <p class="govuk-body">
                 <a class="govuk-link" href="<%= account_security_report_path %>" data-module="gem-track-click" data-track-category="account-manage" data-track-action="security" data-track-label="not-me">
-                  <%= t("account.security.event.report_suspicious_activity") %>
+                  <%= t("account.security.report_suspicious_activity") %>
                 </a>
               </p>
             </dd>

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -420,10 +420,12 @@ Doorkeeper.configure do
     if controller.params[:response_type] == "code"
       access_grant = context.issued_token
 
-      SecurityActivity.login_with!(
-        controller.current_user,
-        access_grant.application,
-        controller.request.remote_ip,
+      SecurityActivity.record_event(
+        SecurityActivity::LOGIN_SUCCESS,
+        ip_address: controller.request.remote_ip,
+        user_agent_name: controller.request.user_agent,
+        user: controller.current_user,
+        oauth_application: context.issued_token.application,
       )
 
       EphemeralState.create!(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,17 +46,10 @@ en:
       activity: Sign-in attempts and changes to account details
       description: <p class="govuk-body">Read the <a class="govuk-link" href="https://www.gov.uk/government/publications/govuk-accounts-trial-full-privacy-notice-and-accessibility-statement" data-module="gem-track-click" data-track-category="account-manage" data-track-action="security" data-track-label="privacy-notice">full GOV.UK accounts privacy notice</a> to find out how we collect, process and use information about you.</p>
       event:
-        account_locked: Password verification failed too many times, account locked for 1 hour.
-        additional_factor_verification_failure: Additional factor was incorrect when logging ibn.
-        additional_factor_verification_success: Additional factor was correct when logging in.
-        email_change_requested: Change of email address has been requested
-        email_changed: Change of email address has been confirmed.
-        login_failure: Entered an incorrect password when logging in.
+        email_change_requested: Changed email address
         login_success: Signed in
-        manual_account_unlock: Account unlocked by clicking link.
         password_changed: Changed password
-        password_reset_request: Requested a password reset link.
-        password_reset_success: Reset password
+        password_reset_success: Changed password
         phone_changed: Changed phone number
       heading: Security
       no_activity_found: There is no currently logged activity on your account. As you use your account to log in and interact with services you will be able to see a record of how it has been used here.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,11 +46,18 @@ en:
       activity: Sign-in attempts and changes to account details
       description: <p class="govuk-body">Read the <a class="govuk-link" href="https://www.gov.uk/government/publications/govuk-accounts-trial-full-privacy-notice-and-accessibility-statement" data-module="gem-track-click" data-track-category="account-manage" data-track-action="security" data-track-label="privacy-notice">full GOV.UK accounts privacy notice</a> to find out how we collect, process and use information about you.</p>
       event:
-        change_email: Changed email address
-        change_password: Changed password
-        change_phone: Changed phone number
-        login: Signed in
-        report_suspicious_activity: Report suspicious activity
+        account_locked: Password verification failed too many times, account locked for 1 hour.
+        additional_factor_verification_failure: Additional factor was incorrect when logging ibn.
+        additional_factor_verification_success: Additional factor was correct when logging in.
+        email_change_requested: Change of email address has been requested
+        email_changed: Change of email address has been confirmed.
+        login_failure: Entered an incorrect password when logging in.
+        login_success: Signed in
+        manual_account_unlock: Account unlocked by clicking link.
+        password_changed: Changed password
+        password_reset_request: Requested a password reset link.
+        password_reset_success: Reset password
+        phone_changed: Changed phone number
       heading: Security
       no_activity_found: There is no currently logged activity on your account. As you use your account to log in and interact with services you will be able to see a record of how it has been used here.
       report:
@@ -61,6 +68,7 @@ en:
           <p class="govuk-body">Use the feedback form to tell us if you think something does not look right with your GOV.UK account.</p>
           <p class="govuk-body">We’ll get back to you as soon as possible.</p>
         heading: Report suspicious activity
+      report_suspicious_activity: Report suspicious activity
     your_account:
       account_not_used:
         action: "%{link} to start getting the most out of your account."

--- a/db/migrate/20201214101842_create_user_agent.rb
+++ b/db/migrate/20201214101842_create_user_agent.rb
@@ -1,0 +1,12 @@
+class CreateUserAgent < ActiveRecord::Migration[6.0]
+  def change
+    create_table :user_agents do |t|
+      t.string :name, limit: 1000, null: false
+    end
+
+    add_index :user_agents, :name, unique: true
+
+    add_reference :security_activities, :user_agent, index: true
+    add_foreign_key :security_activities, :user_agents
+  end
+end

--- a/db/migrate/20201214111332_change_security_activities_make_ip_address_nullable.rb
+++ b/db/migrate/20201214111332_change_security_activities_make_ip_address_nullable.rb
@@ -1,0 +1,5 @@
+class ChangeSecurityActivitiesMakeIpAddressNullable < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :security_activities, :ip_address, true
+  end
+end

--- a/db/migrate/20201214153711_add_notes_to_security_activities.rb
+++ b/db/migrate/20201214153711_add_notes_to_security_activities.rb
@@ -1,0 +1,5 @@
+class AddNotesToSecurityActivities < ActiveRecord::Migration[6.0]
+  def change
+    add_column :security_activities, :notes, :string
+  end
+end

--- a/db/migrate/20201216202609_add_factor_to_security_activities.rb
+++ b/db/migrate/20201216202609_add_factor_to_security_activities.rb
@@ -1,0 +1,5 @@
+class AddFactorToSecurityActivities < ActiveRecord::Migration[6.0]
+  def change
+    add_column :security_activities, :factor, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_14_111332) do
+ActiveRecord::Schema.define(version: 2020_12_14_153711) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -142,6 +142,7 @@ ActiveRecord::Schema.define(version: 2020_12_14_111332) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "user_agent_id"
+    t.string "notes"
     t.index ["oauth_application_id"], name: "index_security_activities_on_oauth_application_id"
     t.index ["user_agent_id"], name: "index_security_activities_on_user_agent_id"
     t.index ["user_id"], name: "index_security_activities_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_14_093233) do
+ActiveRecord::Schema.define(version: 2020_12_14_111332) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -137,12 +137,19 @@ ActiveRecord::Schema.define(version: 2020_12_14_093233) do
   create_table "security_activities", force: :cascade do |t|
     t.integer "event_type", null: false
     t.bigint "user_id", null: false
-    t.string "ip_address", null: false
+    t.string "ip_address"
     t.bigint "oauth_application_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "user_agent_id"
     t.index ["oauth_application_id"], name: "index_security_activities_on_oauth_application_id"
+    t.index ["user_agent_id"], name: "index_security_activities_on_user_agent_id"
     t.index ["user_id"], name: "index_security_activities_on_user_id"
+  end
+
+  create_table "user_agents", force: :cascade do |t|
+    t.string "name", limit: 1000, null: false
+    t.index ["name"], name: "index_user_agents_on_name", unique: true
   end
 
   create_table "users", force: :cascade do |t|
@@ -194,5 +201,6 @@ ActiveRecord::Schema.define(version: 2020_12_14_093233) do
   add_foreign_key "oauth_openid_requests", "oauth_access_grants", column: "access_grant_id", on_delete: :cascade
   add_foreign_key "registration_states", "jwts"
   add_foreign_key "security_activities", "oauth_applications"
+  add_foreign_key "security_activities", "user_agents"
   add_foreign_key "security_activities", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_14_153711) do
+ActiveRecord::Schema.define(version: 2020_12_16_202609) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -143,6 +143,7 @@ ActiveRecord::Schema.define(version: 2020_12_14_153711) do
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "user_agent_id"
     t.string "notes"
+    t.string "factor"
     t.index ["oauth_application_id"], name: "index_security_activities_on_oauth_application_id"
     t.index ["user_agent_id"], name: "index_security_activities_on_user_agent_id"
     t.index ["user_id"], name: "index_security_activities_on_user_id"

--- a/lib/tasks/statistics.rake
+++ b/lib/tasks/statistics.rake
@@ -56,7 +56,7 @@ namespace :statistics do
     results += "\n"
 
     all_logins = SecurityActivity
-      .where(event_type: "login")
+      .of_type(SecurityActivity::LOGIN_SUCCESS)
       .where(oauth_application_id: nil)
       .where("created_at < ?", args.end_date)
     results += "Total number of logins to #{args.end_date}: \n#{all_logins.count}\n\n"
@@ -76,14 +76,14 @@ namespace :statistics do
     results += "Accounts logged in between #{args.start_date} and #{args.end_date}: \n#{user_logins.count}\n\n"
 
     all_login_frequency = SecurityActivity
-    .where(event_type: "login")
-    .where(oauth_application_id: nil)
-    .where("created_at < ?", args.end_date)
-    .pluck(:user_id)
-    .tally
-    .values
-    .tally
-    .sort
+      .of_type(SecurityActivity::LOGIN_SUCCESS)
+      .where(oauth_application_id: nil)
+      .where("created_at < ?", args.end_date)
+      .pluck(:user_id)
+      .tally
+      .values
+      .tally
+      .sort
     results += "Number of logins per account to #{args.end_date}:\n"
     all_login_frequency.each do |frequency, count|
       results += "Accounts logged into #{frequency} #{'time'.pluralize(frequency)}: #{count}\n"
@@ -91,14 +91,14 @@ namespace :statistics do
     results += "\n"
 
     login_frequency = SecurityActivity
-    .where(event_type: "login")
-    .where(oauth_application_id: nil)
-    .where("created_at BETWEEN ? AND ?", args.start_date, args.end_date)
-    .pluck(:user_id)
-    .tally
-    .values
-    .tally
-    .sort
+      .of_type(SecurityActivity::LOGIN_SUCCESS)
+      .where(oauth_application_id: nil)
+      .where("created_at BETWEEN ? AND ?", args.start_date, args.end_date)
+      .pluck(:user_id)
+      .tally
+      .values
+      .tally
+      .sort
     results += "Number of logins between #{args.start_date} and #{args.end_date}:\n"
     login_frequency.each do |frequency, count|
       results += "Accounts logged into #{frequency} #{'time'.pluralize(frequency)}: #{count}\n"

--- a/spec/feature/change_phone_spec.rb
+++ b/spec/feature/change_phone_spec.rb
@@ -19,6 +19,17 @@ RSpec.feature "Change Phone" do
     expect(user.reload.phone).to eq("+447581123456")
   end
 
+  it "shows the change phone event on the security page" do
+    log_in
+    go_to_change_number_page
+    enter_new_phone_number
+    enter_password
+    enter_mfa
+    visit_security_page
+
+    expect(page).to have_text(I18n.t("account.security.event.phone_changed"))
+  end
+
   context "when the user enters the same phone number" do
     it "returns an error" do
       log_in
@@ -153,5 +164,9 @@ RSpec.feature "Change Phone" do
     phone_code = user.reload.phone_code
     fill_in "phone_code", with: "1#{phone_code}"
     click_on I18n.t("mfa.phone.code.fields.submit.label")
+  end
+
+  def visit_security_page
+    click_on I18n.t("navigation.menu_bar.security.link_text")
   end
 end

--- a/spec/feature/confirm_email_prompt_spec.rb
+++ b/spec/feature/confirm_email_prompt_spec.rb
@@ -29,6 +29,15 @@ RSpec.feature "Confirm email prompt" do
       when_i_navigate_to_home
       then_i_do_not_see_the_confirmation_reminder_banner
     end
+
+    scenario "The email confirmed event is shown on the security page" do
+      given_i_have_logged_in
+      when_i_navigate_to_home
+      then_i_see_the_confirmation_reminder_banner
+      when_i_confirm_my_email_with_a_confirmation_link
+      when_i_navigate_to_security
+      then_i_see_the_confirmation_security_event
+    end
   end
 
   context "For an existing user requesting to change their email address" do
@@ -98,5 +107,9 @@ RSpec.feature "Confirm email prompt" do
 
   def then_i_do_not_see_the_confirmation_reminder_banner
     expect(page).not_to have_content(I18n.t("confirm.link_text"))
+  end
+
+  def then_i_see_the_confirmation_security_event
+    expect(page).to have_text(I18n.t("account.security.event.email_changed"))
   end
 end

--- a/spec/feature/confirm_email_prompt_spec.rb
+++ b/spec/feature/confirm_email_prompt_spec.rb
@@ -29,15 +29,6 @@ RSpec.feature "Confirm email prompt" do
       when_i_navigate_to_home
       then_i_do_not_see_the_confirmation_reminder_banner
     end
-
-    scenario "The email confirmed event is shown on the security page" do
-      given_i_have_logged_in
-      when_i_navigate_to_home
-      then_i_see_the_confirmation_reminder_banner
-      when_i_confirm_my_email_with_a_confirmation_link
-      when_i_navigate_to_security
-      then_i_see_the_confirmation_security_event
-    end
   end
 
   context "For an existing user requesting to change their email address" do
@@ -107,9 +98,5 @@ RSpec.feature "Confirm email prompt" do
 
   def then_i_do_not_see_the_confirmation_reminder_banner
     expect(page).not_to have_content(I18n.t("confirm.link_text"))
-  end
-
-  def then_i_see_the_confirmation_security_event
-    expect(page).to have_text(I18n.t("account.security.event.email_changed"))
   end
 end

--- a/spec/feature/login_spec.rb
+++ b/spec/feature/login_spec.rb
@@ -21,6 +21,14 @@ RSpec.feature "Logging in" do
     expect(page).to have_text(I18n.t("mfa.phone.code.fields.phone_code.label"))
   end
 
+  it "shows the login event on the security page" do
+    enter_email_address_and_password
+    enter_mfa
+    visit_security_page
+
+    expect(page).to have_text(I18n.t("account.security.event.login_success"))
+  end
+
   context "when the email is missing" do
     it "shows an error" do
       enter_email_address_and_password(email: "")
@@ -203,5 +211,9 @@ RSpec.feature "Logging in" do
 
   def go_straight_to_account_page
     visit user_root_path
+  end
+
+  def visit_security_page
+    click_on I18n.t("navigation.menu_bar.security.link_text")
   end
 end

--- a/spec/models/security_activity_spec.rb
+++ b/spec/models/security_activity_spec.rb
@@ -1,0 +1,130 @@
+RSpec.describe SecurityActivity do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:event) { SecurityActivity::LOGIN_SUCCESS }
+  let(:event_type) { event&.id }
+
+  let(:user) { FactoryBot.create(:user) }
+  let(:user_id) { user&.id }
+
+  let(:ip_address) { "127.0.0.1" }
+
+  context "validations" do
+    let(:activity) { SecurityActivity.new(event_type: event_type, user_id: user_id, ip_address: ip_address) }
+
+    it "is valid with an event_type, user_id, and ip_address" do
+      expect(activity).to be_valid
+    end
+
+    context "without an event_type" do
+      let(:event_type) { nil }
+
+      it "is invalid" do
+        expect(activity).to_not be_valid
+      end
+    end
+
+    context "with a bad event_type" do
+      let(:event_type) { 999_999 }
+
+      it "is invalid" do
+        expect(activity).to_not be_valid
+      end
+    end
+
+    context "without a user_id" do
+      let(:user_id) { nil }
+
+      it "is invalid" do
+        expect(activity).to_not be_valid
+      end
+    end
+
+    context "without an IP address" do
+      let(:ip_address) { nil }
+
+      it "is invalid" do
+        expect(activity).to_not be_valid
+      end
+
+      context "the event doesn't require an IP address" do
+        let(:event) { SecurityActivity::ACCOUNT_LOCKED }
+
+        it "is valid" do
+          expect(activity).to be_valid
+        end
+      end
+    end
+  end
+
+  context "#event" do
+    let(:activity) { SecurityActivity.new(event_type: event_type, user_id: user_id, ip_address: ip_address) }
+
+    it "returns the correct event" do
+      expect(activity.event).to eq(event)
+    end
+  end
+
+  context "#client" do
+    let(:application) { FactoryBot.create(:oauth_application, name: "name", redirect_uri: "http://localhost/") }
+    let(:activity) { SecurityActivity.new(event_type: event_type, user_id: user_id, ip_address: ip_address, oauth_application_id: application&.id) }
+
+    it "returns the provided OAuth application name" do
+      expect(activity.client).to eq(application.name)
+    end
+
+    context "without an oauth_application_id" do
+      let(:application) { nil }
+
+      it "returns the default application name" do
+        expect(activity.client).to eq(AccountManagerApplication::NAME)
+      end
+    end
+  end
+
+  context "#to_hash" do
+    let(:notes) { "notes" }
+    let(:activity) { SecurityActivity.create!(event_type: event_type, user_id: user_id, ip_address: ip_address, notes: notes) }
+
+    it "includes the event type" do
+      expect(activity.to_hash[:action]).to eq(event.name)
+    end
+
+    it "includes the creation time" do
+      expect(activity.to_hash[:timestamp]).to eq(activity.created_at.utc)
+    end
+
+    it "doesn't include any PII" do
+      activity.to_hash.each_value do |v|
+        expect(v.to_s).to_not include(notes)
+        expect(v.to_s).to_not include(user.email)
+        expect(v.to_s).to_not include(user.phone)
+      end
+    end
+  end
+
+  context "#record_event" do
+    let(:user_agent_name) { "user-agent-name" }
+    let(:activity) { SecurityActivity.record_event(SecurityActivity::LOGIN_SUCCESS, user: user, ip_address: ip_address, user_agent_name: user_agent_name) }
+
+    it "constructs a valid event" do
+      expect(activity.valid?).to be(true)
+    end
+
+    it "saves the user-agent to the database" do
+      expect(activity.user_agent&.name).to eq(user_agent_name)
+    end
+  end
+
+  context "#of_type" do
+    it "filters the events" do
+      SecurityActivity.record_event(SecurityActivity::LOGIN_SUCCESS, user: user, ip_address: ip_address)
+      SecurityActivity.record_event(SecurityActivity::LOGIN_SUCCESS, user: user, ip_address: ip_address)
+      SecurityActivity.record_event(SecurityActivity::LOGIN_SUCCESS, user: user, ip_address: ip_address)
+      SecurityActivity.record_event(SecurityActivity::LOGIN_FAILURE, user: user, ip_address: ip_address)
+
+      expect(SecurityActivity.of_type(SecurityActivity::LOGIN_SUCCESS).count).to be(3)
+      expect(SecurityActivity.of_type(SecurityActivity::LOGIN_FAILURE).count).to be(1)
+    end
+  end
+end

--- a/spec/requests/security_activity_spec.rb
+++ b/spec/requests/security_activity_spec.rb
@@ -1,0 +1,138 @@
+RSpec.describe "security activities" do
+  let(:user) { FactoryBot.create(:user) }
+
+  it "records ACCOUNT_LOCKED events" do
+    (Devise.maximum_attempts + 1).times do
+      post new_user_session_path, params: { "user[email]" => user.email, "user[password]" => "incorrect" }
+    end
+
+    expect_event SecurityActivity::ACCOUNT_LOCKED
+  end
+
+  it "records MANUAL_ACCOUNT_UNLOCK events" do
+    unlock_token = user.lock_access!
+    get user_unlock_path(unlock_token: unlock_token)
+
+    expect_event SecurityActivity::MANUAL_ACCOUNT_UNLOCK
+  end
+
+  context "with MFA enabled" do
+    before { allow(Rails.configuration).to receive(:feature_flag_mfa).and_return(true) }
+
+    it "records ADDITIONAL_FACTOR_VERIFICATION_SUCCESS events" do
+      post new_user_session_path, params: { "user[email]" => user.email, "user[password]" => user.password }
+      post user_session_phone_verify_path, params: { "phone_code" => user.reload.phone_code }
+
+      expect_event SecurityActivity::ADDITIONAL_FACTOR_VERIFICATION_SUCCESS
+    end
+
+    it "records ADDITIONAL_FACTOR_VERIFICATION_FAILURE events" do
+      post new_user_session_path, params: { "user[email]" => user.email, "user[password]" => user.password }
+      post user_session_phone_verify_path, params: { "phone_code" => "incorrect" }
+
+      expect_event SecurityActivity::ADDITIONAL_FACTOR_VERIFICATION_FAILURE
+    end
+  end
+
+  it "records LOGIN_SUCCESS events" do
+    post new_user_session_path, params: { "user[email]" => user.email, "user[password]" => user.password }
+
+    expect_event SecurityActivity::LOGIN_SUCCESS
+  end
+
+  it "records LOGIN_FAILURE events" do
+    post new_user_session_path, params: { "user[email]" => user.email }
+    post response.redirect_url, params: { "user[email]" => user.email, "user[password]" => "incorrect" }
+
+    expect_event SecurityActivity::LOGIN_FAILURE
+  end
+
+  it "records PASSWORD_RESET_REQUEST events" do
+    post create_password_path, params: { "user[email]" => user.email }
+
+    expect_event SecurityActivity::PASSWORD_RESET_REQUEST
+  end
+
+  it "records PASSWORD_RESET_SUCCESS events" do
+    post user_password_path, params: {
+      "_method" => "put",
+      "user[password]" => "new-password",
+      "user[password_confirmation]" => "new-password",
+      "user[reset_password_token]" => user.send_reset_password_instructions,
+    }
+
+    expect_event SecurityActivity::PASSWORD_RESET_SUCCESS
+  end
+
+  context "with a user logged in" do
+    before { sign_in user }
+
+    context "with an OAuth application" do
+      let(:application) do
+        FactoryBot.create(
+          :oauth_application,
+          name: "name",
+          redirect_uri: "http://localhost",
+          scopes: %i[openid],
+        )
+      end
+
+      it "records LOGIN_SUCCESS events for OAuth authorizations" do
+        get authorization_endpoint_url(client: application, scope: "openid")
+
+        expect_event SecurityActivity::LOGIN_SUCCESS, application: application
+      end
+    end
+
+    it "records EMAIL_CHANGE_REQUESTED events" do
+      post user_registration_path, params: {
+        "_method" => "put",
+        "user[email]" => "new-email-address@example.com",
+        "user[current_password]" => user.password,
+      }
+
+      expect_event SecurityActivity::EMAIL_CHANGE_REQUESTED, notes: "from #{user.email} to #{user.reload.unconfirmed_email}"
+    end
+
+    context "with MFA enabled" do
+      before { allow(Rails.configuration).to receive(:feature_flag_mfa).and_return(true) }
+
+      it "records PHONE_CHANGED events" do
+        old_phone = user.phone
+
+        post edit_user_registration_phone_code_path, params: {
+          "phone" => "07581123456",
+          "current_password" => user.password,
+        }
+        post edit_user_registration_phone_verify_path, params: { "phone_code" => user.phone_code }
+
+        expect_event SecurityActivity::PHONE_CHANGED, notes: "from #{old_phone} to #{user.reload.phone}"
+      end
+    end
+
+    it "records PASSWORD_CHANGED events" do
+      post user_registration_path, params: {
+        "_method" => "put",
+        "user[password]" => "new-password",
+        "user[password_confirmation]" => "new-password",
+        "user[current_password]" => user.password,
+      }
+
+      expect_event SecurityActivity::PASSWORD_CHANGED
+    end
+  end
+
+  it "records EMAIL_CHANGED events" do
+    get user_confirmation_path(confirmation_token: user.confirmation_token)
+
+    expect_event SecurityActivity::EMAIL_CHANGED, notes: "to #{user.email}"
+  end
+
+  def expect_event(event, application: nil, notes: nil)
+    events = user.security_activities.of_type(event)
+    events = events.where(oauth_application_id: application.id) if application
+    events = events.where(notes: notes) if notes
+
+    expect(events.count).to_not eq(0)
+  end
+end


### PR DESCRIPTION
Currently (on `main` that is) we record:

- Successful login to the account manager
- Successful login to a service (via OAuth)
- Successful email change
- Successful password change (this includes password resets)
- Successful phone number change

[Signon records rather more events](https://github.com/alphagov/signon/blob/master/app/models/event_log.rb).  Not all of those will be applicable, as we don't have user permissions in the same way Signon does (or... at all), but many of them are.

Based on the Signon events, I think these would be useful:

```
account_locked: Password verification failed too many times, account locked for 1 hour.
email_change_confirmed: Change of email address has been confirmed.
email_changed: Changed email address
login_failure: Entered an incorrect password when logging in.
login_success: Signed in
manual_account_unlock: Account unlocked by clicking link.
password_changed: Changed password
password_reset_request: Requested a password reset link.
password_reset_success: Reset password
two_step_changed: Changed phone number
two_step_verification_failure: Entered an incorrect 2fa code when logging in.
two_step_verification_success: Entered the correct 2fa code when logging in.
```

The descriptions are placeholders  at the moment to make it clear what they're for, but actual ones will need writing.  Maybe not all of the events will need to show up in the security page.

Here's what the events look like in the Rails log:

```
{"id":6,"timestamp":"2020-12-15T09:48:49.804Z","action":"login_failure","user_id":3,"ip_address":"172.19.0.2","user_agent":"Mozilla/5.0 (X11; Linux x86_64; rv:83.0) Gecko/20100101 Firefox/83.0"}

{"id":7,"timestamp":"2020-12-15T09:49:22.440Z","action":"login_success","user_id":3,"ip_address":"172.19.0.2","user_agent":"Mozilla/5.0 (X11; Linux x86_64; rv:83.0) Gecko/20100101 Firefox/83.0"}
```

---

[Trello card](https://trello.com/c/KhP5YL8n/505-log-account-events-security-monitoring)