### PR TITLE
Use 'match: :first' to find "your information" checkboxes

### DIFF
--- a/spec/feature/registration_from_another_application_spec.rb
+++ b/spec/feature/registration_from_another_application_spec.rb
@@ -187,8 +187,8 @@ RSpec.feature "Registration (coming from another application)" do
   end
 
   def i_consent_my_information_being_used
-    find(:css, "input[name='cookie_consent'][value='yes']").set(true)
-    find(:css, "input[name='feedback_consent'][value='yes']").set(true)
+    find(:css, "input[name='cookie_consent'][value='yes']", match: :first).set(true)
+    find(:css, "input[name='feedback_consent'][value='yes']", match: :first).set(true)
     click_on I18n.t("devise.registrations.your_information.fields.submit.label")
   end
 


### PR DESCRIPTION
We've seen this test sometimes failing with the element not found,
which suggests the page is being slow to load.  I can't reproduce this
locally, only in GitHub Actions or in Concourse, so it's probably due
to load on those while this test is running.

Using `match: :first` will make Capybara wait up to 2 seconds before
erroring.