### PR TITLE
Add rake task to report on commonly used passwords

### DIFF
--- a/app/jobs/user_banned_password_check_job.rb
+++ b/app/jobs/user_banned_password_check_job.rb
@@ -1,0 +1,13 @@
+class UserBannedPasswordCheckJob < ApplicationJob
+  queue_as :user_password_check
+
+  def perform(user_id)
+    user = User.find(user_id)
+
+    has_banned_password = BannedPassword.pluck(:password).any? do |password|
+      user.valid_password?(password)
+    end
+
+    user.update!(banned_password_match: has_banned_password)
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,6 +1,7 @@
 :queues:
   - mailers
   - default
+  - user_password_check
 
 :schedule:
   expire_registration_state:

--- a/db/migrate/20210105085218_add_banned_password_match_to_users.rb
+++ b/db/migrate/20210105085218_add_banned_password_match_to_users.rb
@@ -1,0 +1,5 @@
+class AddBannedPasswordMatchToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :banned_password_match, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_21_103602) do
+ActiveRecord::Schema.define(version: 2021_01_05_085218) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -192,6 +192,7 @@ ActiveRecord::Schema.define(version: 2020_12_21_103602) do
     t.boolean "cookie_consent", default: false, null: false
     t.string "session_token"
     t.boolean "has_received_onboarding_email", default: false, null: false
+    t.boolean "banned_password_match"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/lib/tasks/security.rake
+++ b/lib/tasks/security.rake
@@ -4,4 +4,11 @@ namespace :security do
     count = BannedPassword.import_from_ncsc
     puts "imported #{count} passwords"
   end
+
+  desc "Check usage of passwords on the banned password list."
+  task check_banned_password_usage: :environment do
+    User.where(banned_password_match: nil).each do |user|
+      UserBannedPasswordCheckJob.perform_later(user.id)
+    end
+  end
 end

--- a/spec/jobs/user_banned_password_check_job_spec.rb
+++ b/spec/jobs/user_banned_password_check_job_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe UserBannedPasswordCheckJob do
+  let!(:user) { FactoryBot.create(:user) }
+
+  before(:all) do
+    BannedPassword.import_list(%w[banned-password])
+  end
+
+  context "user has a banned password" do
+    before do
+      user.update_attribute(:password, "banned-password") # rubocop:disable Rails/SkipsModelValidations
+    end
+
+    it "marks their password as banned" do
+      UserBannedPasswordCheckJob.perform_now(user.id)
+
+      expect(user.reload.banned_password_match).to be true
+    end
+  end
+
+  context "user does not have a banned password" do
+    before do
+      user.update_attribute(:password, "not-a-banned-password") # rubocop:disable Rails/SkipsModelValidations
+    end
+
+    it "marks their password as banned" do
+      UserBannedPasswordCheckJob.perform_now(user.id)
+
+      expect(user.reload.banned_password_match).to be false
+    end
+  end
+end


### PR DESCRIPTION
We have [recently implemented](https://github.com/alphagov/govuk-account-manager-prototype/pull/495) a block on new users using a password on the NCSC's commonly used password list.

However we believe existing users may have already used these passwords. This task will report how many users this affects, so we can plan on how to ask them to change their password.

Since the task is slow and could be terminated by a deployment, it is run as a Sidekiq job in a separate queue (with the lowest priority), so as not to block any other queued tasks. If re-run, it will only check users who do not have an existing check result stored.

Trello card: https://trello.com/c/N4Yzytap