### PR TITLE
Deactivate CSS assets sass compression

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,7 +27,11 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress CSS using a preprocessor.
-  # config.assets.css_compressor = :sass
+  config.assets.css_compressor = nil
+
+  # Rather than use a CSS compressor, use the SASS style to perform compression
+  config.sass.style = :compressed
+  config.sass.line_comments = false
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false


### PR DESCRIPTION
We're seeing this error when precompiling assets in the staging deployment:
```
          SassC::SyntaxError: Error: "calc(0px)" is not a number for `max'
                  on line 1169:20 of stdin, in function `max`
                  from line 1169:20 of stdin
          >> @supports (margin: max(calc(0px))) {
          
             -------------------^
```

This is a known problem, as seen in other GOV.UK applications:
- https://github.com/alphagov/govuk-frontend/issues/1350
- https://github.com/alphagov/finder-frontend/issues/1124
- https://github.com/alphagov/whitehall/issues/4724
- https://github.com/alphagov/whitehall/commit/1ae8699230617783533979d77b9d71a54198b752