### PR TITLE
Update footer to match the rest of GOV.UK

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -107,7 +107,7 @@
         ]
       },
       {
-        title: "The UK has left the EU",
+        title: "Brexit transition",
         items: [
           href: "https://www.gov.uk/transition",
           text: "Check the new rules for January 2021"


### PR DESCRIPTION
We'd changed the language to Brexit transition

GOV.UK Homepage:
![image](https://user-images.githubusercontent.com/3694062/102608522-e7959c00-4121-11eb-946e-eb60a3763a42.png)

Us right now:
![image](https://user-images.githubusercontent.com/3694062/102608553-f67c4e80-4121-11eb-9ffa-ffe6d95b9d2c.png)
