### PR TITLE
Destroy stale login and registration states upon success

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -55,4 +55,15 @@ protected
       user_root_path
     end
   end
+
+  def destroy_stale_states(jwt_id)
+    registration_states = RegistrationState.where(jwt_id: jwt_id).pluck(:id)
+    login_states = LoginState.where(jwt_id: jwt_id).pluck(:id)
+
+    RegistrationState.where(id: registration_states).update_all(jwt_id: nil)
+    LoginState.where(id: login_states).update_all(jwt_id: nil)
+
+    RegistrationState.where(id: registration_states).destroy_all
+    LoginState.where(id: login_states).destroy_all
+  end
 end

--- a/app/controllers/devise_registration_controller.rb
+++ b/app/controllers/devise_registration_controller.rb
@@ -81,6 +81,7 @@ class DeviseRegistrationController < Devise::RegistrationsController
     if @resource_error_messages.empty?
       RegistrationState.transaction do
         state = MultiFactorAuth.is_enabled? ? :phone : :your_information
+        destroy_stale_states(session[:jwt_id]) if session[:jwt_id]
         @registration_state = RegistrationState.create!(
           touched_at: Time.zone.now,
           state: state,

--- a/app/controllers/devise_sessions_controller.rb
+++ b/app/controllers/devise_sessions_controller.rb
@@ -21,6 +21,7 @@ class DeviseSessionsController < Devise::SessionsController
     end
 
     if resource
+      destroy_stale_states(session[:jwt_id]) if session[:jwt_id]
       @login_state = LoginState.create!(
         created_at: Time.zone.now,
         user_id: resource.id,


### PR DESCRIPTION
If a user has a JWT and they attempt to signup or login multiple times, we will associate the Jwt object with multiple login or registration states. This results in a foreign key failure when they successfully do one of these actions and we attempt to delete the state.

By manually deleting these stale states, we stop this happening.

We need to remove the jwt_id first, otherwise the Jwt also gets destroyed (unlike in #510 where we failed to remove the `jwt_id` so cascaded the destroy).

Trello card: https://trello.com/c/CFOt8maS