### PR TITLE
Update feedback banner design

### DIFF
--- a/app/assets/stylesheets/accounts.scss
+++ b/app/assets/stylesheets/accounts.scss
@@ -61,9 +61,10 @@ $_current-indicator-width: 4px;
 
 .feedback-footer {
   margin-bottom: govuk-spacing(4);
-  padding: govuk-spacing(6);
+  padding: govuk-spacing(3);
   background: govuk-colour("light-grey");
   @include govuk-media-query($from: tablet) {
+    padding: govuk-spacing(6);
     margin-top: govuk-spacing(2);
     margin-bottom: govuk-spacing(8);
   }

--- a/app/assets/stylesheets/accounts.scss
+++ b/app/assets/stylesheets/accounts.scss
@@ -60,9 +60,13 @@ $_current-indicator-width: 4px;
 }
 
 .feedback-footer {
-  margin-top: govuk-spacing(4);
-  padding: govuk-spacing(8) 0;
+  margin-bottom: govuk-spacing(4);
+  padding: govuk-spacing(6);
   background: govuk-colour("light-grey");
+  @include govuk-media-query($from: tablet) {
+    margin-top: govuk-spacing(2);
+    margin-bottom: govuk-spacing(8);
+  }
 }
 
 .mfa-phone-create {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -78,8 +78,8 @@
   </div>
 
   <% if feedback_enabled_page %>
-    <div class="feedback-footer">
-      <div class="govuk-width-container">
+    <div class="govuk-width-container">
+      <div class="feedback-footer">
         <%= render "govuk_publishing_components/components/heading", {
           text: t("feedback.banners.title"),
           heading_level: 2,

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -278,7 +278,7 @@ en:
             label: Continue
         heading: Sign in to your GOV.UK account
         register: <p class="govuk-body">You can <a class="govuk-link" href="%{register}">sign up for a new account</a> if this is your first visit.</p>
-        reset_password: <p class="govuk-body">You can <a class="govuk-link" href="%{reset_password}">change your password</a> if you’ve forgotten it.</p>
+        reset_password: <p class="govuk-body govuk-!-margin-bottom-0">You can <a class="govuk-link" href="%{reset_password}">change your password</a> if you’ve forgotten it.</p>
     unlocks:
       heading: Resend unlock instructions to unlock your GOV.UK account
       label: Enter your email


### PR DESCRIPTION
Update the visual look of the feedback banner at the bottom of the page.
The previous design was a little bit too subtle.

Before | After
------------ | -------------
![Screenshot 2020-12-22 at 14 50 03](https://user-images.githubusercontent.com/7116819/102901081-1767db00-4465-11eb-921b-e8ef8adbedd8.png) |   ![Screenshot 2020-12-22 at 14 59 54](https://user-images.githubusercontent.com/7116819/102902103-63ffe600-4466-11eb-91b7-3c69ea25fd91.png)


### Before
![Screenshot 2020-12-22 at 14 49 48](https://user-images.githubusercontent.com/7116819/102901194-3c5c4e00-4465-11eb-9f17-51ab704805c9.png)

### After
![Screenshot 2020-12-22 at 14 46 51](https://user-images.githubusercontent.com/7116819/102901191-3bc3b780-4465-11eb-8f12-e0ed2744886c.png)

https://trello.com/c/2iEZAz2W