### PR TITLE
Add adhoc email mailer

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -39,4 +39,11 @@ class UserMailer < ApplicationMailer
     @feedback_form_link = feedback_form_url
     mail(to: email, subject: I18n.t("mailer.post_delete.subject"))
   end
+
+  def adhoc_email
+    email = params[:email]
+    subject = params[:subject]
+    body = params[:body]
+    mail(to: email, subject: subject, body: body)
+  end
 end


### PR DESCRIPTION
This will allow us to send emails using free-text (e.g. if we need to email all account users at once).

Relevant documentation update in: https://github.com/alphagov/govuk-account-team-manual/pull/4

Trello card: https://trello.com/c/2AG1XMbd