### PR TITLE
Vary confirmation banner by type of confirmation

### DIFF
--- a/app/helpers/account_helper.rb
+++ b/app/helpers/account_helper.rb
@@ -19,4 +19,10 @@ module AccountHelper
       I18n.t("devise.registrations.update_needs_confirmation"),
     ].include? notice
   end
+
+  def confirmation_banner_prompt_type
+    return "update" if confirmed_user_changed_email?
+
+    "set_up"
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -36,6 +36,12 @@ module ApplicationHelper
     !current_user.confirmed_at? || current_user.unconfirmed_email?
   end
 
+  def confirmed_user_changed_email?
+    return false unless current_user
+
+    current_user.confirmed_at? && current_user.unconfirmed_email?
+  end
+
   def has_criteria_keys?(registration_state)
     return false if registration_state.blank?
 

--- a/app/views/application/_email-confirmation-reminder.html.erb
+++ b/app/views/application/_email-confirmation-reminder.html.erb
@@ -1,6 +1,6 @@
 <section class="email-reminder" aria-label="Notice" role="region">
   <p class="govuk-body govuk-!-margin-0">
-    <%= sanitize(t("confirm.intro")) %>
+    <%= sanitize(t("confirm.intro.#{confirmation_banner_prompt_type}")) %>
     <a href="<%= new_user_confirmation_path %>" class="govuk-link"><%= t("confirm.link_text") %></a>
   </p>
 </section>

--- a/config/locales/account/confirmations.en.yml
+++ b/config/locales/account/confirmations.en.yml
@@ -1,7 +1,9 @@
 ---
 en:
   confirm:
-    intro: "<strong>Confirm your email address</strong> to finish updating your account and email alerts."
+    intro:
+      set_up: "<strong>Confirm your email address</strong> to finish setting up your account and email alerts."
+      update: "<strong>Confirm your email address</strong> to finish updating your account and email alerts."
     link_text: Resend confirmation email
   confirmation_sent:
     continue_to_account: Go to your GOV.UK account

--- a/spec/feature/confirm_email_prompt_spec.rb
+++ b/spec/feature/confirm_email_prompt_spec.rb
@@ -6,10 +6,13 @@ RSpec.feature "Confirm email prompt" do
       given_i_have_logged_in
       when_i_navigate_to_home
       then_i_see_the_confirmation_reminder_banner
+      and_i_see_a_confirmation_intro_for_setting_up_an_account
       when_i_navigate_to_manage
       then_i_see_the_confirmation_reminder_banner
+      and_i_see_a_confirmation_intro_for_setting_up_an_account
       when_i_navigate_to_security
       then_i_see_the_confirmation_reminder_banner
+      and_i_see_a_confirmation_intro_for_setting_up_an_account
     end
 
     scenario "Resend form is prefilled on new user signup" do
@@ -38,6 +41,7 @@ RSpec.feature "Confirm email prompt" do
       given_i_have_logged_in
       when_i_navigate_to_home
       then_i_see_the_confirmation_reminder_banner
+      and_i_see_a_confirmation_intro_for_updating_an_account
       when_i_click_the_link_on_the_confirmation_banner
       then_i_see_the_new_confirmaton_page_header
       and_my_unconfirmed_email_address_should_be_prefilled
@@ -47,6 +51,7 @@ RSpec.feature "Confirm email prompt" do
       given_i_have_logged_in
       when_i_navigate_to_home
       then_i_see_the_confirmation_reminder_banner
+      and_i_see_a_confirmation_intro_for_updating_an_account
       when_i_confirm_my_email_with_a_confirmation_link
       when_i_navigate_to_home
       then_i_do_not_see_the_confirmation_reminder_banner
@@ -94,6 +99,14 @@ RSpec.feature "Confirm email prompt" do
 
   def when_i_confirm_my_email_with_a_confirmation_link
     visit user_confirmation_path(confirmation_token: user.confirmation_token)
+  end
+
+  def and_i_see_a_confirmation_intro_for_setting_up_an_account
+    expect(page).to have_content(Rails::Html::FullSanitizer.new.sanitize(I18n.t("confirm.intro", confirmation_action: "setting up")))
+  end
+
+  def and_i_see_a_confirmation_intro_for_updating_an_account
+    expect(page).to have_content(Rails::Html::FullSanitizer.new.sanitize(I18n.t("confirm.intro", confirmation_action: "updating")))
   end
 
   def then_i_do_not_see_the_confirmation_reminder_banner

--- a/spec/feature/confirm_email_prompt_spec.rb
+++ b/spec/feature/confirm_email_prompt_spec.rb
@@ -102,11 +102,11 @@ RSpec.feature "Confirm email prompt" do
   end
 
   def and_i_see_a_confirmation_intro_for_setting_up_an_account
-    expect(page).to have_content(Rails::Html::FullSanitizer.new.sanitize(I18n.t("confirm.intro", confirmation_action: "setting up")))
+    expect(page).to have_content(Rails::Html::FullSanitizer.new.sanitize(I18n.t("confirm.intro.set_up")))
   end
 
   def and_i_see_a_confirmation_intro_for_updating_an_account
-    expect(page).to have_content(Rails::Html::FullSanitizer.new.sanitize(I18n.t("confirm.intro", confirmation_action: "updating")))
+    expect(page).to have_content(Rails::Html::FullSanitizer.new.sanitize(I18n.t("confirm.intro.update")))
   end
 
   def then_i_do_not_see_the_confirmation_reminder_banner


### PR DESCRIPTION
[Trello](https://trello.com/c/6RDvm4m2/543-a-few-minor-brexit-content-changes)

The current intro sentence on the email confirmation banner suggests the user should finsih "updating" their address.
For a new user this isn't quite the case.

We can vary the message by looking at if the user has a current confirmed_at timetsamp but has an unconfirmed email (and so must be updatng their email).

So a new user sees this:

![image](https://user-images.githubusercontent.com/3694062/103675124-79e9cc80-4f77-11eb-8ba6-32962dbc43ad.png)

and an existing user changing their email sees Initally:

![image](https://user-images.githubusercontent.com/3694062/103675958-6db23f00-4f78-11eb-9582-f095f0ccd55b.png)

Then after a refresh the banner only hangs around:

![image](https://user-images.githubusercontent.com/3694062/103676045-87538680-4f78-11eb-8ff2-1c9277a440af.png)
