### PR TITLE
Do not show cookie banner on "your information" page

### DIFF
--- a/app/views/devise/registrations/your_information.html.erb
+++ b/app/views/devise/registrations/your_information.html.erb
@@ -1,4 +1,5 @@
 <% content_for :title, t("devise.registrations.your_information.heading") %>
+<% @skip_cookie_banner = true %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,30 +29,32 @@
 
   <%= render "govuk_publishing_components/components/skip_link" %>
 
-  <%= render "govuk_publishing_components/components/cookie_banner", {
-    title: t("cookie_banner.title"),
-    text: t("cookie_banner.description"),
-    confirmation_message: t("cookie_banner.confirmation_message"),
-    cookie_preferences_href: t("cookie_banner.cookie_settings_href"),
-    services_cookies: {
-      yes: {
-        text: "Yes",
-        data_attributes: {
-          "track-category": "cookieBanner",
+  <% unless @skip_cookie_banner %>
+    <%= render "govuk_publishing_components/components/cookie_banner", {
+      title: t("cookie_banner.title"),
+      text: t("cookie_banner.description"),
+      confirmation_message: t("cookie_banner.confirmation_message"),
+      cookie_preferences_href: t("cookie_banner.cookie_settings_href"),
+      services_cookies: {
+        yes: {
+          text: "Yes",
+          data_attributes: {
+            "track-category": "cookieBanner",
+          },
+        },
+        no: {
+          text: "No",
+          data_attributes: {
+            "track-category": "cookieBanner",
+          },
+        },
+        cookie_preferences: {
+          text: t("cookie_banner.cookie_preferences_text"),
+          href: t("cookie_banner.cookie_settings_href"),
         },
       },
-      no: {
-        text: "No",
-        data_attributes: {
-          "track-category": "cookieBanner",
-        },
-      },
-      cookie_preferences: {
-        text: t("cookie_banner.cookie_preferences_text"),
-        href: t("cookie_banner.cookie_settings_href"),
-      },
-    },
-  } %>
+    } %>
+  <% end %>
 
   <%= render "govuk_publishing_components/components/layout_header", {
     product_name: "Account",


### PR DESCRIPTION
The user has to explicitly opt in or out to cookies on this page, and
that is explained in the text, so by showing the banner we're asking
the same question twice.

---

[Trello card](https://trello.com/c/PST8uRqd/407-should-the-cookie-banner-should-appear-on-data-consent-and-control-page)