### PR TITLE
Return jwt from get_payload instead of string

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,17 +22,17 @@ class ApplicationController < ActionController::Base
 
 protected
 
-  def get_payload(payload = nil)
-    if payload
+  def get_payload(payload_string = nil)
+    jwt = nil
+    if payload_string
       jwt = Jwt.create!(
-        jwt_payload: payload,
+        jwt_payload: payload_string,
       )
       session[:jwt_id] = jwt.id
-      payload
     elsif session[:jwt_id]
       jwt = Jwt.find(session[:jwt_id])
-      jwt&.jwt_payload&.deep_symbolize_keys
     end
+    jwt&.jwt_payload&.deep_symbolize_keys
   end
 
   def top_level_error_handler(exception = nil)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,15 +23,12 @@ class ApplicationController < ActionController::Base
 protected
 
   def get_payload(payload_string = nil)
-    jwt = nil
-    if payload_string
-      jwt = Jwt.create!(
-        jwt_payload: payload_string,
-      )
-      session[:jwt_id] = jwt.id
-    elsif session[:jwt_id]
-      jwt = Jwt.find(session[:jwt_id])
-    end
+    jwt = if payload_string
+            Jwt.create!(jwt_payload: payload_string)
+              .tap { |j| session[:jwt_id] = j.id }
+          elsif session[:jwt_id]
+            Jwt.find(session[:jwt_id])
+          end
     jwt&.jwt_payload&.deep_symbolize_keys
   end
 

--- a/spec/requests/jwt_login_spec.rb
+++ b/spec/requests/jwt_login_spec.rb
@@ -45,4 +45,17 @@ RSpec.describe "JWT log in" do
     post new_user_session_path, params: { "user[email]" => user.email, "user[password]" => user.password }
     expect(response).to redirect_to(jwt_post_login_oauth.delete_prefix(Rails.application.config.redirect_base_url))
   end
+
+  context "the user is already logged in" do
+    let(:user) { FactoryBot.create(:user) }
+
+    before do
+      sign_in(user)
+    end
+
+    it "redirects the user to the OAuth consent flow" do
+      post welcome_path, params: { "jwt" => jwt }
+      expect(response).to redirect_to(jwt_post_login_oauth.delete_prefix(Rails.application.config.redirect_base_url))
+    end
+  end
 end


### PR DESCRIPTION
It looks like the get_payload method is supposed to:

* parse the string input if provided
* lookup a pre-existing session if there's no input
* return a HashMap with symbolized keys representing the JWT

However, if you provided it with a string as input, it would return the
same string as the return value instead of the parsed JWT.

There were no tests covering the (weird?) situation where someone who's
already signed in signs in again with a fresh JWT, so this wasn't caught
until production:

https://sentry.io/organizations/govuk/issues/2098313434/?project=5370953

I've added a little test that would have reproduced the issue.

I suspect that having the parameter called `payload` contributed to this
mistake, so I've renamed it to `payload_string` to make it a bit clearer
(although I don't normally advocate sticking types in variable names).

I'm not familiar with this codebase, so please review my change carefully! 🙏 
I think it's right though...

(I felt that [making No Diggity jokes about the no method #dig error](https://gds.slack.com/archives/C011Y5SAY3U/p1608228967064300?thread_ts=1608228804.064200&cid=C011Y5SAY3U)
was probably not good leadership. I figured proposing a fix might help offset
that 😅.)