### PR TITLE
Add timestamps to jwts table

### DIFF
--- a/app/jobs/expire_jwt_job.rb
+++ b/app/jobs/expire_jwt_job.rb
@@ -2,6 +2,6 @@ class ExpireJwtJob < ApplicationJob
   queue_as :default
 
   def perform
-    Jwt.without_login_states.without_registration_states.where("created_at < ?", 60.minutes.ago).delete_all
+    Jwt.without_login_states.without_registration_states.where("jwts.created_at < ?", 60.minutes.ago).delete_all
   end
 end

--- a/db/migrate/20201221092526_add_timestamps_to_jwt.rb
+++ b/db/migrate/20201221092526_add_timestamps_to_jwt.rb
@@ -1,0 +1,12 @@
+class AddTimestampsToJwt < ActiveRecord::Migration[6.0]
+  def up
+    add_timestamps :jwts
+    Jwt.update_all(created_at: Time.zone.now, updated_at: Time.zone.now)
+    change_column_null :jwts, :created_at, false
+    change_column_null :jwts, :updated_at, false
+  end
+
+  def down
+    remove_timestamps :jwts
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_16_202609) do
+ActiveRecord::Schema.define(version: 2020_12_21_092526) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -53,6 +53,8 @@ ActiveRecord::Schema.define(version: 2020_12_16_202609) do
 
   create_table "jwts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.jsonb "jwt_payload"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "login_states", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/jobs/expire_jwt_job.rb
+++ b/spec/jobs/expire_jwt_job.rb
@@ -1,0 +1,17 @@
+RSpec.describe ExpireJwtJob do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let!(:user) { FactoryBot.create(:user) }
+
+  it "deletes hour-old state" do
+    freeze_time do
+      Jwt.create!(created_at: 61.minutes.ago, jwt_payload: "old")
+      Jwt.create!(created_at: 30.minutes.ago, jwt_payload: "new")
+
+      described_class.perform_now
+
+      expect(Jwt.count).to eq(1)
+      expect(Jwt.pluck(:jwt_payload)).to eq(%w[/new])
+    end
+  end
+end

--- a/spec/jobs/expire_jwt_job.rb
+++ b/spec/jobs/expire_jwt_job.rb
@@ -5,13 +5,45 @@ RSpec.describe ExpireJwtJob do
 
   it "deletes hour-old state" do
     freeze_time do
-      Jwt.create!(created_at: 61.minutes.ago, jwt_payload: "old")
-      Jwt.create!(created_at: 30.minutes.ago, jwt_payload: "new")
+      Jwt.create!(created_at: 61.minutes.ago, jwt_payload: "old", skip_parse_jwt_token: true)
+      Jwt.create!(created_at: 30.minutes.ago, jwt_payload: "new", skip_parse_jwt_token: true)
 
       described_class.perform_now
 
       expect(Jwt.count).to eq(1)
-      expect(Jwt.pluck(:jwt_payload)).to eq(%w[/new])
+      expect(Jwt.pluck(:jwt_payload)).to eq(%w[new])
+    end
+  end
+
+  it "doesn't delete jwts attached to a RegistrationState" do
+    freeze_time do
+      jwt = Jwt.create!(created_at: 61.minutes.ago, jwt_payload: "old", skip_parse_jwt_token: true)
+      RegistrationState.create!(
+        touched_at: Time.zone.now,
+        state: :start,
+        email: "email@example.com",
+        jwt_id: jwt.id,
+      )
+
+      described_class.perform_now
+
+      expect(Jwt.last).to eq(jwt)
+    end
+  end
+
+  it "doesn't delete jwts attached to a LoginState" do
+    freeze_time do
+      jwt = Jwt.create!(created_at: 61.minutes.ago, jwt_payload: "old", skip_parse_jwt_token: true)
+      LoginState.create!(
+        created_at: Time.zone.now,
+        user: user,
+        redirect_path: "/",
+        jwt_id: jwt.id,
+      )
+
+      described_class.perform_now
+
+      expect(Jwt.last).to eq(jwt)
     end
   end
 end


### PR DESCRIPTION
This was missed in the migration which created the table, so no jwts
have been expired since they were introduced.  We have about 2000 of
them now.

---

Fixes #522