### PR TITLE
Validate new user fields in the model, not in the controller

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -4,7 +4,7 @@
     "files": "^(.secrets.baseline|.env.example|.github/workflows/ci.yml|README.md|config/brakeman.ignore|config/i18n-tasks.yml|config/locales/.*.yml)$|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2020-12-15T14:42:35Z",
+  "generated_at": "2020-12-17T14:09:02Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -115,7 +115,7 @@
       {
         "hashed_secret": "efa245831a7d955cad1c630beb4c67ae6819dec7",
         "is_verified": false,
-        "line_number": 198,
+        "line_number": 188,
         "type": "Secret Keyword"
       }
     ]

--- a/app/controllers/devise_registration_controller.rb
+++ b/app/controllers/devise_registration_controller.rb
@@ -45,6 +45,7 @@ class DeviseRegistrationController < Devise::RegistrationsController
         MultiFactorAuth.generate_and_send_code(@registration_state) if MultiFactorAuth.is_enabled?
       end
       session[:registration_state_id] = @registration_state.id
+      session.delete(:jwt_id)
       redirect_to url_for_state
     end
   end

--- a/app/controllers/devise_registration_controller.rb
+++ b/app/controllers/devise_registration_controller.rb
@@ -169,7 +169,6 @@ class DeviseRegistrationController < Devise::RegistrationsController
       next unless resource.persisted?
 
       persist_attributes(resource)
-      persist_consent(resource)
       persist_email_subscription(resource)
 
       @previous_url = registration_state.previous_url
@@ -288,6 +287,8 @@ protected
         email: registration_state.email,
         password: registration_state.password, # pragma: allowlist secret
         password_confirmation: registration_state.password,
+        cookie_consent: registration_state.cookie_consent,
+        feedback_consent: registration_state.feedback_consent,
       }
 
       if registration_state.phone
@@ -324,13 +325,6 @@ protected
     else
       new_user_registration_start_path
     end
-  end
-
-  def persist_consent(user)
-    user.update!(
-      cookie_consent: registration_state.cookie_consent,
-      feedback_consent: registration_state.feedback_consent,
-    )
   end
 
   def persist_attributes(user)

--- a/app/controllers/devise_sessions_controller.rb
+++ b/app/controllers/devise_sessions_controller.rb
@@ -31,6 +31,7 @@ class DeviseSessionsController < Devise::SessionsController
 
       @login_state_id = login_state.id
       session[:login_state_id] = login_state.id
+      session.delete(:jwt_id)
 
       if request.env["warden.mfa.required"]
         MultiFactorAuth.generate_and_send_code(resource)

--- a/app/controllers/edit_phone_controller.rb
+++ b/app/controllers/edit_phone_controller.rb
@@ -21,7 +21,7 @@ class EditPhoneController < ApplicationController
       end
 
       unless MultiFactorAuth.valid? phone_number
-        @phone_error_message = I18n.t("mfa.errors.phone.invalid")
+        @phone_error_message = I18n.t("activerecord.errors.models.user.attributes.phone.invalid")
       end
 
       render :show and return if @password_error_message || @phone_error_message

--- a/app/views/devise/registrations/start.html.erb
+++ b/app/views/devise/registrations/start.html.erb
@@ -22,8 +22,8 @@
         name: "user[email]",
         type: "email",
         id: "email",
-        value: @email,
-        error_message: devise_error_items(:email, @resource_error_messages),
+        value: params.dig(:user, :email),
+        error_message: devise_error_items(:email),
         autocomplete: "email",
       } %>
 
@@ -34,7 +34,7 @@
         hint: t("devise.registrations.start.fields.password.hint"),
         name: "user[password]",
         id: "password",
-        error_message: devise_error_items(:password, @resource_error_messages),
+        error_message: devise_error_items(:password),
         autocomplete: "new-password",
       } %>
 
@@ -45,9 +45,9 @@
         hint: t("devise.registrations.start.fields.phone.hint"),
         name: "user[phone]",
         id: "phone",
-        value: MultiFactorAuth.formatted_phone_number(@phone),
+        value: MultiFactorAuth.formatted_phone_number(params.dig(:user, :phone)),
         width: 10,
-        error_message: devise_error_items(:phone, @resource_error_messages),
+        error_message: devise_error_items(:phone),
         autocomplete: "tel",
       } %>
 

--- a/config/locales/mfa.en.yml
+++ b/config/locales/mfa.en.yml
@@ -1,10 +1,16 @@
 ---
 en:
+  activerecord:
+    errors:
+      models:
+        user:
+          attributes:
+            phone:
+              blank: Enter your mobile number
+              invalid: That does not look like a valid mobile number. Try entering your number again.
   mfa:
     errors:
       phone:
-        blank: Enter your mobile number
-        invalid: That does not look like a valid mobile number. Try entering your number again.
         nochange: Your account is already using this mobile number. Enter a different number.
       phone_code:
         expired: The security code you’ve entered has expired. Security codes expire after 10 minutes. We can <a class="govuk-link" href="%{resend_link}">send a new security code</a>.

--- a/lib/multi_factor_auth.rb
+++ b/lib/multi_factor_auth.rb
@@ -23,6 +23,8 @@ module MultiFactorAuth
   end
 
   def self.e164_number(phone_number)
+    return unless valid? phone_number
+
     if (country_code = domestic_country_code(phone_number))
       TelephoneNumber.parse(phone_number, country_code).e164_number
     else

--- a/spec/feature/change_phone_spec.rb
+++ b/spec/feature/change_phone_spec.rb
@@ -48,7 +48,7 @@ RSpec.feature "Change Phone" do
       enter_non_mobile_phone_number
       enter_password
 
-      expect(page).to have_text(I18n.t("mfa.errors.phone.invalid"))
+      expect(page).to have_text(I18n.t("activerecord.errors.models.user.attributes.phone.invalid"))
     end
   end
 
@@ -59,7 +59,7 @@ RSpec.feature "Change Phone" do
       enter_invalid_phone_number
       enter_password
 
-      expect(page).to have_text(I18n.t("mfa.errors.phone.invalid"))
+      expect(page).to have_text(I18n.t("activerecord.errors.models.user.attributes.phone.invalid"))
     end
   end
 

--- a/spec/feature/login_spec.rb
+++ b/spec/feature/login_spec.rb
@@ -124,16 +124,6 @@ RSpec.feature "Logging in" do
     end
   end
 
-  context "the user doesn't have a phone number" do
-    before { user.update!(phone: nil) }
-
-    it "skips over the MFA screen" do
-      enter_email_address_and_password
-
-      expect(page).to have_text(I18n.t("account.your_account.heading"))
-    end
-  end
-
   context "MFA is disabled" do
     let(:mfa_enabled) { false }
 

--- a/spec/feature/registration_spec.rb
+++ b/spec/feature/registration_spec.rb
@@ -28,6 +28,8 @@ RSpec.feature "Registration" do
     expect(User.last).to_not be_nil
     expect(User.last.email).to eq(email)
     expect(User.last.phone).to eq("+447958123456")
+    expect(User.last.cookie_consent).to be(true)
+    expect(User.last.feedback_consent).to be(false)
   end
 
   it "sends an email" do

--- a/spec/feature/registration_spec.rb
+++ b/spec/feature/registration_spec.rb
@@ -157,7 +157,7 @@ RSpec.feature "Registration" do
       enter_non_mobile_phone_number
       submit_registration_form
 
-      expect(page).to have_text(I18n.t("mfa.errors.phone.invalid"))
+      expect(page).to have_text(I18n.t("activerecord.errors.models.user.attributes.phone.invalid"))
     end
   end
 
@@ -169,7 +169,7 @@ RSpec.feature "Registration" do
       enter_invalid_phone_number
       submit_registration_form
 
-      expect(page).to have_text(I18n.t("mfa.errors.phone.invalid"))
+      expect(page).to have_text(I18n.t("activerecord.errors.models.user.attributes.phone.invalid"))
     end
   end
 


### PR DESCRIPTION
This helps to avoid bugs by

- Doing things in the conventional Rails way, helping our future
selves (and new people)

- Ensures that we have consistent validations between creating and
updating users

- Ensures that we can't bypass validations due to a controller bug