### PR TITLE
Add "Created account" security event

### DIFF
--- a/app/controllers/devise_registration_controller.rb
+++ b/app/controllers/devise_registration_controller.rb
@@ -180,6 +180,8 @@ class DeviseRegistrationController < Devise::RegistrationsController
         user_is_confirmed: false,
         user_is_new: true,
       }
+
+      record_security_event(SecurityActivity::USER_CREATED, user: resource)
     end
     flash.clear
   end

--- a/app/models/security_activity.rb
+++ b/app/models/security_activity.rb
@@ -19,6 +19,9 @@ class SecurityActivity < ApplicationRecord
     EMAIL_CHANGED = LogEntry.new(id: 11, name: :email_changed, require_user: true),
     PHONE_CHANGED = LogEntry.new(id: 2, name: :phone_changed, require_user: true),
     PASSWORD_CHANGED = LogEntry.new(id: 3, name: :password_changed, require_user: true),
+
+    # on create
+    USER_CREATED = LogEntry.new(id: 12, name: :user_created, require_user: true),
   ].freeze
 
   EVENTS_REQUIRING_USER = EVENTS.select(&:require_user?)

--- a/config/locales/account/security.en.yml
+++ b/config/locales/account/security.en.yml
@@ -18,6 +18,7 @@ en:
         password_changed: Changed password
         password_reset_success: Changed password
         phone_changed: Changed phone number
+        user_created: Created account
       heading: Security
       no_activity_found: There is no currently logged activity on your account. As you use your account to log in and interact with services you will be able to see a record of how it has been used here.
       report:

--- a/spec/factories/registration_state.rb
+++ b/spec/factories/registration_state.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+  factory :registration_state do
+    id { "7216ddfe-d225-4d28-8989-36734bb4c2cd" }
+    email { "test@gov.uk" }
+    password { "parrot_ranger_boiler_tsunami" }
+
+    trait :finished do
+      yes_to_emails { true }
+      cookie_consent { true }
+      feedback_consent { true }
+      touched_at { Time.zone.now }
+      state { "finish" }
+    end
+  end
+end

--- a/spec/feature/registration_spec.rb
+++ b/spec/feature/registration_spec.rb
@@ -44,6 +44,19 @@ RSpec.feature "Registration" do
     assert_enqueued_jobs 1, only: NotifyDeliveryJob
   end
 
+  it "shows an account created security event" do
+    visit_registration_form
+    enter_email_address
+    enter_password
+    enter_uk_phone_number
+    submit_registration_form
+    enter_mfa
+    provide_consent
+    visit_user_account_dashboard
+    click_on_security
+    i_see_an_account_created_event
+  end
+
   it "shows the MFA page" do
     visit_registration_form
     enter_email_address
@@ -341,6 +354,18 @@ RSpec.feature "Registration" do
 
   def visit_registration_form
     visit new_user_registration_start_path
+  end
+
+  def visit_user_account_dashboard
+    visit user_root_path
+  end
+
+  def click_on_security
+    click_on I18n.t("navigation.menu_bar.security.link_text")
+  end
+
+  def i_see_an_account_created_event
+    expect(page).to have_content I18n.t("account.security.event.user_created")
   end
 
   def submit_registration_form

--- a/spec/requests/security_activity_spec.rb
+++ b/spec/requests/security_activity_spec.rb
@@ -2,12 +2,11 @@ RSpec.describe "security activities" do
   let(:user) { FactoryBot.create(:user) }
 
   context "registering a new user" do
-    before { FactoryBot.create(:registration_state, :finished) }
+    let(:registration_state) { FactoryBot.create(:registration_state, :finished) }
 
     it "records USER_CREATED events" do
       # Stub the Registration State to sneak past redirect safeguards
-      registration_state_factory = RegistrationState.find("7216ddfe-d225-4d28-8989-36734bb4c2cd")
-      allow(RegistrationState).to receive(:find).with(nil).and_return(registration_state_factory)
+      allow(RegistrationState).to receive(:find).with(nil).and_return(registration_state)
 
       get new_user_registration_finish_path
       expect_event SecurityActivity::USER_CREATED, { user: User.first }

--- a/spec/requests/security_activity_spec.rb
+++ b/spec/requests/security_activity_spec.rb
@@ -23,28 +23,28 @@ RSpec.describe "security activities" do
       post new_user_session_path, params: { "user[email]" => user.email, "user[password]" => user.password }
       post user_session_phone_verify_path, params: { "phone_code" => user.reload.phone_code }
 
-      expect_event SecurityActivity::ADDITIONAL_FACTOR_VERIFICATION_SUCCESS, factor: :sms
+      expect_event SecurityActivity::ADDITIONAL_FACTOR_VERIFICATION_SUCCESS, { factor: :sms }
     end
 
     it "records ADDITIONAL_FACTOR_VERIFICATION_SUCCESS event with additional analytics data from confirmation email" do
       post new_user_session_path, params: { "user[email]" => user.email, "user[password]" => user.password }
       post user_session_phone_verify_path, params: { "phone_code" => user.reload.phone_code, "from_confirmation_email" => true }
 
-      expect_event SecurityActivity::ADDITIONAL_FACTOR_VERIFICATION_SUCCESS, analytics: "from_confirmation_email"
+      expect_event SecurityActivity::ADDITIONAL_FACTOR_VERIFICATION_SUCCESS, { analytics: "from_confirmation_email" }
     end
 
     it "records ADDITIONAL_FACTOR_VERIFICATION_FAILURE events" do
       post new_user_session_path, params: { "user[email]" => user.email, "user[password]" => user.password }
       post user_session_phone_verify_path, params: { "phone_code" => "incorrect" }
 
-      expect_event SecurityActivity::ADDITIONAL_FACTOR_VERIFICATION_FAILURE, factor: :sms
+      expect_event SecurityActivity::ADDITIONAL_FACTOR_VERIFICATION_FAILURE, { factor: :sms }
     end
 
     it "records ADDITIONAL_FACTOR_VERIFICATION_FAILURE event with additional analytics data from confirmation email" do
       post new_user_session_path, params: { "user[email]" => user.email, "user[password]" => user.password }
       post user_session_phone_verify_path, params: { "phone_code" => "incorrect", "from_confirmation_email" => true }
 
-      expect_event SecurityActivity::ADDITIONAL_FACTOR_VERIFICATION_FAILURE, analytics: "from_confirmation_email"
+      expect_event SecurityActivity::ADDITIONAL_FACTOR_VERIFICATION_FAILURE, { analytics: "from_confirmation_email" }
     end
   end
 
@@ -70,7 +70,7 @@ RSpec.describe "security activities" do
   it "records LOGIN_FAILURE event with additional analytics data from confirmation email" do
     post new_user_session_path, params: { "user[email]" => user.email, "user[password]" => "incorrect", "from_confirmation_email" => true }
 
-    expect_event SecurityActivity::LOGIN_FAILURE, analytics: "from_confirmation_email"
+    expect_event SecurityActivity::LOGIN_FAILURE, { analytics: "from_confirmation_email" }
   end
 
   it "records PASSWORD_RESET_REQUEST events" do
@@ -106,7 +106,7 @@ RSpec.describe "security activities" do
       it "records LOGIN_SUCCESS events for OAuth authorizations" do
         get authorization_endpoint_url(client: application, scope: "openid")
 
-        expect_event SecurityActivity::LOGIN_SUCCESS, application: application
+        expect_event SecurityActivity::LOGIN_SUCCESS, { application: application }
       end
     end
 
@@ -117,7 +117,7 @@ RSpec.describe "security activities" do
         "user[current_password]" => user.password,
       }
 
-      expect_event SecurityActivity::EMAIL_CHANGE_REQUESTED, notes: "from #{user.email} to #{user.reload.unconfirmed_email}"
+      expect_event SecurityActivity::EMAIL_CHANGE_REQUESTED, { notes: "from #{user.email} to #{user.reload.unconfirmed_email}" }
     end
 
     context "with MFA enabled" do
@@ -132,7 +132,7 @@ RSpec.describe "security activities" do
         }
         post edit_user_registration_phone_verify_path, params: { "phone_code" => user.phone_code }
 
-        expect_event SecurityActivity::PHONE_CHANGED, notes: "from #{old_phone} to #{user.reload.phone}"
+        expect_event SecurityActivity::PHONE_CHANGED, { notes: "from #{old_phone} to #{user.reload.phone}" }
       end
     end
 
@@ -154,12 +154,13 @@ RSpec.describe "security activities" do
     expect_event SecurityActivity::EMAIL_CHANGED, notes: "to #{user.email}"
   end
 
-  def expect_event(event, application: nil, factor: nil, notes: nil, analytics: nil)
-    events = user.security_activities.of_type(event)
-    events = events.where(oauth_application_id: application.id) if application
-    events = events.where(factor: factor) if factor
-    events = events.where(notes: notes) if notes
-    events = events.where(analytics: analytics) if analytics
+  def expect_event(event, options = {})
+    event_user = options[:user] || user
+    events = event_user.security_activities.of_type(event)
+    events = events.where(oauth_application_id: options[:application].id) if options[:application]
+    events = events.where(factor: options[:factor]) if options[:factor]
+    events = events.where(notes: options[:notes]) if options[:notes]
+    events = events.where(analytics: options[:analytics]) if options[:analytics]
 
     expect(events.count).to_not eq(0)
   end


### PR DESCRIPTION
[Trello](https://trello.com/c/6RDvm4m2/543-a-few-minor-brexit-content-changes)

## What

Adds an "Created account" security event that is added with every succesful completion of the registration flow.

## Why

Currently the security screen has a null state where the user sees no events. This has some explanitory content outlining what might appear in there.

It may be easier for the user to infer how this tab will be used if they have an actual event to see.

A created event can also be a marker to help contextualise later events ("I created my account, then I didn't log in for 7 days... and I can see that here")

## What it looks like

![image](https://user-images.githubusercontent.com/3694062/103903906-729bfd80-50f4-11eb-9c0c-2b0991f34ecb.png)

## Limitations

So this currently only applies to accounts that are newly created.

Existing accounts could still see the null state (though in decreasing numbres as their events tab fills up).

For neatness we could create a task that goes in and backfills these based on other data we hold (e.g. the created_at user record timestamp). However there is also an IP address associated with these, I'm not sure if we can infer that usefully. I wouldn't want to show the user any inaccurate data on thsi page... so we might have to have a think about what or if we'd do this for existing users.

One for a team chat perhaps?