### PR TITLE
Add a link to the Team Manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# Manuals
+See further howtos in [Team Manual](https://team-manual.account.publishing.service.gov.uk/).
+
 # Set up the GOV.UK account manager prototype
 
 The GOV.UK account manager prototype is an application to test how users:


### PR DESCRIPTION
So that docs are all joined up. If this README were be part of the GOV.UK Dev Docs, people would be able to follow the trail to the most useful documentation.

Follow on from https://github.com/alphagov/govuk-developer-docs/pull/2915