### PR TITLE
Create a second worker and move pw crawl to it

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: rake db:migrate && bin/rails server
-worker: bundle exec sidekiq
+worker: bundle exec sidekiq -c config/sidekiq.yml
+pw_worker: bundle exec sidekiq -c config/password_check.yml

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -214,7 +214,7 @@ jobs:
           CF_SPACE: production
           CF_STARTUP_TIMEOUT: 15 # minutes
           APP_INSTANCES: 20
-          WORKER_INSTANCES: 50
+          WORKER_INSTANCES: 20
           PW_WORKER_INSTANCES: 30
           CDN_DOMAIN: account.publishing.service.gov.uk
           ENABLE_REGISTRATION: "true"

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -143,6 +143,7 @@ jobs:
           CF_STARTUP_TIMEOUT: 15 # minutes
           APP_INSTANCES: 1
           WORKER_INSTANCES: 1
+          PW_WORKER_INSTANCES: 1
           CDN_DOMAIN: account.staging.publishing.service.gov.uk
           ENABLE_REGISTRATION: "true"
           REQUIRE_BASIC_AUTH: "true"
@@ -214,6 +215,7 @@ jobs:
           CF_STARTUP_TIMEOUT: 15 # minutes
           APP_INSTANCES: 20
           WORKER_INSTANCES: 50
+          PW_WORKER_INSTANCES: 30
           CDN_DOMAIN: account.publishing.service.gov.uk
           ENABLE_REGISTRATION: "true"
           APP_DOMAIN: www.gov.uk

--- a/concourse/tasks/deploy-to-govuk-paas.yml
+++ b/concourse/tasks/deploy-to-govuk-paas.yml
@@ -71,3 +71,4 @@ run:
       cf map-route $CF_APP_NAME "$CDN_DOMAIN" --hostname www
 
       cf scale --process worker -i "$WORKER_INSTANCES" $CF_APP_NAME
+      cf scale --process pw_worker -i "$PW_WORKER_INSTANCES" $CF_APP_NAME

--- a/config/password_check.yml
+++ b/config/password_check.yml
@@ -1,0 +1,2 @@
+:queues:
+  - user_password_check


### PR DESCRIPTION
We are looking at an issue where jobs queues are becoming quite long,
our current hypothesis is that the password security job is blocking
everything else on the queue and then when a job ends we're getting a
burst of action as everything else takes the change to run.

This PR is a follow up to move the password check job onto its own
workers where it will not block other jobs the app needs to perform