### PR TITLE
Remove *_id from session if record is not found

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,6 +30,9 @@ protected
             Jwt.find(session[:jwt_id])
           end
     jwt&.jwt_payload&.deep_symbolize_keys
+  rescue ActiveRecord::RecordNotFound
+    session.delete(:jwt_id)
+    nil
   end
 
   def top_level_error_handler(exception = nil)

--- a/app/controllers/devise_registration_controller.rb
+++ b/app/controllers/devise_registration_controller.rb
@@ -336,10 +336,12 @@ protected
   def registration_state
     @registration_state ||=
       begin
-        state = RegistrationState.find(@registration_state_id)
-        state.update!(touched_at: Time.zone.now)
-        state
-      rescue ActiveRecord::RecordNotFound # rubocop:disable Lint/SuppressedException
+        RegistrationState.find(@registration_state_id).tap do |state|
+          state.update!(touched_at: Time.zone.now)
+        end
+      rescue ActiveRecord::RecordNotFound
+        session.delete(:registration_state_id)
+        nil
       end
   end
 

--- a/app/controllers/devise_sessions_controller.rb
+++ b/app/controllers/devise_sessions_controller.rb
@@ -132,7 +132,9 @@ protected
     @login_state ||=
       begin
         LoginState.find(@login_state_id)
-      rescue ActiveRecord::RecordNotFound # rubocop:disable Lint/SuppressedException
+      rescue ActiveRecord::RecordNotFound
+        session.delete(:login_state_id)
+        nil
       end
   end
 


### PR DESCRIPTION
We always have to consider that the session may refer to old things,
so we can't remove the need for any error checking, but we can at
least reduce how often that code ends up being called.