### PR TITLE
Destroy stale login and registration states upon success

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -45,4 +45,9 @@ protected
       user_root_path
     end
   end
+
+  def destroy_stale_states(jwt_id)
+    RegistrationState.where(jwt_id: jwt_id).destroy_all
+    LoginState.where(jwt_id: jwt_id).destroy_all
+  end
 end

--- a/app/controllers/devise_registration_controller.rb
+++ b/app/controllers/devise_registration_controller.rb
@@ -81,6 +81,7 @@ class DeviseRegistrationController < Devise::RegistrationsController
     if @resource_error_messages.empty?
       RegistrationState.transaction do
         state = MultiFactorAuth.is_enabled? ? :phone : :your_information
+        destroy_stale_states(session[:jwt_id]) if session[:jwt_id]
         @registration_state = RegistrationState.create!(
           touched_at: Time.zone.now,
           state: state,

--- a/app/controllers/devise_sessions_controller.rb
+++ b/app/controllers/devise_sessions_controller.rb
@@ -21,6 +21,7 @@ class DeviseSessionsController < Devise::SessionsController
     end
 
     if resource
+      destroy_stale_states(session[:jwt_id]) if session[:jwt_id]
       @login_state = LoginState.create!(
         created_at: Time.zone.now,
         user_id: resource.id,


### PR DESCRIPTION
If a user has a JWT and they attempt to signup or login multiple times, we will associate the Jwt object with multiple login or registration states. This results in a foreign key failure when they successfully do one of these actions and we attempt to delete the state.

By manually deleting these stale states, we stop this happening.

Almost fixed in https://github.com/alphagov/govuk-account-manager-prototype/pull/507, but still a few issues to iron out.

Trello card: https://trello.com/c/CFOt8maS