### PR TITLE
Optimisations for password managers

### DIFF
--- a/app/controllers/devise_passwords_controller.rb
+++ b/app/controllers/devise_passwords_controller.rb
@@ -15,6 +15,7 @@ class DevisePasswordsController < Devise::PasswordsController
     reset_password_token = Devise.token_generator.digest(resource_class, :reset_password_token, params[:reset_password_token])
     resource_for_reset = resource_class.find_by(reset_password_token: reset_password_token)
     @reset_password_token_valid = resource_for_reset&.reset_password_period_valid?
+    @reset_email = resource_for_reset&.email
   end
 
   # PUT /resource/password

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -20,7 +20,7 @@
         type: "email",
         id: "email",
         value: @email,
-        autocomplete: "email",
+        autocomplete: "username",
       } %>
 
       <%= render "govuk_publishing_components/components/button", {

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -18,7 +18,7 @@
     <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do %>
       <%= render "devise/shared/error_messages", resource: resource %>
       <%= hidden_field_tag "user[reset_password_token]", params[:reset_password_token] %>
-
+      <%= email_field_tag 'email', @reset_email, class: "govuk-!-display-none", autocomplete: "off", "aria-hidden": true if @reset_email %>
       <%= render "govuk_publishing_components/components/show_password", {
         label: {
           text: t("devise.passwords.edit.password.label"),
@@ -27,7 +27,7 @@
         name: "user[password]",
         id: "password",
         error_message: devise_error_items(:password),
-        autocomplete: "new-password",
+        autocomplete: @reset_email ? "new-password" : "off",
       } %>
 
       <%= render "devise/shared/password_tip" %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -23,7 +23,7 @@
         type: "email",
         id: "email",
         error_message: devise_error_items(:email),
-        autocomplete: "email",
+        autocomplete: "username",
       } %>
 
       <%= render "govuk_publishing_components/components/button", {

--- a/app/views/devise/registrations/edit_email.html.erb
+++ b/app/views/devise/registrations/edit_email.html.erb
@@ -31,7 +31,7 @@
         id: "email",
         value: @email,
         error_message: devise_error_items(:email),
-        autocomplete: "email",
+        autocomplete: "username",
       } %>
 
       <%= render "govuk_publishing_components/components/show_password", {

--- a/app/views/devise/registrations/edit_password.html.erb
+++ b/app/views/devise/registrations/edit_password.html.erb
@@ -16,6 +16,7 @@
     } %>
 
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do %>
+    <%= email_field_tag 'email', resource.email, class: "govuk-!-display-none", autocomplete: "off", "aria-hidden": true %>
     <%= render "devise/shared/error_messages", resource: resource %>
 
       <%= render "govuk_publishing_components/components/show_password", {

--- a/app/views/devise/registrations/start.html.erb
+++ b/app/views/devise/registrations/start.html.erb
@@ -24,7 +24,7 @@
         id: "email",
         value: params.dig(:user, :email),
         error_message: devise_error_items(:email),
-        autocomplete: "email",
+        autocomplete: "username",
       } %>
 
       <%= render "govuk_publishing_components/components/show_password", {

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -34,7 +34,7 @@
         id: "email",
         value: @email,
         error_message: devise_error_items(:email, @resource_error_messages),
-        autocomplete: "email",
+        autocomplete: "username",
       } %>
 
       <%= render "govuk_publishing_components/components/show_password", {

--- a/app/views/edit_phone/show.html.erb
+++ b/app/views/edit_phone/show.html.erb
@@ -26,6 +26,7 @@
       <%= render "govuk_publishing_components/components/input", {
         label: { text: t("mfa.phone.update.start.fields.phone.label") },
         name: "phone",
+        type: "tel",
         error_message: @phone_error_message,
       } %>
 

--- a/spec/requests/edit_password_spec.rb
+++ b/spec/requests/edit_password_spec.rb
@@ -43,6 +43,8 @@ RSpec.describe "edit-password" do
         post user_password_path, params: params
 
         expect(response.body).to have_content(I18n.t("activerecord.errors.models.user.attributes.reset_password_token.invalid"))
+        expect(response.body).to_not have_selector("input[id='email']")
+        expect(response.body).to have_selector("input[id='password'][autocomplete='off']")
       end
     end
 


### PR DESCRIPTION
Change email field autocomplete labels to "username".
This should ensure that browsers and password managers can better understand the account's login/registration forms.
https://www.chromium.org/developers/design-documents/form-styles-that-chromium-understands

Additionally, add hidden email input fields to the password reset/update forms. 
Again, this is with the purpose of facilitating filling out forms for the user. Password managers should save the new details when the user resets/updates their password, and autofill the fields correctly the next time the user signs in.

https://trello.com/c/a5aN4oga