### PR TITLE
Do not throw an error for `is_password_banned?(nil)`

### DIFF
--- a/app/models/banned_password.rb
+++ b/app/models/banned_password.rb
@@ -19,6 +19,6 @@ class BannedPassword < ApplicationRecord
   end
 
   def self.is_password_banned?(candidate)
-    where(password: candidate.downcase).exists? # pragma: allowlist secret
+    where(password: candidate&.downcase).exists? # pragma: allowlist secret
   end
 end

--- a/spec/models/banned_password_spec.rb
+++ b/spec/models/banned_password_spec.rb
@@ -72,5 +72,9 @@ password
         expect(described_class.is_password_banned?(password.upcase)).to be(true)
       end
     end
+
+    it "allows a nil password" do
+      expect(described_class.is_password_banned?(nil)).to be(false)
+    end
   end
 end


### PR DESCRIPTION
We've seen this error a few times in the registration controller.
It'll happen if the form is submitted without the field being sent.
Note, this is different to the field being sent with an *empty*
value.

So I think this will only happen if:

- the browser is doing something odd (not sending empty fields), or
- the user is constructing the request directly (eg with curl)

Since we've only had 24 errors in 5 days, it doesn't seem like the
problem is triggered by form submissions with an empty password.

While `nil` is not a *banned* password, it is still invalid because
it's forbidden by our length requirement.

---

[Trello card](https://trello.com/c/T2ve1yDC/530-%F0%9F%90%9B-ncsc-list-code-allows-a-nil-candidate-through)