### PR TITLE
Set banned_password_match on login

### DIFF
--- a/app/controllers/devise_sessions_controller.rb
+++ b/app/controllers/devise_sessions_controller.rb
@@ -21,6 +21,10 @@ class DeviseSessionsController < Devise::SessionsController
     end
 
     if resource
+      if resource.banned_password_match.nil?
+        resource.update!(banned_password_match: BannedPassword.is_password_banned?(params.dig(:user, :password)))
+      end
+
       destroy_stale_states(session[:jwt_id]) if session[:jwt_id]
       @login_state = LoginState.create!(
         created_at: Time.zone.now,

--- a/spec/requests/login_spec.rb
+++ b/spec/requests/login_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe "login" do
+  let!(:user) { FactoryBot.create(:user, banned_password_match: nil) }
+
+  it "sets the banned_password_match field to false" do
+    post new_user_session_path, params: { "user[email]" => user.email, "user[password]" => user.password }
+    expect(user.reload.banned_password_match).to be(false)
+  end
+
+  context "the password is banned" do
+    before { BannedPassword.import_list([user.password]) }
+
+    it "sets the banned_password_match field to true" do
+      post new_user_session_path, params: { "user[email]" => user.email, "user[password]" => user.password }
+      expect(user.reload.banned_password_match).to be(true)
+    end
+  end
+end


### PR DESCRIPTION
This is likely far faster than the check job we have running.  After
we know which users are affected, we can lock their accounts, require
them to change it, etc