### PR TITLE
Correctly order RegistrationStates for passing 2fa in test

### DIFF
--- a/spec/feature/registration_from_another_application_spec.rb
+++ b/spec/feature/registration_from_another_application_spec.rb
@@ -179,7 +179,7 @@ RSpec.feature "Registration (coming from another application)" do
   end
 
   def i_enter_phone_code
-    phone_code = RegistrationState.last.phone_code
+    phone_code = RegistrationState.order(:touched_at).last.phone_code
     fill_in "phone_code", with: phone_code
     click_on I18n.t("mfa.phone.code.fields.submit.label")
 

--- a/spec/feature/registration_from_another_application_spec.rb
+++ b/spec/feature/registration_from_another_application_spec.rb
@@ -187,8 +187,8 @@ RSpec.feature "Registration (coming from another application)" do
   end
 
   def i_consent_my_information_being_used
-    find(:css, "input[name='cookie_consent'][value='yes']", match: :first).set(true)
-    find(:css, "input[name='feedback_consent'][value='yes']", match: :first).set(true)
+    find(:css, "input[name='cookie_consent'][value='yes']").set(true)
+    find(:css, "input[name='feedback_consent'][value='yes']").set(true)
     click_on I18n.t("devise.registrations.your_information.fields.submit.label")
   end
 

--- a/spec/feature/registration_spec.rb
+++ b/spec/feature/registration_spec.rb
@@ -363,13 +363,13 @@ RSpec.feature "Registration" do
   end
 
   def enter_mfa
-    phone_code = RegistrationState.last.phone_code
+    phone_code = RegistrationState.order(:touched_at).last.phone_code
     fill_in "phone_code", with: phone_code
     click_on I18n.t("mfa.phone.code.fields.submit.label")
   end
 
   def enter_incorrect_mfa
-    phone_code = RegistrationState.last.phone_code
+    phone_code = RegistrationState.order(:touched_at).last.phone_code
     fill_in "phone_code", with: "1#{phone_code}"
     click_on I18n.t("mfa.phone.code.fields.submit.label")
   end


### PR DESCRIPTION
The registration from another app test was flaky.  Initially I thought
it was a timing issue with that page, but adding a delay didn't help.
I then noticed that this is the test which creates two
RegistrationStates, and the step failing is potentially the 2fa
validation step.  Could it be using the wrong code?

As it turns out, yes:

    > RegistrationState.order_by(:touched_at).pluck(:id)
    ["84471eb6-2e68-447e-a16b-d6d68624eb4c",
    "46085b18-558a-4744-a503-b9e3283dce09"]

    > RegistrationState.last.id
    84471eb6-2e68-447e-a16b-d6d68624eb4c

When not specifying an order, things are implicitly ordered by primary
key.  And you can't trust the ordering of randomly generated UUIDs.

I've also added the fix to the normal registration specs, to avoid
this same issue cropping up in the future.