### PR TITLE
Add suspend/resume functionality for staging

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -4,7 +4,7 @@
     "files": "^.env.example$|^.github/workflows/ci.yml$|^.secrets.baseline$|^README.md$|^config/brakeman.ignore$|^config/i18n-tasks.yml$|^config/locales/.*.yml$|^package-lock.json$|^package.json$|^spec/.*$",
     "lines": null
   },
-  "generated_at": "2021-01-04T09:55:05Z",
+  "generated_at": "2021-01-11T15:13:50Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -92,6 +92,24 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 6,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "concourse/tasks/map-route.yml": [
+      {
+        "hashed_secret": "47748b1fd1747e8bff5493fa6c3bcf16d6449969",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 7,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "concourse/tasks/unmap-route.yml": [
+      {
+        "hashed_secret": "47748b1fd1747e8bff5493fa6c3bcf16d6449969",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 7,
         "type": "Hex High Entropy String"
       }
     ],

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -288,3 +288,66 @@ jobs:
             username: 'Daily GOV.UK Account Statistics'
             icon_emoji: ':chart_with_upwards_trend:'
             attachments_file: statistics/output.json
+
+  - name: suspend-staging
+    plan:
+      - get: git-main
+      - task: map-account-url-to-error-page
+        file: git-main/concourse/tasks/map-route.yml
+        params:
+          CF_APP_NAME: govuk-account-static-errors
+          CF_SPACE: staging
+          CDN_DOMAIN: account.staging.publishing.service.gov.uk
+          HOSTNAME: www
+      - task: unmap-account-url-from-account-app
+        file: git-main/concourse/tasks/unmap-route.yml
+        params:
+          CF_APP_NAME: govuk-account-manager
+          CF_SPACE: staging
+          CDN_DOMAIN: account.staging.publishing.service.gov.uk
+          HOSTNAME: www
+      - task: map-attribute-url-to-error-page
+        file: git-main/concourse/tasks/map-route.yml
+        params:
+          CF_APP_NAME: govuk-account-static-errors
+          CF_SPACE: staging
+          CDN_DOMAIN: account.staging.publishing.service.gov.uk
+          HOSTNAME: attributes
+      - task: unmap-attribute-url-from-attribute-service
+        file: git-main/concourse/tasks/unmap-route.yml
+        params:
+          CF_APP_NAME: govuk-attribute-service
+          CF_SPACE: staging
+          CDN_DOMAIN: account.staging.publishing.service.gov.uk
+          HOSTNAME: attributes
+  - name: resume-staging
+    plan:
+      - get: git-main
+      - task: map-account-url-to-account-app
+        file: git-main/concourse/tasks/map-route.yml
+        params:
+          CF_APP_NAME: govuk-account-manager
+          CF_SPACE: staging
+          CDN_DOMAIN: account.staging.publishing.service.gov.uk
+          HOSTNAME: www
+      - task: unmap-account-url-from-error-page
+        file: git-main/concourse/tasks/unmap-route.yml
+        params:
+          CF_APP_NAME: govuk-account-static-errors
+          CF_SPACE: staging
+          CDN_DOMAIN: account.staging.publishing.service.gov.uk
+          HOSTNAME: www
+      - task: map-attribute-url-to-attribute-service
+        file: git-main/concourse/tasks/map-route.yml
+        params:
+          CF_APP_NAME: govuk-attribute-service
+          CF_SPACE: staging
+          CDN_DOMAIN: account.staging.publishing.service.gov.uk
+          HOSTNAME: attributes
+      - task: unmap-attribute-url-from-error-page
+        file: git-main/concourse/tasks/unmap-route.yml
+        params:
+          CF_APP_NAME: govuk-account-static-errors
+          CF_SPACE: staging
+          CDN_DOMAIN: account.staging.publishing.service.gov.uk
+          HOSTNAME: attributes

--- a/concourse/tasks/map-route.yml
+++ b/concourse/tasks/map-route.yml
@@ -1,0 +1,24 @@
+
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: governmentpaas/cf-cli
+    tag: e1ffec0d1940706f157a8c1e0ab8131b7084fa1c
+params:
+  CF_API: https://api.london.cloud.service.gov.uk
+  CF_USERNAME: ((paas-username))
+  CF_PASSWORD: ((paas-password))
+  CF_ORG: govuk-accounts
+run:
+  path: sh
+  args:
+    - '-c'
+    - |
+      set -eu
+
+      cf api "$CF_API"
+      cf auth
+      cf t -o "$CF_ORG" -s "$CF_SPACE"
+      cf map-route $CF_APP_NAME "$CDN_DOMAIN" --hostname $HOSTNAME
+

--- a/concourse/tasks/unmap-route.yml
+++ b/concourse/tasks/unmap-route.yml
@@ -1,0 +1,24 @@
+
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: governmentpaas/cf-cli
+    tag: e1ffec0d1940706f157a8c1e0ab8131b7084fa1c
+params:
+  CF_API: https://api.london.cloud.service.gov.uk
+  CF_USERNAME: ((paas-username))
+  CF_PASSWORD: ((paas-password))
+  CF_ORG: govuk-accounts
+run:
+  path: sh
+  args:
+    - '-c'
+    - |
+      set -eu
+
+      cf api "$CF_API"
+      cf auth
+      cf t -o "$CF_ORG" -s "$CF_SPACE"
+      cf unmap-route $CF_APP_NAME "$CDN_DOMAIN" --hostname $HOSTNAME
+


### PR DESCRIPTION
A manually triggered concourse job that will suspend the account and redirect all traffic to an appropriate error page.

Plan is:
- Review this as as a "is this a terrible idea"
- Push this on fly to the pipeline with prod tasks suspended.
- Test:
  - Suspending accounts (wait for it to complete and confirm)
  - Resuming accounts (wait and confirm completion)
  - Suspending accounts _and_ then trying to resume before task has finished (check if serial groups stop that happening!)
  - Resuming accounts _and_ then trying to resume before task has finished (check if serial groups stop that happening!)
  - Tidy up

Assuming all goes well there, I suggest we then add the prod varieties to this as jobs on the same pipeline. But so it prioritises Production changes over staging changes for speed.

So order would be:
**suspending**
- Prod suspending (on success triggers) -> staging suspending
- Prod resumption (on success triggers) -> staging resumption

So the two worlds are in-sync but assuming that if we need to suspend it's because there's a production problem primarily.