### PR TITLE
Skip parsing JWT payload on migration

### DIFF
--- a/app/models/jwt.rb
+++ b/app/models/jwt.rb
@@ -1,11 +1,13 @@
 class Jwt < ApplicationRecord
+  attr_accessor :skip_parse_jwt_token
+
   has_one :registration_state
   has_one :login_state
 
   scope :without_login_states, -> { left_joins(:login_state).where("login_states.jwt_id IS NULL") }
   scope :without_registration_states, -> { left_joins(:registration_state).where("registration_states.jwt_id IS NULL") }
 
-  before_save :parse_jwt_token
+  before_save :parse_jwt_token, unless: :skip_parse_jwt_token
 
   class InvalidJWT < StandardError; end
   class InsufficientScopes < InvalidJWT; end

--- a/db/migrate/20201210151427_create_jwt.rb
+++ b/db/migrate/20201210151427_create_jwt.rb
@@ -9,7 +9,7 @@ class CreateJwt < ActiveRecord::Migration[6.0]
 
     RegistrationState.all.each do |state|
       next unless state.read_attribute(:jwt_payload)
-      jwt = Jwt.create(jwt_payload: state.read_attribute(:jwt_payload))
+      jwt = Jwt.create(jwt_payload: state.read_attribute(:jwt_payload), skip_parse_jwt_token: true)
       RegistrationState.update(jwt_id: jwt.id)
     end
 


### PR DESCRIPTION
We parse the raw JWT on saving the Jwt model and stored the parsed data in the database. However in the migration, we already have parsed data so don't need to parse this again.

This wasn't caught previously as the migration had been run before the before_save callback was introduced to the Jwt model.

Trello card: https://trello.com/c/CFOt8maS