### PR TITLE
Revert "Destroy stale login and registration states upon success"

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -55,9 +55,4 @@ protected
       user_root_path
     end
   end
-
-  def destroy_stale_states(jwt_id)
-    RegistrationState.where(jwt_id: jwt_id).destroy_all
-    LoginState.where(jwt_id: jwt_id).destroy_all
-  end
 end

--- a/app/controllers/devise_registration_controller.rb
+++ b/app/controllers/devise_registration_controller.rb
@@ -81,7 +81,6 @@ class DeviseRegistrationController < Devise::RegistrationsController
     if @resource_error_messages.empty?
       RegistrationState.transaction do
         state = MultiFactorAuth.is_enabled? ? :phone : :your_information
-        destroy_stale_states(session[:jwt_id]) if session[:jwt_id]
         @registration_state = RegistrationState.create!(
           touched_at: Time.zone.now,
           state: state,

--- a/app/controllers/devise_sessions_controller.rb
+++ b/app/controllers/devise_sessions_controller.rb
@@ -21,7 +21,6 @@ class DeviseSessionsController < Devise::SessionsController
     end
 
     if resource
-      destroy_stale_states(session[:jwt_id]) if session[:jwt_id]
       @login_state = LoginState.create!(
         created_at: Time.zone.now,
         user_id: resource.id,


### PR DESCRIPTION
Deleting the stale registration and/or login states results in the Jwt also being destroyed, since there is a dependent destroy.

Reverting this change until we figure out a better fix.

Reverts alphagov/govuk-account-manager-prototype#510