### PR TITLE
Log sign in events that come from the confirmation email

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -4,7 +4,7 @@
     "files": "^(.secrets.baseline|.env.example|.github/workflows/ci.yml|README.md|config/brakeman.ignore|config/i18n-tasks.yml|config/locales/.*.yml)$|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2020-12-22T13:32:34Z",
+  "generated_at": "2020-12-22T13:32:47Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -64,7 +64,7 @@
         "hashed_secret": "06062101a81dd812ca9902fdf5f27ed472079d75",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 66,
+        "line_number": 74,
         "type": "Secret Keyword"
       }
     ],

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -4,7 +4,7 @@
     "files": "^(.secrets.baseline|.env.example|.github/workflows/ci.yml|README.md|config/brakeman.ignore|config/i18n-tasks.yml|config/locales/.*.yml)$|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2020-12-22T13:32:18Z",
+  "generated_at": "2020-12-22T13:32:34Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -64,7 +64,7 @@
         "hashed_secret": "06062101a81dd812ca9902fdf5f27ed472079d75",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 64,
+        "line_number": 66,
         "type": "Secret Keyword"
       }
     ],

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -4,7 +4,7 @@
     "files": "^(.secrets.baseline|.env.example|.github/workflows/ci.yml|README.md|config/brakeman.ignore|config/i18n-tasks.yml|config/locales/.*.yml)$|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2020-12-17T14:09:02Z",
+  "generated_at": "2020-12-22T13:32:18Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -108,6 +108,14 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 75,
+        "type": "Secret Keyword"
+      }
+    ],
+    "spec/feature/login_from_confirmation_email_spec.rb": [
+      {
+        "hashed_secret": "efa245831a7d955cad1c630beb4c67ae6819dec7",
+        "is_verified": false,
+        "line_number": 45,
         "type": "Secret Keyword"
       }
     ],

--- a/app/controllers/devise_confirmations_controller.rb
+++ b/app/controllers/devise_confirmations_controller.rb
@@ -30,6 +30,14 @@ class DeviseConfirmationsController < Devise::ConfirmationsController
     @email = current_user&.unconfirmed_email || current_user&.email
   end
 
+  def after_confirmation_path_for(resource_name, resource)
+    if signed_in?(resource_name)
+      signed_in_root_path(resource)
+    else
+      new_session_path(resource_name, from_confirmation_email: true)
+    end
+  end
+
   def after_resending_confirmation_instructions_path_for(_resource_name)
     session[:confirmations] = {
       email: resource.unconfirmed_email,

--- a/app/models/security_activity.rb
+++ b/app/models/security_activity.rb
@@ -25,7 +25,7 @@ class SecurityActivity < ApplicationRecord
   EVENTS_REQUIRING_APPLICATION = EVENTS.select(&:require_application?)
   EVENTS_REQUIRING_FACTOR = EVENTS.select(&:require_factor?)
 
-  VALID_OPTIONS = %i[user user_id oauth_application oauth_application_id ip_address user_agent user_agent_id factor notes].freeze
+  VALID_OPTIONS = %i[user user_id oauth_application oauth_application_id ip_address user_agent user_agent_id factor notes analytics].freeze
 
   VALID_FACTORS = %w[sms].freeze
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -15,6 +15,8 @@
         <%= render "devise/shared/error_messages", resource: resource %>
       <% end %>
 
+      <%= hidden_field_tag "from_confirmation_email", params[:from_confirmation_email] %>
+
       <%= render "govuk_publishing_components/components/input", {
         label: {
           text: t("devise.sessions.new.fields.email.label"),

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -15,6 +15,14 @@
         <%= render "devise/shared/error_messages", resource: resource %>
       <% end %>
 
+      <% if flash[:notice] %>
+        <% if flash_as_notice(flash[:notice]) %>
+          <%= render "govuk_publishing_components/components/notice", { description_text: flash[:notice] } %>
+        <% else %>
+          <%= render "govuk_publishing_components/components/success_alert", { message: flash[:notice] } %>
+        <% end %>
+      <% end %>
+
       <%= hidden_field_tag "from_confirmation_email", params[:from_confirmation_email] %>
 
       <%= render "govuk_publishing_components/components/input", {

--- a/app/views/devise/sessions/phone_code.html.erb
+++ b/app/views/devise/sessions/phone_code.html.erb
@@ -13,6 +13,8 @@
     <% end %>
 
     <%= form_with url: user_session_phone_verify_path, method: :post, html: { autocomplete: "off", "data-module" => "explicit-cross-domain-links" } do %>
+      <%= hidden_field_tag "from_confirmation_email", params[:from_confirmation_email] %>
+
       <%= render "govuk_publishing_components/components/input", {
         label: { text: t("mfa.phone.code.fields.phone_code.label") },
         name: "phone_code",
@@ -42,7 +44,7 @@
     } %>
 
     <p class="govuk-body">
-      <%= sanitize(t("mfa.phone.code.not_received.sign_in_message", link: user_session_phone_resend_path)) %>
+      <%= sanitize(t("mfa.phone.code.not_received.sign_in_message", link: resend_phone_code_path)) %>
     </p>
   </div>
 </div>

--- a/app/views/devise/sessions/phone_resend.html.erb
+++ b/app/views/devise/sessions/phone_resend.html.erb
@@ -15,6 +15,8 @@
     <p class="govuk-body"><%= t("mfa.phone.resend.description") %></p>
 
     <%= form_with(url: user_session_phone_resend_path, method: :post) do %>
+      <%= hidden_field_tag "from_confirmation_email", params[:from_confirmation_email] %>
+
       <%= render "govuk_publishing_components/components/button", {
         text: t("mfa.phone.resend.fields.submit.label"),
         margin_bottom: true,

--- a/db/migrate/20201221103602_add_analytics_to_security_activities.rb
+++ b/db/migrate/20201221103602_add_analytics_to_security_activities.rb
@@ -1,0 +1,5 @@
+class AddAnalyticsToSecurityActivities < ActiveRecord::Migration[6.0]
+  def change
+    add_column :security_activities, :analytics, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_21_092526) do
+ActiveRecord::Schema.define(version: 2020_12_21_103602) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -146,6 +146,7 @@ ActiveRecord::Schema.define(version: 2020_12_21_092526) do
     t.bigint "user_agent_id"
     t.string "notes"
     t.string "factor"
+    t.string "analytics"
     t.index ["oauth_application_id"], name: "index_security_activities_on_oauth_application_id"
     t.index ["user_agent_id"], name: "index_security_activities_on_user_agent_id"
     t.index ["user_id"], name: "index_security_activities_on_user_id"

--- a/lib/tasks/statistics.rake
+++ b/lib/tasks/statistics.rake
@@ -104,6 +104,37 @@ namespace :statistics do
       results += "Accounts logged into #{frequency} #{'time'.pluralize(frequency)}: #{count}\n"
     end
 
+    all_login_frequency_ex_confirm = SecurityActivity
+      .of_type(SecurityActivity::LOGIN_SUCCESS)
+      .where(oauth_application_id: nil)
+      .where.not(analytics: "from_confirmation_email")
+      .where("created_at < ?", args.end_date)
+      .pluck(:user_id)
+      .tally
+      .values
+      .tally
+      .sort
+    results += "Number of logins per account to #{args.end_date} (excluding logins immediately after confirming email):\n"
+    all_login_frequency_ex_confirm.each do |frequency, count|
+      results += "Accounts logged into #{frequency} #{'time'.pluralize(frequency)}: #{count}\n"
+    end
+    results += "\n"
+
+    login_frequency_ex_confirm = SecurityActivity
+      .of_type(SecurityActivity::LOGIN_SUCCESS)
+      .where(oauth_application_id: nil)
+      .where.not(analytics: "from_confirmation_email")
+      .where("created_at BETWEEN ? AND ?", args.start_date, args.end_date)
+      .pluck(:user_id)
+      .tally
+      .values
+      .tally
+      .sort
+    results += "Number of logins between #{args.start_date} and #{args.end_date} (excluding logins immediately after confirming email):\n"
+    login_frequency_ex_confirm.each do |frequency, count|
+      results += "Accounts logged into #{frequency} #{'time'.pluralize(frequency)}: #{count}\n"
+    end
+
     output = [{
       title: "Daily Statistics",
       text: results,

--- a/spec/feature/login_from_confirmation_email_spec.rb
+++ b/spec/feature/login_from_confirmation_email_spec.rb
@@ -1,0 +1,61 @@
+RSpec.feature "Logging in from confirmation email" do
+  include ActiveJob::TestHelper
+  include ActiveSupport::Testing::TimeHelpers
+
+  before { allow(Rails.configuration).to receive(:feature_flag_mfa).and_return(mfa_enabled) }
+
+  let(:mfa_enabled) { true }
+
+  let!(:user) { FactoryBot.create(:user) }
+
+  it "records extra information in the security activity when logging in" do
+    enter_email_address_and_password
+    enter_mfa
+
+    expect(SecurityActivity.of_type(SecurityActivity::ADDITIONAL_FACTOR_VERIFICATION_SUCCESS).last.analytics).to eq("from_confirmation_email")
+    expect(SecurityActivity.of_type(SecurityActivity::LOGIN_SUCCESS).last.analytics).to eq("from_confirmation_email")
+  end
+
+  it "records extra information in the security activity when logging in after requesting new MFA code" do
+    enter_email_address_and_password
+    request_new_mfa_code
+    enter_mfa
+
+    expect(SecurityActivity.of_type(SecurityActivity::ADDITIONAL_FACTOR_VERIFICATION_SUCCESS).last.analytics).to eq("from_confirmation_email")
+    expect(SecurityActivity.of_type(SecurityActivity::LOGIN_SUCCESS).last.analytics).to eq("from_confirmation_email")
+  end
+
+  context "when the password is entered incorrectly" do
+    it "records extra information in the security activity" do
+      enter_email_address_and_password(password: "not-my-password") # pragma: allowlist secret
+
+      expect(SecurityActivity.of_type(SecurityActivity::LOGIN_FAILURE).last.analytics).to eq("from_confirmation_email")
+    end
+  end
+
+  context "when the MFA code is entered incorrectly" do
+    it "records extra information in the security activity" do
+      enter_email_address_and_password
+      enter_mfa(phone_code: "not valid")
+
+      expect(SecurityActivity.of_type(SecurityActivity::ADDITIONAL_FACTOR_VERIFICATION_FAILURE).last.analytics).to eq("from_confirmation_email")
+    end
+  end
+
+  def enter_email_address_and_password(email: user.email, password: user.password)
+    visit user_confirmation_path(confirmation_token: user.confirmation_token)
+    fill_in "email", with: email
+    fill_in "password", with: password
+    click_on I18n.t("devise.sessions.new.fields.submit.label")
+  end
+
+  def enter_mfa(phone_code: user.reload.phone_code)
+    fill_in "phone_code", with: phone_code
+    click_on I18n.t("mfa.phone.code.fields.submit.label")
+  end
+
+  def request_new_mfa_code
+    click_on "send a new security code"
+    click_on I18n.t("mfa.phone.resend.fields.submit.label")
+  end
+end


### PR DESCRIPTION
When a user comes from the confirmation email and is not logged in, we want to be able to record this so the login can be treated differently by our performance analysts. Therefore adding a new analytics field to the `SecurityActivity` model and using a query string parameter to keep track of this during the login process.

I also noticed a flash message was missing from the login form, so have added that.

Trello card: https://trello.com/c/p3uQyqMt