### PR TITLE
Don't redundantly look up user in database

### DIFF
--- a/app/controllers/devise_sessions_controller.rb
+++ b/app/controllers/devise_sessions_controller.rb
@@ -21,11 +21,10 @@ class DeviseSessionsController < Devise::SessionsController
     end
 
     if resource
-      user = User.find_by(email: @email).id
       @login_state = LoginState.create!(
         created_at: Time.zone.now,
-        user_id: user,
-        redirect_path: after_login_path(payload, user),
+        user_id: resource.id,
+        redirect_path: after_login_path(payload, resource),
         jwt_id: session[:jwt_id],
       )
 


### PR DESCRIPTION
The `resource` is the user, so there's no need to look it up a second
time.