### PR TITLE
Update API Adapters and fix email API calls

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,7 +122,7 @@ GEM
     fugit (1.3.9)
       et-orbi (~> 1.1, >= 1.1.8)
       raabro (~> 1.3)
-    gds-api-adapters (67.2.1)
+    gds-api-adapters (68.0.0)
       addressable
       link_header
       null_logger

--- a/app/models/email_subscription.rb
+++ b/app/models/email_subscription.rb
@@ -17,7 +17,7 @@ class EmailSubscription < ApplicationRecord
       skip_confirmation_email: true,
     )
 
-    update!(subscription_id: subscription.to_hash.dig("id"))
+    update!(subscription_id: subscription.to_hash.dig("subscription", "id"))
   end
 
   def deactivate_immediately

--- a/spec/jobs/activate_email_subscriptions_job_spec.rb
+++ b/spec/jobs/activate_email_subscriptions_job_spec.rb
@@ -10,7 +10,14 @@ RSpec.describe ActivateEmailSubscriptionsJob do
 
     it "calls email-alert-api to create the subscription" do
       stub_subscriber_list = stub_email_alert_api_has_subscriber_list_by_slug(slug: subscription.topic_slug, returned_attributes: { id: "list-id" })
-      stub_activate = stub_email_alert_api_creates_a_subscription("list-id", user.email, "daily", "subscription-id", skip_confirmation_email: true)
+
+      stub_activate = stub_email_alert_api_creates_a_subscription(
+        subscriber_list_id: "list-id",
+        address: user.email,
+        frequency: "daily",
+        returned_subscription_id: "subscription-id",
+        skip_confirmation_email: true,
+      )
 
       described_class.perform_now user.id
 
@@ -24,8 +31,15 @@ RSpec.describe ActivateEmailSubscriptionsJob do
 
       it "recreates the subscription" do
         stub_subscriber_list = stub_email_alert_api_has_subscriber_list_by_slug(slug: subscription.topic_slug, returned_attributes: { id: "list-id" })
-        stub_activate = stub_email_alert_api_creates_a_subscription("list-id", user.email, "daily", "subscription-id", skip_confirmation_email: true)
         stub_deactivate = stub_email_alert_api_unsubscribes_a_subscription(subscription.subscription_id)
+
+        stub_activate = stub_email_alert_api_creates_a_subscription(
+          subscriber_list_id: "list-id",
+          address: user.email,
+          frequency: "daily",
+          returned_subscription_id: "subscription-id",
+          skip_confirmation_email: true,
+        )
 
         described_class.perform_now user.id
 

--- a/spec/requests/api/v1/transition_checker/emails_spec.rb
+++ b/spec/requests/api/v1/transition_checker/emails_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe "/api/v1/transition-checker/*" do
 
         it "deactivates the old subscription and activates the new subscription" do
           stub_subscriber_list = stub_email_alert_api_has_subscriber_list_by_slug(slug: new_topic_slug, returned_attributes: { id: "list-id" })
-          stub_activate = stub_email_alert_api_creates_a_subscription("list-id", user.email, "daily", "subscription-id", skip_confirmation_email: true)
+          stub_activate = stub_email_alert_api_creates_a_subscription(subscriber_list_id: "list-id", address: user.email, frequency: "daily", returned_subscription_id: "subscription-id", skip_confirmation_email: true)
           stub_deactivate = stub_email_alert_api_unsubscribes_a_subscription(subscription.subscription_id)
           post api_v1_transition_checker_email_subscription_path, headers: headers, params: params
           expect(user.reload.email_subscriptions&.first&.topic_slug).to eq(new_topic_slug)
@@ -107,7 +107,7 @@ RSpec.describe "/api/v1/transition-checker/*" do
       context "without an email subscription" do
         it "activates the new subscription" do
           stub_subscriber_list = stub_email_alert_api_has_subscriber_list_by_slug(slug: new_topic_slug, returned_attributes: { id: "list-id" })
-          stub_activate = stub_email_alert_api_creates_a_subscription("list-id", user.email, "daily", "subscription-id", skip_confirmation_email: true)
+          stub_activate = stub_email_alert_api_creates_a_subscription(subscriber_list_id: "list-id", address: user.email, frequency: "daily", returned_subscription_id: "subscription-id", skip_confirmation_email: true)
           post api_v1_transition_checker_email_subscription_path, headers: headers, params: params
           expect(user.reload.email_subscriptions&.first&.topic_slug).to eq(new_topic_slug)
           expect(stub_subscriber_list).to have_been_made


### PR DESCRIPTION
https://trello.com/c/hdOrNhuC/669-sign-in-after-subscribing

Previously we changed the API for new subscriptions to return the
full subscription object [1]. This updates the calling code to use
the new object to retrieve the subscription ID, in preparation for
removing the top-level ID from the API response.

This also updates calls to the test helper for new subscriptions to
match the new interface [2].

[1]: https://github.com/alphagov/email-alert-api/commit/48c4f932684322547b158b73f787e4a893bcf980#diff-55bcb57312510e288ebb536aa34cdf8583515971989b86654d4a59e388045825
[2]: https://github.com/alphagov/gds-api-adapters/blob/4ad9b70a4e06b65268a8128a5b5842ffa461575a/lib/gds_api/test_helpers/email_alert_api.rb#L221-L228