### PR TITLE
Raise an exception on missing translations in tests

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -36,7 +36,7 @@ Rails.application.configure do
   config.active_support.deprecation = :stderr
 
   # Raises error for missing translations.
-  # config.action_view.raise_on_missing_translations = true
+  config.action_view.raise_on_missing_translations = true
 
   config.active_job.queue_adapter = :test
 


### PR DESCRIPTION
Many of our views have calls to I18n.t where the translation name is
some interpolated string, and so I'd feel more confident if those
raised an exception if things go awry.