### PR TITLE
Install yarn into test image

### DIFF
--- a/concourse/Dockerfile
+++ b/concourse/Dockerfile
@@ -7,9 +7,16 @@ RUN apt-get update --fix-missing && apt-get -y upgrade \
       postgresql-11 redis-server \
     && rm ./google-chrome-stable_current_amd64.deb
 
-COPY Gemfile* .ruby-version /application/
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+    && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 23E7166788B63E1E \
+    && apt update -y \
+    && apt install -y yarn
+
+COPY Gemfile* .ruby-version package.json /application/
 
 WORKDIR /application/
+
+RUN yarn install
 
 RUN bundle install
 

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -111,7 +111,7 @@ jobs:
                 service redis-server start
                 export TEST_DATABASE_URL="postgres://postgres:password@localhost:5432/accounts"
                 export RAILS_ENV=test
-                npm install
+                yarn install
                 bundle install
                 bundle exec rails db:setup
                 bundle exec rails db:migrate


### PR DESCRIPTION
We have added a dependency on node packages which run with yarn, but we don't install yarn in the test image. Therefore we need to download the latest stable version when building the test machine image.

Since we're using yarn to run the linter, there's no need to run `npm install` anymore.