### PR TITLE
Add dependent destroy to Jwt state relations

### DIFF
--- a/app/models/jwt.rb
+++ b/app/models/jwt.rb
@@ -1,8 +1,8 @@
 class Jwt < ApplicationRecord
   attr_accessor :skip_parse_jwt_token
 
-  has_one :registration_state
-  has_one :login_state
+  has_one :registration_state, dependent: :destroy
+  has_one :login_state, dependent: :destroy
 
   scope :without_login_states, -> { left_joins(:login_state).where("login_states.jwt_id IS NULL") }
   scope :without_registration_states, -> { left_joins(:registration_state).where("registration_states.jwt_id IS NULL") }


### PR DESCRIPTION
If a `Jwt` is related to both a `LoginState` and `RegistrationState`, deleting one or the other will fail as it is still attached to the other.

By adding dependent destroy, the related `LoginState` or `RegistrationState` will also be destroyed.

Trello card: https://trello.com/c/CFOt8maS