### PR TITLE
Run npm install on quality checks pipeline

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -111,6 +111,7 @@ jobs:
                 service redis-server start
                 export TEST_DATABASE_URL="postgres://postgres:password@localhost:5432/accounts"
                 export RAILS_ENV=test
+                npm install
                 bundle install
                 bundle exec rails db:setup
                 bundle exec rails db:migrate


### PR DESCRIPTION
A dependency on a node package was introduced in https://github.com/alphagov/govuk-account-manager-prototype/pull/549 but has not been installed before running quality checks.  This ensures that package gets installed.