### PR TITLE
Remove separate rubocop step from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,6 @@ jobs:
           bundle config path tmp/bundle
           bundle install --jobs 4 --retry 3
 
-      - run: bundle exec rubocop
-
       - run: bundle exec brakeman
 
       - env:


### PR DESCRIPTION
We already run this as part of `bundle exec rake`.