### PR TITLE
Bump to 50 workers in production

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -213,7 +213,7 @@ jobs:
           CF_SPACE: production
           CF_STARTUP_TIMEOUT: 15 # minutes
           APP_INSTANCES: 20
-          WORKER_INSTANCES: 20
+          WORKER_INSTANCES: 50
           CDN_DOMAIN: account.publishing.service.gov.uk
           ENABLE_REGISTRATION: "true"
           APP_DOMAIN: www.gov.uk


### PR DESCRIPTION
We're running a one-off task for every user in the database, which is
potentially quite slow.

The docs say to let the PaaS know if we're adding more than ~50GiB of
memory usage at a time, but each worker only uses 1GiB, so this is an
increase of 30GiB.