### PR TITLE
Short-circuit banned password job if already checked

### DIFF
--- a/app/jobs/user_banned_password_check_job.rb
+++ b/app/jobs/user_banned_password_check_job.rb
@@ -7,6 +7,8 @@ class UserBannedPasswordCheckJob < ApplicationJob
     user = User.find(user_id)
     denylist = BannedPassword.limit(BATCH_SIZE).offset(offset).pluck(:password)
 
+    return unless user.banned_password_match.nil?
+
     has_banned_password = denylist.any? do |password| # pragma: allowlist secret
       user.valid_password?(password)
     end

--- a/spec/jobs/user_banned_password_check_job_spec.rb
+++ b/spec/jobs/user_banned_password_check_job_spec.rb
@@ -15,6 +15,12 @@ RSpec.describe UserBannedPasswordCheckJob do
 
       expect(user.reload.banned_password_match).to be true
     end
+
+    it "doesn't update the user if already checked" do
+      user.update_attribute(:banned_password_match, false) # rubocop:disable Rails/SkipsModelValidations
+      UserBannedPasswordCheckJob.perform_now(user.id)
+      expect(user.reload.banned_password_match).to be false
+    end
   end
 
   context "user does not have a banned password" do


### PR DESCRIPTION
We're updating this field on login and password update, so it may no
longer need checking by the time the job is scheduled.