### PR TITLE
Remove data migration to rename brexit checker app

### DIFF
--- a/db/migrate/20210108094047_rename_brexit_checker_app_name.rb
+++ b/db/migrate/20210108094047_rename_brexit_checker_app_name.rb
@@ -1,8 +1,0 @@
-class RenameBrexitCheckerAppName < ActiveRecord::Migration[6.0]
-  def up
-    Doorkeeper::Application.find_by(uid: "r0JFn7O_750_W4i-IjQpMA8j970dNchgKbJ7ZGz0ozI")&.update!(name: "Brexit checker (Demonstration App)")
-    Doorkeeper::Application.find_by(uid: "01zNRqAHzpPv1biZ4NOOpFyV568uYlVPhycwfzicWUE")&.update!(name: "Brexit checker (Integration)")
-    Doorkeeper::Application.find_by(uid: "ZAHfbCrOLCjvWQNsgal-i79UavGkytB_093jNzRPJR0")&.update!(name: "Brexit checker (Staging)")
-    Doorkeeper::Application.find_by(uid: "20VwoXiasGyUE7nS3M9l9TBjew8Lid_qCd6eSmSXuQU")&.update!(name: "Brexit checker")
-  end
-end


### PR DESCRIPTION
Just tested this on live, we've got the new language in now.

This is no longer needed, does not offer anything for posterity and so
can be removed

