### PR TITLE
Simplify welcome controller / get_payload

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,17 +22,12 @@ class ApplicationController < ActionController::Base
 
 protected
 
-  def get_payload(payload = nil)
-    if payload
-      jwt = Jwt.create!(
-        jwt_payload: payload,
-      )
-      session[:jwt_id] = jwt.id
-      payload
-    elsif session[:jwt_id]
-      jwt = Jwt.find(session[:jwt_id])
-      jwt&.jwt_payload&.deep_symbolize_keys
-    end
+  def get_jwt_payload_from_session
+    return unless session[:jwt_id]
+
+    jwt = Jwt.find(session[:jwt_id])
+    session.delete(:jwt_id) unless jwt
+    jwt&.jwt_payload&.deep_symbolize_keys
   end
 
   def top_level_error_handler(exception = nil)

--- a/app/controllers/devise_registration_controller.rb
+++ b/app/controllers/devise_registration_controller.rb
@@ -21,7 +21,7 @@ class DeviseRegistrationController < Devise::RegistrationsController
   def start
     render :closed and return unless Rails.configuration.enable_registration
 
-    payload = get_payload
+    payload = get_jwt_payload_from_session
 
     @email = params.dig(:user, :email)
     @password = params.dig(:user, :password) # pragma: allowlist secret

--- a/app/controllers/devise_sessions_controller.rb
+++ b/app/controllers/devise_sessions_controller.rb
@@ -11,7 +11,7 @@ class DeviseSessionsController < Devise::SessionsController
   ]
 
   def create
-    payload = get_payload
+    payload = get_jwt_payload_from_session
 
     render :new and return unless params.dig(:user, :email) || params.dig(:user, :password)
 

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -4,19 +4,17 @@ class WelcomeController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def show
-    payload = get_payload(params[:jwt])
-
-    if current_user
-      redirect_to add_param_to_url(after_login_path(payload, current_user), "_ga", params[:_ga])
-      return
-    end
-
-    redirect_to add_param_to_url(new_user_registration_start_path, "_ga", params[:_ga])
+    session[:jwt_id] = Jwt.create!(jwt_payload: params[:jwt]).id if params[:jwt]
+    redirect_to add_param_to_url(destination_url, "_ga", params[:_ga])
   end
 
 protected
 
-  def after_login_path(payload, user)
-    payload&.dig(:post_login_oauth).presence || after_sign_in_path_for(user)
+  def destination_url
+    if current_user
+      after_sign_in_path_for(current_user)
+    else
+      new_user_registration_start_path
+    end
   end
 end


### PR DESCRIPTION
This PR makes three changes to the JWT handling:

get_payload does two different things, and one of those things is only
used by a single controller, so just inline that branch where it's
used.

If there is a jwt_id in the session, but no Jwt model is found, delete
the session key.

JWTs are sent by cross-domain POST requests, so if a JWT is received
in the welcome controller, the user will be logged out, meaning the
logged-in branch can be simplified to not refer to the JWT.

This also solves what is, I think, a bug:

1. The user arrives on the welcome controller with a JWT
2. jwt_id gets set in their session
3. They log in, and get sent to the JWT's post-login path
4. Some time later, but before the session has expired, the user does
   a GET request to the welcome controller
5. The user gets sent to the JWT's post-login path again