### PR TITLE
Rejig layout so that main does not contain nav

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -64,7 +64,7 @@
         "hashed_secret": "06062101a81dd812ca9902fdf5f27ed472079d75",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 74,
+        "line_number": 72,
         "type": "Secret Keyword"
       }
     ],

--- a/app/views/account/show.html.erb
+++ b/app/views/account/show.html.erb
@@ -1,75 +1,70 @@
 <% content_for :title, t("account.your_account.heading") %>
 <% content_for :location, "your-account" %>
+<% content_for :account_navigation do %>
+  <%= render "account-navigation", page_is: yield(:location) %>
+<% end %>
 
 <% if show_confirmation_reminder? %>
   <%= render "email-confirmation-reminder" %>
 <% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-third">
-    <%= render "account-navigation", page_is: yield(:location) %>
-  </div>
+<% if flash[:notice] %>
+  <% if flash_as_notice(flash[:notice]) %>
+    <%= render "govuk_publishing_components/components/notice", { description_text: flash[:notice] } %>
+  <% else %>
+    <%= render "govuk_publishing_components/components/success_alert", { message: flash[:notice] } %>
+  <% end %>
+<% end%>
 
-  <div class="govuk-grid-column-two-thirds">
-    <% if flash[:notice] %>
-      <% if flash_as_notice(flash[:notice]) %>
-        <%= render "govuk_publishing_components/components/notice", { description_text: flash[:notice] } %>
-      <% else %>
-        <%= render "govuk_publishing_components/components/success_alert", { message: flash[:notice] } %>
-      <% end %>
-    <% end%>
+<%= render "govuk_publishing_components/components/heading", {
+  text: yield(:title),
+  heading_level: 1,
+  font_size: "l",
+  margin_bottom: 4,
+} %>
 
+<% if current_user.email %>
+  <p class="govuk-body accounts-your-account__email">
+    <%= current_user.email %>
+  </p>
+<% end %>
+
+<% if @user_info && @user_info[:transition_checker_state] %>
+  <div class="accounts-panel">
     <%= render "govuk_publishing_components/components/heading", {
-      text: yield(:title),
-      heading_level: 1,
-      font_size: "l",
+      text: t("account.your_account.transition.heading"),
+      heading_level: 2,
+      font_size: "m",
       margin_bottom: 4,
     } %>
 
-    <% if current_user.email %>
-      <p class="govuk-body accounts-your-account__email">
-        <%= current_user.email %>
-      </p>
-    <% end %>
+    <p class="govuk-body"><%= t("account.your_account.transition.description") %></p>
 
-    <% if @user_info && @user_info[:transition_checker_state] %>
-      <div class="accounts-panel">
-        <%= render "govuk_publishing_components/components/heading", {
-          text: t("account.your_account.transition.heading"),
-          heading_level: 2,
-          font_size: "m",
-          margin_bottom: 4,
-        } %>
+    <p class="govuk-body govuk-!-margin-0">
+      <a href="<%= transition_checker_path %>/saved-results" class="govuk-link" data-module="gem-track-click" data-track-category="account-manage" data-track-action="your-account" data-track-label="see-results">
+        <%= t("account.your_account.transition.link1") %>
+      </a>
+    </p>
+    <p class="govuk-body"><%= t("account.your_account.transition.link1_description") %></p>
 
-        <p class="govuk-body"><%= t("account.your_account.transition.description") %></p>
-
-        <p class="govuk-body govuk-!-margin-0">
-          <a href="<%= transition_checker_path %>/saved-results" class="govuk-link" data-module="gem-track-click" data-track-category="account-manage" data-track-action="your-account" data-track-label="see-results">
-            <%= t("account.your_account.transition.link1") %>
-          </a>
-        </p>
-        <p class="govuk-body"><%= t("account.your_account.transition.link1_description") %></p>
-
-        <p class="govuk-body govuk-!-margin-0">
-          <a href="<%= transition_checker_path %>/edit-saved-results" class="govuk-link" data-module="gem-track-click" data-track-category="account-manage" data-track-action="your-account" data-track-label="update-results">
-            <%= t("account.your_account.transition.link2") %>
-          </a>
-        </p>
-        <p class="govuk-body"><%= t("account.your_account.transition.link2_description") %></p>
-      </div>
-    <% else %>
-      <div class="accounts-panel">
-        <%= render "govuk_publishing_components/components/heading", {
-          text: t("account.your_account.account_not_used.heading"),
-          heading_level: 2,
-          font_size: "m",
-          margin_bottom: 4,
-        } %>
-
-        <p class="govuk-body"><%= t("account.your_account.account_not_used.description") %></p>
-
-        <p class="govuk-body"><%= sanitize(t("account.your_account.account_not_used.action", link: link_to(t("account.your_account.account_not_used.link_text"), "#{transition_checker_path.to_s}/edit-saved-results", html_options = { class: "govuk-link"} ))) %></p>
-      </div>
-    <% end %>
+    <p class="govuk-body govuk-!-margin-0">
+      <a href="<%= transition_checker_path %>/edit-saved-results" class="govuk-link" data-module="gem-track-click" data-track-category="account-manage" data-track-action="your-account" data-track-label="update-results">
+        <%= t("account.your_account.transition.link2") %>
+      </a>
+    </p>
+    <p class="govuk-body"><%= t("account.your_account.transition.link2_description") %></p>
   </div>
-</div>
+<% else %>
+  <div class="accounts-panel">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("account.your_account.account_not_used.heading"),
+      heading_level: 2,
+      font_size: "m",
+      margin_bottom: 4,
+    } %>
+
+    <p class="govuk-body"><%= t("account.your_account.account_not_used.description") %></p>
+
+    <p class="govuk-body"><%= sanitize(t("account.your_account.account_not_used.action", link: link_to(t("account.your_account.account_not_used.link_text"), "#{transition_checker_path.to_s}/edit-saved-results", html_options = { class: "govuk-link"} ))) %></p>
+  </div>
+<% end %>

--- a/app/views/delete/confirmation.html.erb
+++ b/app/views/delete/confirmation.html.erb
@@ -1,25 +1,20 @@
 <% content_for :title, t("account.delete.confirmation.heading") %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+<%= render "govuk_publishing_components/components/heading", {
+  text: yield(:title),
+  heading_level: 1,
+  font_size: "l",
+  margin_bottom: 4,
+} %>
 
-    <%= render "govuk_publishing_components/components/heading", {
-      text: yield(:title),
-      heading_level: 1,
-      font_size: "l",
-      margin_bottom: 4,
-    } %>
+<p class="govuk-body">
+  <%= I18n.t("account.delete.confirmation.description_1") %>
+</p>
 
-    <p class="govuk-body">
-      <%= I18n.t("account.delete.confirmation.description_1") %>
-    </p>
+<p class="govuk-body">
+  <%= sanitize(I18n.t("account.delete.confirmation.description_2", link: feedback_form_path)) %>
+</p>
 
-    <p class="govuk-body">
-      <%= sanitize(I18n.t("account.delete.confirmation.description_2", link: feedback_form_path)) %>
-    </p>
-
-    <p class="govuk-body">
-      <%= sanitize(I18n.t("account.delete.confirmation.return_link", link: Plek.new.website_root)) %>
-    </p>
-  </div>
-</div>
+<p class="govuk-body">
+  <%= sanitize(I18n.t("account.delete.confirmation.return_link", link: Plek.new.website_root)) %>
+</p>

--- a/app/views/delete/show.html.erb
+++ b/app/views/delete/show.html.erb
@@ -1,68 +1,63 @@
 <% content_for :title, t("account.delete.heading") %>
 <% content_for :location, "manage" %>
+<% content_for :account_navigation do %>
+  <%= render "account-navigation", page_is: yield(:location) %>
+<% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-third">
-    <%= render "account-navigation", page_is: yield(:location) %>
-  </div>
+<%= render "govuk_publishing_components/components/back_link", {
+  href: account_manage_path
+} %>
 
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/back_link", {
-      href: account_manage_path
-    } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: yield(:title),
+  heading_level: 1,
+  font_size: "xl",
+  margin_bottom: 4,
+} %>
 
-    <%= render "govuk_publishing_components/components/heading", {
-      text: yield(:title),
-      heading_level: 1,
-      font_size: "xl",
-      margin_bottom: 4,
-    } %>
+<p class="govuk-body"><%= t("account.delete.description") %></p>
+<ul class="govuk-list govuk-list--bullet">
+  <% t("account.delete.doomed").each do |item| %>
+    <li><%= item %></li>
+  <% end %>
+</ul>
 
-    <p class="govuk-body"><%= t("account.delete.description") %></p>
-    <ul class="govuk-list govuk-list--bullet">
-      <% t("account.delete.doomed").each do |item| %>
-        <li><%= item %></li>
-      <% end %>
-    </ul>
+<%= form_with(url: account_delete_path, method: :delete) do %>
+  <%= render "govuk_publishing_components/components/show_password", {
+    label: {
+      text: t("devise.registrations.edit.fields.current_password.label"),
+    },
+    heading_size: "m",
+    hint: t("devise.registrations.edit.fields.current_password.hint_delete"),
+    name: "current_password",
+    error_message: @password_error_message,
+    autocomplete: "current-password",
+  } %>
 
-    <%= form_with(url: account_delete_path, method: :delete) do %>
-      <%= render "govuk_publishing_components/components/show_password", {
-        label: {
-          text: t("devise.registrations.edit.fields.current_password.label"),
-        },
-        heading_size: "m",
-        hint: t("devise.registrations.edit.fields.current_password.hint_delete"),
-        name: "current_password",
-        error_message: @password_error_message,
-        autocomplete: "current-password",
-      } %>
+  <%= render "govuk_publishing_components/components/inset_text", {
+    text: t("account.delete.insert_text")
+  } %>
 
-      <%= render "govuk_publishing_components/components/inset_text", {
-        text: t("account.delete.insert_text")
-      } %>
-
-      <%= render "govuk_publishing_components/components/button", {
-        text: t("account.delete.action"),
-        destructive: true,
-        inline_layout: true,
-        data_attributes: {
-          module: "gem-track-click",
-          "track-category": "account-manage",
-          "track-action": "delete",
-          "track-label": "delete-account"
-        }
-      } %>
-      <span class="govuk-body"><%= t("general.or") %></span>
-      <%= link_to t("general.cancel"),
-        account_manage_path,
-        class: "govuk-body govuk-link",
-        data: {
-          module: "gem-track-click",
-          "track-category": "account-manage",
-          "track-action": "delete",
-          "track-label": "cancel"
-        }
-      %>
-    <% end %>
-  </div>
-</div>
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("account.delete.action"),
+    destructive: true,
+    inline_layout: true,
+    data_attributes: {
+      module: "gem-track-click",
+      "track-category": "account-manage",
+      "track-action": "delete",
+      "track-label": "delete-account"
+    }
+  } %>
+  <span class="govuk-body"><%= t("general.or") %></span>
+  <%= link_to t("general.cancel"),
+    account_manage_path,
+    class: "govuk-body govuk-link",
+    data: {
+      module: "gem-track-click",
+      "track-category": "account-manage",
+      "track-action": "delete",
+      "track-label": "cancel"
+    }
+  %>
+<% end %>

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,32 +1,28 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("devise.confirmations.resend.heading"),
-      heading_level: 1,
-      font_size: "xl",
-      margin_bottom: 3,
-    } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("devise.confirmations.resend.heading"),
+  heading_level: 1,
+  font_size: "xl",
+  margin_bottom: 3,
+} %>
 
-    <p class="govuk-body"><%= t("devise.confirmations.resend.instructions") %></p>
+<p class="govuk-body"><%= t("devise.confirmations.resend.instructions") %></p>
 
-    <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do %>
-      <%= render "devise/shared/error_messages", resource: resource %>
+<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do %>
+  <%= render "devise/shared/error_messages", resource: resource %>
 
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: t("devise.confirmations.resend.label"),
-        },
-        name: "user[email]",
-        type: "email",
-        id: "email",
-        value: @email,
-        autocomplete: "username",
-      } %>
+  <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: t("devise.confirmations.resend.label"),
+    },
+    name: "user[email]",
+    type: "email",
+    id: "email",
+    value: @email,
+    autocomplete: "username",
+  } %>
 
-      <%= render "govuk_publishing_components/components/button", {
-        text: t("devise.confirmations.resend.button"),
-        margin_bottom: 3,
-      } %>
-    <% end %>
-  </div>
-</div>
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("devise.confirmations.resend.button"),
+    margin_bottom: 3,
+  } %>
+<% end %>

--- a/app/views/devise/confirmations/sent.html.erb
+++ b/app/views/devise/confirmations/sent.html.erb
@@ -1,56 +1,52 @@
 <% content_for :title, t("confirmation_sent.heading") %>
 <% service = service_for(params[:previous_url], current_user) if @user_is_new %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: yield(:title),
-      heading_level: 1,
-      margin_bottom: 4,
-      font_size: "xl",
-    } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: yield(:title),
+  heading_level: 1,
+  margin_bottom: 4,
+  font_size: "xl",
+} %>
 
-    <p class="govuk-body">
-      <%= t("confirmation_sent.instruction_one") %> <strong><%= @email %></strong>
-    </p>
+<p class="govuk-body">
+  <%= t("confirmation_sent.instruction_one") %> <strong><%= @email %></strong>
+</p>
 
-    <p class="govuk-body">
-      <%= t("confirmation_sent.instruction_two") %>
-    </p>
+<p class="govuk-body">
+  <%= t("confirmation_sent.instruction_two") %>
+</p>
 
-    <p class="govuk-body">
-      <% if @user_is_new %>
-        <%= sanitize(t("confirmation_sent.new_user_instruction_list")) %>
-      <% else %>
-        <%= sanitize(t("confirmation_sent.existing_user_instruction_list")) %>
-      <% end %>
-    </p>
+<p class="govuk-body">
+  <% if @user_is_new %>
+    <%= sanitize(t("confirmation_sent.new_user_instruction_list")) %>
+  <% else %>
+    <%= sanitize(t("confirmation_sent.existing_user_instruction_list")) %>
+  <% end %>
+</p>
 
-    <% unless @user_is_confirmed %>
-      <%= render "govuk_publishing_components/components/inset_text", {
-        text: t("confirmation_sent.delay_consequence")
-      } %>
-    <% end %>
+<% unless @user_is_confirmed %>
+  <%= render "govuk_publishing_components/components/inset_text", {
+    text: t("confirmation_sent.delay_consequence")
+  } %>
+<% end %>
 
-    <p class="govuk-body" data-module="gem-track-click">
-      <% if service %>
-        <a class="govuk-link" href="<%= service[:url] %>" data-module="explicit-cross-domain-links" data-track-category="account-create" data-track-action="confirm-email" data-track-label="<%= service[:name] %>">
-          <%= t("confirmation_sent.continue_to_service", service_name: service[:name]) %>
-        </a>
-      <% else %>
-        <a class="govuk-link" href="<%= user_root_path %>" data-track-category="account-create" data-track-action="confirm-email" data-track-label="Account">
-          <%= t("confirmation_sent.continue_to_account") %>
-        </a>
-      <% end %>
-    </p>
+<p class="govuk-body" data-module="gem-track-click">
+  <% if service %>
+    <a class="govuk-link" href="<%= service[:url] %>" data-module="explicit-cross-domain-links" data-track-category="account-create" data-track-action="confirm-email" data-track-label="<%= service[:name] %>">
+      <%= t("confirmation_sent.continue_to_service", service_name: service[:name]) %>
+    </a>
+  <% else %>
+    <a class="govuk-link" href="<%= user_root_path %>" data-track-category="account-create" data-track-action="confirm-email" data-track-label="Account">
+      <%= t("confirmation_sent.continue_to_account") %>
+    </a>
+  <% end %>
+</p>
 
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("confirmation_sent.re_register_subtitle"),
-      heading_level: 2,
-      margin_bottom: 3,
-      font_size: 19,
-    } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("confirmation_sent.re_register_subtitle"),
+  heading_level: 2,
+  margin_bottom: 3,
+  font_size: 19,
+} %>
 
-    <%= sanitize(t("confirmation_sent.re_register_instructions", resend_confirmation_link: new_user_confirmation_path, retry_link: edit_user_registration_email_path)) %>
-  </div>
-</div>
+<%= sanitize(t("confirmation_sent.re_register_instructions", resend_confirmation_link: new_user_confirmation_path, retry_link: edit_user_registration_email_path)) %>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,41 +1,37 @@
 <% content_for :title, t("devise.passwords.edit.heading") %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <% unless @reset_password_token_valid %>
-      <%= render "govuk_publishing_components/components/error_alert", {
-        message: sanitize("#{t("errors.messages.expired")} <a class=\"govuk-link\" href=\"#{reset_password_path}\">#{t("errors.messages.expired_link_text")}</a>.")
-      } %>
-    <% end %>
+<% unless @reset_password_token_valid %>
+  <%= render "govuk_publishing_components/components/error_alert", {
+    message: sanitize("#{t("errors.messages.expired")} <a class=\"govuk-link\" href=\"#{reset_password_path}\">#{t("errors.messages.expired_link_text")}</a>.")
+  } %>
+<% end %>
 
-    <%= render "govuk_publishing_components/components/heading", {
-      text: yield(:title),
-      heading_level: 1,
-      margin_top: 0,
-      margin_bottom: 3,
-    } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: yield(:title),
+  heading_level: 1,
+  margin_top: 0,
+  margin_bottom: 3,
+} %>
 
-    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do %>
-      <%= render "devise/shared/error_messages", resource: resource %>
-      <%= hidden_field_tag "user[reset_password_token]", params[:reset_password_token] %>
-      <%= email_field_tag 'email', @reset_email, class: "govuk-!-display-none", autocomplete: "off", "aria-hidden": true if @reset_email %>
-      <%= render "govuk_publishing_components/components/show_password", {
-        label: {
-          text: t("devise.passwords.edit.password.label"),
-        },
-        hint: t("devise.passwords.edit.password.hint"),
-        name: "user[password]",
-        id: "password",
-        error_message: devise_error_items(:password),
-        autocomplete: @reset_email ? "new-password" : "off",
-      } %>
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+  <%= hidden_field_tag "user[reset_password_token]", params[:reset_password_token] %>
+  <%= email_field_tag 'email', @reset_email, class: "govuk-!-display-none", autocomplete: "off", "aria-hidden": true if @reset_email %>
+  <%= render "govuk_publishing_components/components/show_password", {
+    label: {
+      text: t("devise.passwords.edit.password.label"),
+    },
+    hint: t("devise.passwords.edit.password.hint"),
+    name: "user[password]",
+    id: "password",
+    error_message: devise_error_items(:password),
+    autocomplete: @reset_email ? "new-password" : "off",
+  } %>
 
-      <%= render "devise/shared/password_tip" %>
+  <%= render "devise/shared/password_tip" %>
 
-      <%= render "govuk_publishing_components/components/button", {
-        text: t("devise.passwords.edit.submit.label"),
-        margin_bottom: 3,
-      } %>
-    <% end %>
-  </div>
-</div>
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("devise.passwords.edit.submit.label"),
+    margin_bottom: 3,
+  } %>
+<% end %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,35 +1,31 @@
 <% content_for :title, t("change_password.heading") %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: yield(:title),
-      heading_level: 1,
-      font_size: "l",
-      margin_top: 0,
-      margin_bottom: 3,
-    } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: yield(:title),
+  heading_level: 1,
+  font_size: "l",
+  margin_top: 0,
+  margin_bottom: 3,
+} %>
 
-    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do %>
-      <%= render "devise/shared/error_messages", resource: resource %>
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do %>
+  <%= render "devise/shared/error_messages", resource: resource %>
 
-      <p class="govuk-body"><%= I18n.t("change_password.content") %></p>
+  <p class="govuk-body"><%= I18n.t("change_password.content") %></p>
 
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: t("devise.passwords.new.email.label"),
-        },
-        name: "user[email]",
-        type: "email",
-        id: "email",
-        error_message: devise_error_items(:email),
-        autocomplete: "username",
-      } %>
+  <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: t("devise.passwords.new.email.label"),
+    },
+    name: "user[email]",
+    type: "email",
+    id: "email",
+    error_message: devise_error_items(:email),
+    autocomplete: "username",
+  } %>
 
-      <%= render "govuk_publishing_components/components/button", {
-        text: t("devise.passwords.new.submit.label"),
-        margin_bottom: 3,
-      } %>
-    <% end %>
-  </div>
-</div>
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("devise.passwords.new.submit.label"),
+    margin_bottom: 3,
+  } %>
+<% end %>

--- a/app/views/devise/passwords/sent.html.erb
+++ b/app/views/devise/passwords/sent.html.erb
@@ -1,27 +1,23 @@
 <% content_for :title, t("reset_sent.heading") %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: yield(:title),
-      heading_level: 1,
-      font_size: "l",
-      margin_top: 0,
-      margin_bottom: 3,
-    } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: yield(:title),
+  heading_level: 1,
+  font_size: "l",
+  margin_top: 0,
+  margin_bottom: 3,
+} %>
 
-    <p class="govuk-body">
-      <%= t("reset_sent.content_with_email", email: @email) if @email.present? %>
-      <%= t("reset_sent.content_without_email") if !@email.present? %>
-    </p>
+<p class="govuk-body">
+  <%= t("reset_sent.content_with_email", email: @email) if @email.present? %>
+  <%= t("reset_sent.content_without_email") if !@email.present? %>
+</p>
 
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("reset_sent.subheading"),
-      heading_level: 2,
-      margin_top: 0,
-      margin_bottom: 3,
-    } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("reset_sent.subheading"),
+  heading_level: 2,
+  margin_top: 0,
+  margin_bottom: 3,
+} %>
 
-    <%= sanitize(t("reset_sent.try_again", link: reset_password_path)) %>
-  </div>
-</div>
+<%= sanitize(t("reset_sent.try_again", link: reset_password_path)) %>

--- a/app/views/devise/registrations/closed.html.erb
+++ b/app/views/devise/registrations/closed.html.erb
@@ -1,17 +1,13 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/back_link", {
-      href: new_user_session_path
-    } %>
+<%= render "govuk_publishing_components/components/back_link", {
+  href: new_user_session_path
+} %>
 
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("devise.registrations.closed.heading"),
-      heading_level: 1,
-      margin_bottom: 3,
-    } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("devise.registrations.closed.heading"),
+  heading_level: 1,
+  margin_bottom: 3,
+} %>
 
-    <% t("devise.registrations.closed.message").each do |msg| %>
-      <p class="govuk-body"><%= msg %></p>
-    <% end %>
-  </div>
-</div>
+<% t("devise.registrations.closed.message").each do |msg| %>
+  <p class="govuk-body"><%= msg %></p>
+<% end %>

--- a/app/views/devise/registrations/edit_email.html.erb
+++ b/app/views/devise/registrations/edit_email.html.erb
@@ -1,73 +1,68 @@
 <% content_for :title, t("devise.registrations.edit.heading_email") %>
 <% content_for :location, "manage" %>
+<% content_for :account_navigation do %>
+  <%= render "account-navigation", page_is: yield(:location) %>
+<% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-third">
-    <%= render "account-navigation", page_is: yield(:location) %>
-  </div>
+<%= render "govuk_publishing_components/components/back_link", { href: account_manage_path } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: yield(:title),
+  heading_level: 1,
+  font_size: "l",
+  margin_bottom: 6,
+} %>
 
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/back_link", { href: account_manage_path } %>
-    <%= render "govuk_publishing_components/components/heading", {
-      text: yield(:title),
-      heading_level: 1,
-      font_size: "l",
-      margin_bottom: 6,
-    } %>
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do %>
+  <%= render "devise/shared/error_messages", resource: resource %>
 
-    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do %>
-      <%= render "devise/shared/error_messages", resource: resource %>
+  <%= render "govuk_publishing_components/components/inset_text", {
+    text: t("devise.registrations.edit.fields.email.inset_text", email: resource.email),
+  } %>
 
-      <%= render "govuk_publishing_components/components/inset_text", {
-        text: t("devise.registrations.edit.fields.email.inset_text", email: resource.email),
-      } %>
+  <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: t("devise.registrations.edit.fields.email.label"),
+    },
+    name: "user[email]",
+    type: "email",
+    id: "email",
+    value: @email,
+    error_message: devise_error_items(:email),
+    autocomplete: "username",
+  } %>
 
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: t("devise.registrations.edit.fields.email.label"),
-        },
-        name: "user[email]",
-        type: "email",
-        id: "email",
-        value: @email,
-        error_message: devise_error_items(:email),
-        autocomplete: "username",
-      } %>
+  <%= render "govuk_publishing_components/components/show_password", {
+    label: {
+      text: t("devise.registrations.edit.fields.current_password.label"),
+    },
+    heading_size: "m",
+    hint: t("devise.registrations.edit.fields.current_password.hint"),
+    name: "user[current_password]",
+    id: "current__confirmation",
+    error_message: devise_error_items(:current_password),
+    autocomplete: "current-password",
+  } %>
 
-      <%= render "govuk_publishing_components/components/show_password", {
-        label: {
-          text: t("devise.registrations.edit.fields.current_password.label"),
-        },
-        heading_size: "m",
-        hint: t("devise.registrations.edit.fields.current_password.hint"),
-        name: "user[current_password]",
-        id: "current__confirmation",
-        error_message: devise_error_items(:current_password),
-        autocomplete: "current-password",
-      } %>
-
-      <%= render "govuk_publishing_components/components/button", {
-        text: t("devise.registrations.edit.fields.submit.label"),
-        margin_bottom: 3,
-        inline_layout: true,
-        data_attributes: {
-          module: "gem-track-click",
-          "track-category": "account-manage",
-          "track-action": "email",
-          "track-label": ""
-        }
-      } %>
-      <span class="govuk-body"><%= t("general.or") %></span>
-      <%= link_to t("general.cancel"),
-        account_manage_path,
-        class: "govuk-body govuk-link",
-        data: {
-          module: "gem-track-click",
-          "track-category": "account-manage",
-          "track-action": "email",
-          "track-label": "cancel"
-        }
-      %>
-    <% end %>
-  </div>
-</div>
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("devise.registrations.edit.fields.submit.label"),
+    margin_bottom: 3,
+    inline_layout: true,
+    data_attributes: {
+      module: "gem-track-click",
+      "track-category": "account-manage",
+      "track-action": "email",
+      "track-label": ""
+    }
+  } %>
+  <span class="govuk-body"><%= t("general.or") %></span>
+  <%= link_to t("general.cancel"),
+    account_manage_path,
+    class: "govuk-body govuk-link",
+    data: {
+      module: "gem-track-click",
+      "track-category": "account-manage",
+      "track-action": "email",
+      "track-label": "cancel"
+    }
+  %>
+<% end %>

--- a/app/views/devise/registrations/edit_password.html.erb
+++ b/app/views/devise/registrations/edit_password.html.erb
@@ -1,71 +1,66 @@
 <% content_for :title, t("devise.registrations.edit.heading_password") %>
 <% content_for :location, "manage" %>
+<% content_for :account_navigation do %>
+  <%= render "account-navigation", page_is: yield(:location) %>
+<% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-third">
-    <%= render "account-navigation", page_is: yield(:location) %>
-  </div>
+<%= render "govuk_publishing_components/components/back_link", { href: account_manage_path } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: yield(:title),
+  heading_level: 1,
+  font_size: "l",
+  margin_bottom: 6,
+} %>
 
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/back_link", { href: account_manage_path } %>
-    <%= render "govuk_publishing_components/components/heading", {
-      text: yield(:title),
-      heading_level: 1,
-      font_size: "l",
-      margin_bottom: 6,
-    } %>
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do %>
+  <%= email_field_tag 'email', resource.email, class: "govuk-!-display-none", autocomplete: "off", "aria-hidden": true %>
+  <%= render "devise/shared/error_messages", resource: resource %>
 
-    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do %>
-    <%= email_field_tag 'email', resource.email, class: "govuk-!-display-none", autocomplete: "off", "aria-hidden": true %>
-    <%= render "devise/shared/error_messages", resource: resource %>
+  <%= render "govuk_publishing_components/components/show_password", {
+    label: {
+      text: t("devise.registrations.edit.fields.password.label"),
+    },
+    hint: t("devise.registrations.edit.fields.password.hint"),
+    name: "user[password]",
+    id: "password",
+    error_message: devise_error_items(:password),
+    autocomplete: "new-password",
+  } %>
 
-      <%= render "govuk_publishing_components/components/show_password", {
-        label: {
-          text: t("devise.registrations.edit.fields.password.label"),
-        },
-        hint: t("devise.registrations.edit.fields.password.hint"),
-        name: "user[password]",
-        id: "password",
-        error_message: devise_error_items(:password),
-        autocomplete: "new-password",
-      } %>
+  <%= render "devise/shared/password_tip" %>
 
-      <%= render "devise/shared/password_tip" %>
+  <%= render "govuk_publishing_components/components/show_password", {
+    label: {
+      text: t("devise.registrations.edit.fields.current_password.label"),
+    },
+    heading_size: "m",
+    hint: t("devise.registrations.edit.fields.current_password.hint_current"),
+    name: "user[current_password]",
+    id: "current__confirmation",
+    error_message: devise_error_items(:current_password),
+    autocomplete: "current-password",
+  } %>
 
-      <%= render "govuk_publishing_components/components/show_password", {
-        label: {
-          text: t("devise.registrations.edit.fields.current_password.label"),
-        },
-        heading_size: "m",
-        hint: t("devise.registrations.edit.fields.current_password.hint_current"),
-        name: "user[current_password]",
-        id: "current__confirmation",
-        error_message: devise_error_items(:current_password),
-        autocomplete: "current-password",
-      } %>
-
-      <%= render "govuk_publishing_components/components/button", {
-        text: t("devise.registrations.edit.fields.submit.label"),
-        margin_bottom: 3,
-        inline_layout: true,
-        data_attributes: {
-          module: "gem-track-click",
-          "track-category": "account-manage",
-          "track-action": "password",
-          "track-label": ""
-        }
-      } %>
-      <span class="govuk-body"><%= t("general.or") %></span>
-      <%= link_to t("general.cancel"),
-        account_manage_path,
-        class: "govuk-body govuk-link",
-        data: {
-          module: "gem-track-click",
-          "track-category": "account-manage",
-          "track-action": "password",
-          "track-label": "cancel"
-        }
-      %>
-    <% end %>
-  </div>
-</div>
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("devise.registrations.edit.fields.submit.label"),
+    margin_bottom: 3,
+    inline_layout: true,
+    data_attributes: {
+      module: "gem-track-click",
+      "track-category": "account-manage",
+      "track-action": "password",
+      "track-label": ""
+    }
+  } %>
+  <span class="govuk-body"><%= t("general.or") %></span>
+  <%= link_to t("general.cancel"),
+    account_manage_path,
+    class: "govuk-body govuk-link",
+    data: {
+      module: "gem-track-click",
+      "track-category": "account-manage",
+      "track-action": "password",
+      "track-label": "cancel"
+    }
+  %>
+<% end %>

--- a/app/views/devise/registrations/phone_code.html.erb
+++ b/app/views/devise/registrations/phone_code.html.erb
@@ -1,50 +1,46 @@
 <% content_for :title, t("mfa.phone.code.sign_up_heading") %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: yield(:title),
-      heading_level: 1,
-      font_size: "xl",
-      margin_top: 0,
-      margin_bottom: 3,
-    } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: yield(:title),
+  heading_level: 1,
+  font_size: "xl",
+  margin_top: 0,
+  margin_bottom: 3,
+} %>
 
-    <% t("mfa.phone.code.description_with_phone_number", phone_number: MultiFactorAuth.formatted_phone_number(@registration_state.phone)).each do |msg| %>
-      <p class="govuk-body"><%= sanitize(msg) %></p>
-    <% end %>
+<% t("mfa.phone.code.description_with_phone_number", phone_number: MultiFactorAuth.formatted_phone_number(@registration_state.phone)).each do |msg| %>
+  <p class="govuk-body"><%= sanitize(msg) %></p>
+<% end %>
 
-    <%= form_with(url: new_user_registration_phone_verify_path, method: :post, html: { autocomplete: "off" }) do %>
-      <%= render "govuk_publishing_components/components/input", {
-        label: { text: t("mfa.phone.code.fields.phone_code.label") },
-        name: "phone_code",
-        maxlength: 5,
-        type: "number",
-        error_message: sanitize(@phone_code_error_message),
-        width: 5,
-      } %>
+<%= form_with(url: new_user_registration_phone_verify_path, method: :post, html: { autocomplete: "off" }) do %>
+  <%= render "govuk_publishing_components/components/input", {
+    label: { text: t("mfa.phone.code.fields.phone_code.label") },
+    name: "phone_code",
+    maxlength: 5,
+    type: "number",
+    error_message: sanitize(@phone_code_error_message),
+    width: 5,
+  } %>
 
-      <%= render "govuk_publishing_components/components/button", {
-        text: t("mfa.phone.code.fields.submit.label"),
-        margin_bottom: true,
-        data_attributes: {
-          module: "gem-track-click",
-          "track-category": "account-create",
-          "track-action": "create",
-          "track-label": "security-code"
-        }
-      } %>
-    <% end %>
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("mfa.phone.code.fields.submit.label"),
+    margin_bottom: true,
+    data_attributes: {
+      module: "gem-track-click",
+      "track-category": "account-create",
+      "track-action": "create",
+      "track-label": "security-code"
+    }
+  } %>
+<% end %>
 
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("mfa.phone.code.not_received.sign_up_heading"),
-      heading_level: 2,
-      margin_bottom: 4,
-      font_size: "m",
-    } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("mfa.phone.code.not_received.sign_up_heading"),
+  heading_level: 2,
+  margin_bottom: 4,
+  font_size: "m",
+} %>
 
-    <p class="govuk-body">
-      <%= sanitize(t("mfa.phone.code.not_received.sign_up_message", link: new_user_registration_phone_resend_path)) %>
-    </p>
-  </div>
-</div>
+<p class="govuk-body">
+  <%= sanitize(t("mfa.phone.code.not_received.sign_up_message", link: new_user_registration_phone_resend_path)) %>
+</p>

--- a/app/views/devise/registrations/phone_resend.html.erb
+++ b/app/views/devise/registrations/phone_resend.html.erb
@@ -1,45 +1,41 @@
 <% content_for :title, t("mfa.phone.resend.heading") %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/back_link", {
-      href: new_user_registration_phone_code_path
+<%= render "govuk_publishing_components/components/back_link", {
+  href: new_user_registration_phone_code_path
+} %>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("mfa.phone.resend.heading"),
+  heading_level: 1,
+  font_size: "xl",
+  margin_top: 0,
+  margin_bottom: 3,
+} %>
+
+<p class="govuk-body"><%= t("mfa.phone.resend.description") %></p>
+
+<%= form_with(url: new_user_registration_phone_resend_path, method: :post) do %>
+  <%= render "govuk_publishing_components/components/details", {
+    title: t("mfa.phone.resend.change_phone"),
+    open: @phone_error_message.present?,
+  } do %>
+    <%= render "govuk_publishing_components/components/input", {
+      label: { text: t("mfa.phone.resend.fields.phone.label") },
+      name: "phone",
+      value: MultiFactorAuth.formatted_phone_number(@phone),
+      error_message: @phone_error_message,
+      width: 10,
+      autocomplete: "tel",
     } %>
+  <% end %>
 
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("mfa.phone.resend.heading"),
-      heading_level: 1,
-      font_size: "xl",
-      margin_top: 0,
-      margin_bottom: 3,
-    } %>
-
-    <p class="govuk-body"><%= t("mfa.phone.resend.description") %></p>
-
-    <%= form_with(url: new_user_registration_phone_resend_path, method: :post) do %>
-      <%= render "govuk_publishing_components/components/details", {
-        title: t("mfa.phone.resend.change_phone"),
-        open: @phone_error_message.present?,
-      } do %>
-        <%= render "govuk_publishing_components/components/input", {
-          label: { text: t("mfa.phone.resend.fields.phone.label") },
-          name: "phone",
-          value: MultiFactorAuth.formatted_phone_number(@phone),
-          error_message: @phone_error_message,
-          width: 10,
-          autocomplete: "tel",
-        } %>
-      <% end %>
-
-      <%= render "govuk_publishing_components/components/button", {
-        text: t("mfa.phone.resend.fields.submit.label"),
-        data_attributes: {
-          module: "gem-track-click",
-          "track-category": "account-create",
-          "track-action": "create",
-          "track-label": "resend-security-code"
-        }
-      } %>
-    <% end %>
-  </div>
-</div>
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("mfa.phone.resend.fields.submit.label"),
+    data_attributes: {
+      module: "gem-track-click",
+      "track-category": "account-create",
+      "track-action": "create",
+      "track-label": "resend-security-code"
+    }
+  } %>
+<% end %>

--- a/app/views/devise/registrations/start.html.erb
+++ b/app/views/devise/registrations/start.html.erb
@@ -1,77 +1,72 @@
 <% content_for :title, t("devise.registrations.start.heading") %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= form_with(url: new_user_registration_start_path, method: :post) do %>
-      <% if resource || @resource_error_messages %>
-        <%= render "devise/shared/error_messages", resource: resource, resource_error_messages: @resource_error_messages %>
-      <% end %>
+<%= form_with(url: new_user_registration_start_path, method: :post) do %>
+  <% if resource || @resource_error_messages %>
+    <%= render "devise/shared/error_messages", resource: resource, resource_error_messages: @resource_error_messages %>
+  <% end %>
 
-      <%= render "govuk_publishing_components/components/heading", {
-        text: yield(:title),
-        heading_level: 1,
-        font_size: "xl",
-        margin_top: 0,
-        margin_bottom: 3,
-      } %>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: yield(:title),
+    heading_level: 1,
+    font_size: "xl",
+    margin_top: 0,
+    margin_bottom: 3,
+  } %>
 
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: t("devise.registrations.start.fields.email.label"),
-        },
-        name: "user[email]",
-        type: "email",
-        id: "email",
-        value: params.dig(:user, :email),
-        error_message: devise_error_items(:email),
-        autocomplete: "username",
-      } %>
+  <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: t("devise.registrations.start.fields.email.label"),
+    },
+    name: "user[email]",
+    type: "email",
+    id: "email",
+    value: params.dig(:user, :email),
+    error_message: devise_error_items(:email),
+    autocomplete: "username",
+  } %>
 
-      <%= render "govuk_publishing_components/components/show_password", {
-        label: {
-          text: t("devise.registrations.start.fields.password.label"),
-        },
-        hint: t("devise.registrations.start.fields.password.hint"),
-        name: "user[password]",
-        id: "password",
-        error_message: devise_error_items(:password),
-        autocomplete: "new-password",
-      } %>
+  <%= render "govuk_publishing_components/components/show_password", {
+    label: {
+      text: t("devise.registrations.start.fields.password.label"),
+    },
+    hint: t("devise.registrations.start.fields.password.hint"),
+    name: "user[password]",
+    id: "password",
+    error_message: devise_error_items(:password),
+    autocomplete: "new-password",
+  } %>
 
-      <%= render "devise/shared/password_tip" %>
+  <%= render "devise/shared/password_tip" %>
 
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: t("devise.registrations.start.fields.phone.label"),
-        },
-        hint: t("devise.registrations.start.fields.phone.hint"),
-        name: "user[phone]",
-        id: "phone",
-        value: MultiFactorAuth.formatted_phone_number(params.dig(:user, :phone)),
-        width: 10,
-        error_message: devise_error_items(:phone),
-        autocomplete: "tel",
-      } %>
+  <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: t("devise.registrations.start.fields.phone.label"),
+    },
+    hint: t("devise.registrations.start.fields.phone.hint"),
+    name: "user[phone]",
+    id: "phone",
+    value: MultiFactorAuth.formatted_phone_number(params.dig(:user, :phone)),
+    width: 10,
+    error_message: devise_error_items(:phone),
+    autocomplete: "tel",
+  } %>
 
-      <%= render "govuk_publishing_components/components/button", {
-        text: t("devise.registrations.start.fields.submit.label"),
-        data_attributes: {
-          module: "gem-track-click",
-          "track-category": "account-create",
-          "track-action": "create",
-          "track-label": "password"
-        },
-        margin_bottom: 3,
-      } %>
-    <% end %>
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("devise.registrations.start.fields.submit.label"),
+    data_attributes: {
+      module: "gem-track-click",
+      "track-category": "account-create",
+      "track-action": "create",
+      "track-label": "password"
+    },
+    margin_bottom: 3,
+  } %>
+<% end %>
 
-    <p class="govuk-body"><%= sanitize(t("devise.registrations.start.sign_in", link: link_to(t("devise.registrations.start.sign_in_link"), new_user_session_path, class: "govuk-link"))) %></p>
+<p class="govuk-body"><%= sanitize(t("devise.registrations.start.sign_in", link: link_to(t("devise.registrations.start.sign_in_link"), new_user_session_path, class: "govuk-link"))) %></p>
 
-    <% if @criteria_keys %>
-      <%= render "govuk_publishing_components/components/inset_text", {
-        text: sanitize(t("devise.registrations.start.checker_inset_text", link: link_to(t("devise.registrations.start.checker_inset_text_link"), "#{transition_checker_path}/save-your-results?#{@criteria_keys.to_query('c')}", class: "govuk-link")))
-      } %>
-    <% end %>
-
-  </div>
-</div>
+<% if @criteria_keys %>
+  <%= render "govuk_publishing_components/components/inset_text", {
+    text: sanitize(t("devise.registrations.start.checker_inset_text", link: link_to(t("devise.registrations.start.checker_inset_text_link"), "#{transition_checker_path}/save-your-results?#{@criteria_keys.to_query('c')}", class: "govuk-link")))
+  } %>
+<% end %>

--- a/app/views/devise/registrations/transition_checker.html.erb
+++ b/app/views/devise/registrations/transition_checker.html.erb
@@ -1,11 +1,7 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("devise.registrations.transition_checker.heading"),
-      heading_level: 1,
-      margin_bottom: 3,
-    } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("devise.registrations.transition_checker.heading"),
+  heading_level: 1,
+  margin_bottom: 3,
+} %>
 
-    <p class="govuk-body"><%= sanitize(t("devise.registrations.transition_checker.message", link: "#{transition_checker_path}/questions")) %></p>
-  </div>
-</div>
+<p class="govuk-body"><%= sanitize(t("devise.registrations.transition_checker.message", link: "#{transition_checker_path}/questions")) %></p>

--- a/app/views/devise/registrations/transition_emails.html.erb
+++ b/app/views/devise/registrations/transition_emails.html.erb
@@ -1,53 +1,49 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("devise.registrations.transition_emails.heading"),
-      heading_level: 1,
-      font_size: "xl",
-      margin_top: 0,
-      margin_bottom: 3,
-    } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("devise.registrations.transition_emails.heading"),
+  heading_level: 1,
+  font_size: "xl",
+  margin_top: 0,
+  margin_bottom: 3,
+} %>
 
-    <%= form_with(
-      url: new_user_registration_transition_emails_path,
-      method: :post,
-      data: {
-        module: "track-form",
-        "track-category": "account-create"
+<%= form_with(
+  url: new_user_registration_transition_emails_path,
+  method: :post,
+  data: {
+    module: "track-form",
+    "track-category": "account-create"
+  }
+) do %>
+  <%= sanitize(t("devise.registrations.transition_emails.description")) %>
+
+  <%= render "govuk_publishing_components/components/radio", {
+    name: "email_decision",
+    heading: t("devise.registrations.transition_emails.fields.emailsignup.heading"),
+    heading_size: "s",
+    error_message: devise_error_items(:email_decision, @resource_error_messages),
+    items: [
+      {
+        value: "yes",
+        text: t("devise.registrations.transition_emails.fields.emailsignup.yes"),
+        data_attributes: {
+          "track-action": "email-transition"
+        }
+      },
+      {
+        value: "no",
+        text: t("devise.registrations.transition_emails.fields.emailsignup.no"),
+        data_attributes: {
+          "track-action": "email-transition"
+        }
       }
-    ) do %>
-      <%= sanitize(t("devise.registrations.transition_emails.description")) %>
+    ]
+  } %>
 
-      <%= render "govuk_publishing_components/components/radio", {
-        name: "email_decision",
-        heading: t("devise.registrations.transition_emails.fields.emailsignup.heading"),
-        heading_size: "s",
-        error_message: devise_error_items(:email_decision, @resource_error_messages),
-        items: [
-          {
-            value: "yes",
-            text: t("devise.registrations.transition_emails.fields.emailsignup.yes"),
-            data_attributes: {
-              "track-action": "email-transition"
-            }
-          },
-          {
-            value: "no",
-            text: t("devise.registrations.transition_emails.fields.emailsignup.no"),
-            data_attributes: {
-              "track-action": "email-transition"
-            }
-          }
-        ]
-      } %>
+  <%= render "govuk_publishing_components/components/inset_text", {
+    text: t("devise.registrations.transition_emails.unsubscribe")
+  } %>
 
-      <%= render "govuk_publishing_components/components/inset_text", {
-        text: t("devise.registrations.transition_emails.unsubscribe")
-      } %>
-
-      <%= render "govuk_publishing_components/components/button", {
-        text: t("devise.registrations.transition_emails.fields.submit.label"),
-      } %>
-    <% end %>
-  </div>
-</div>
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("devise.registrations.transition_emails.fields.submit.label"),
+  } %>
+<% end %>

--- a/app/views/devise/registrations/your_information.html.erb
+++ b/app/views/devise/registrations/your_information.html.erb
@@ -1,111 +1,107 @@
 <% content_for :title, t("devise.registrations.your_information.heading") %>
 <% @skip_cookie_banner = true %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: yield(:title),
-      heading_level: 1,
-      font_size: "xl",
-      margin_bottom: 3,
-    } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: yield(:title),
+  heading_level: 1,
+  font_size: "xl",
+  margin_bottom: 3,
+} %>
 
-    <% if defined?(@error_items) %>
-      <%= render "govuk_publishing_components/components/error_summary", {
-        id: "error-summary",
-        title: t("feedback.show.errors.summary"),
-        items: @error_items
-      } %>
-    <% end %>
+<% if defined?(@error_items) %>
+  <%= render "govuk_publishing_components/components/error_summary", {
+    id: "error-summary",
+    title: t("feedback.show.errors.summary"),
+    items: @error_items
+  } %>
+<% end %>
 
-    <%= sanitize(t("devise.registrations.your_information.description")) %>
+<%= sanitize(t("devise.registrations.your_information.description")) %>
 
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("devise.registrations.your_information.data_choice_heading"),
-      heading_level: 2,
-      font_size: "m",
-      margin_bottom: 3,
-    } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("devise.registrations.your_information.data_choice_heading"),
+  heading_level: 2,
+  font_size: "m",
+  margin_bottom: 3,
+} %>
 
-    <%= sanitize(t("devise.registrations.your_information.data_choice_description")) %>
+<%= sanitize(t("devise.registrations.your_information.data_choice_description")) %>
 
-    <%= form_with(
-      url: new_user_registration_your_information_path,
-      method: :post,
-      data: {
-        module: "track-form",
-        "track-category": "account-create"
+<%= form_with(
+  url: new_user_registration_your_information_path,
+  method: :post,
+  data: {
+    module: "track-form",
+    "track-category": "account-create"
+  }
+) do %>
+
+  <%= render "govuk_publishing_components/components/radio", {
+    name: "cookie_consent",
+    id: "cookie_consent",
+    heading: t("devise.registrations.your_information.fields.cookie_consent.heading"),
+    heading_size: "s",
+    error_message: error_items("cookie_consent", @error_items),
+    hint: t("devise.registrations.your_information.fields.cookie_consent.hint"),
+    items: [
+      {
+        value: "yes",
+        text: t("devise.registrations.your_information.fields.cookie_consent.yes"),
+        checked: @consents.fetch(:cookie_consent_decision, nil) == "yes",
+        data_attributes: {
+          "track-action": "personal-information-cookies"
+        }
+      },
+      {
+        value: "no",
+        text: t("devise.registrations.your_information.fields.cookie_consent.no"),
+        checked: @consents.fetch(:cookie_consent_decision, nil) == "no",
+        data_attributes: {
+          "track-action": "personal-information-cookies"
+        }
       }
-    ) do %>
+    ]
+  } %>
 
-      <%= render "govuk_publishing_components/components/radio", {
-        name: "cookie_consent",
-        id: "cookie_consent",
-        heading: t("devise.registrations.your_information.fields.cookie_consent.heading"),
-        heading_size: "s",
-        error_message: error_items("cookie_consent", @error_items),
-        hint: t("devise.registrations.your_information.fields.cookie_consent.hint"),
-        items: [
-          {
-            value: "yes",
-            text: t("devise.registrations.your_information.fields.cookie_consent.yes"),
-            checked: @consents.fetch(:cookie_consent_decision, nil) == "yes",
-            data_attributes: {
-              "track-action": "personal-information-cookies"
-            }
-          },
-          {
-            value: "no",
-            text: t("devise.registrations.your_information.fields.cookie_consent.no"),
-            checked: @consents.fetch(:cookie_consent_decision, nil) == "no",
-            data_attributes: {
-              "track-action": "personal-information-cookies"
-            }
-          }
-        ]
-      } %>
+  <%= render "govuk_publishing_components/components/heading", {
+    text:  t("devise.registrations.your_information.fields.feedback_consent.section_heading"),
+    heading_level: 2,
+    font_size: "m",
+    margin_bottom: 3,
+  } %>
 
-      <%= render "govuk_publishing_components/components/heading", {
-        text:  t("devise.registrations.your_information.fields.feedback_consent.section_heading"),
-        heading_level: 2,
-        font_size: "m",
-        margin_bottom: 3,
-      } %>
+  <p class="govuk-body">
+    <%=  t("devise.registrations.your_information.fields.feedback_consent.message") %>
+  </p>
 
-      <p class="govuk-body">
-        <%=  t("devise.registrations.your_information.fields.feedback_consent.message") %>
-      </p>
+  <%= render "govuk_publishing_components/components/radio", {
+    name: "feedback_consent",
+    id: "feedback_consent",
+    heading: t("devise.registrations.your_information.fields.feedback_consent.heading"),
+    heading_size: "s",
+    error_message: error_items("feedback_consent", @error_items),
+    hint: t("devise.registrations.your_information.fields.feedback_consent.hint"),
+    items: [
+      {
+        value: "yes",
+        text: t("devise.registrations.your_information.fields.feedback_consent.yes"),
+        checked: @consents.fetch(:feedback_consent_decision, nil) == "yes",
+        data_attributes: {
+          "track-action": "personal-information-feedback"
+        }
+      },
+      {
+        value: "no",
+        text: t("devise.registrations.your_information.fields.feedback_consent.no"),
+        checked: @consents.fetch(:feedback_consent_decision, nil) == "no",
+        data_attributes: {
+          "track-action": "personal-information-feedback"
+        }
+      }
+    ]
+  } %>
 
-      <%= render "govuk_publishing_components/components/radio", {
-        name: "feedback_consent",
-        id: "feedback_consent",
-        heading: t("devise.registrations.your_information.fields.feedback_consent.heading"),
-        heading_size: "s",
-        error_message: error_items("feedback_consent", @error_items),
-        hint: t("devise.registrations.your_information.fields.feedback_consent.hint"),
-        items: [
-          {
-            value: "yes",
-            text: t("devise.registrations.your_information.fields.feedback_consent.yes"),
-            checked: @consents.fetch(:feedback_consent_decision, nil) == "yes",
-            data_attributes: {
-              "track-action": "personal-information-feedback"
-            }
-          },
-          {
-            value: "no",
-            text: t("devise.registrations.your_information.fields.feedback_consent.no"),
-            checked: @consents.fetch(:feedback_consent_decision, nil) == "no",
-            data_attributes: {
-              "track-action": "personal-information-feedback"
-            }
-          }
-        ]
-      } %>
-
-      <%= render "govuk_publishing_components/components/button", {
-        text: t("devise.registrations.your_information.fields.submit.label"),
-      } %>
-    <% end %>
-  </div>
-</div>
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("devise.registrations.your_information.fields.submit.label"),
+  } %>
+<% end %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,76 +1,72 @@
 <% content_for :title, t("devise.sessions.new.heading") %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: yield(:title),
-      heading_level: 1,
-      font_size: "xl",
-      margin_top: 0,
-      margin_bottom: 3,
-    } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: yield(:title),
+  heading_level: 1,
+  font_size: "xl",
+  margin_top: 0,
+  margin_bottom: 3,
+} %>
 
-    <%= form_with url: new_user_session_path, html: { "data-module" => "explicit-cross-domain-links" } do %>
-      <% if resource %>
-        <%= render "devise/shared/error_messages", resource: resource %>
-      <% end %>
+<%= form_with url: new_user_session_path, html: { "data-module" => "explicit-cross-domain-links" } do %>
+  <% if resource %>
+    <%= render "devise/shared/error_messages", resource: resource %>
+  <% end %>
 
-      <% if flash[:notice] %>
-        <% if flash_as_notice(flash[:notice]) %>
-          <%= render "govuk_publishing_components/components/notice", { description_text: flash[:notice] } %>
-        <% else %>
-          <%= render "govuk_publishing_components/components/success_alert", { message: flash[:notice] } %>
-        <% end %>
-      <% end %>
-
-      <%= hidden_field_tag "from_confirmation_email", params[:from_confirmation_email] %>
-
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: t("devise.sessions.new.fields.email.label"),
-        },
-        name: "user[email]",
-        type: "email",
-        id: "email",
-        value: @email,
-        error_message: devise_error_items(:email, @resource_error_messages),
-        autocomplete: "username",
-      } %>
-
-      <%= render "govuk_publishing_components/components/show_password", {
-        label: {
-          text: t("devise.sessions.new.fields.password.label"),
-        },
-        name: "user[password]",
-        id: "password",
-        error_message: devise_error_items(:password, @resource_error_messages),
-        autocomplete: "current-password",
-      } %>
-
-      <% if devise_mapping.rememberable? %>
-        <%= render "govuk_publishing_components/components/checkboxes", {
-          name: "user[remember_me]",
-          items: [
-            {
-              label: t("devise.sessions.new.fields.remember.label"),
-              value: "1",
-            },
-          ],
-        } %>
-      <% end %>
-
-      <%= render "govuk_publishing_components/components/button", {
-        text: t("devise.sessions.new.fields.submit.label"),
-        margin_bottom: 3,
-        data_attributes: {
-          module: "gem-track-click",
-          "track-category": "account-signin",
-          "track-action": "signin",
-          "track-label": "password"
-        }
-      } %>
+  <% if flash[:notice] %>
+    <% if flash_as_notice(flash[:notice]) %>
+      <%= render "govuk_publishing_components/components/notice", { description_text: flash[:notice] } %>
+    <% else %>
+      <%= render "govuk_publishing_components/components/success_alert", { message: flash[:notice] } %>
     <% end %>
+  <% end %>
 
-    <%= sanitize(t("devise.sessions.new.reset_password", reset_password: reset_password_path)) %>
-  </div>
-</div>
+  <%= hidden_field_tag "from_confirmation_email", params[:from_confirmation_email] %>
+
+  <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: t("devise.sessions.new.fields.email.label"),
+    },
+    name: "user[email]",
+    type: "email",
+    id: "email",
+    value: @email,
+    error_message: devise_error_items(:email, @resource_error_messages),
+    autocomplete: "username",
+  } %>
+
+  <%= render "govuk_publishing_components/components/show_password", {
+    label: {
+      text: t("devise.sessions.new.fields.password.label"),
+    },
+    name: "user[password]",
+    id: "password",
+    error_message: devise_error_items(:password, @resource_error_messages),
+    autocomplete: "current-password",
+  } %>
+
+  <% if devise_mapping.rememberable? %>
+    <%= render "govuk_publishing_components/components/checkboxes", {
+      name: "user[remember_me]",
+      items: [
+        {
+          label: t("devise.sessions.new.fields.remember.label"),
+          value: "1",
+        },
+      ],
+    } %>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("devise.sessions.new.fields.submit.label"),
+    margin_bottom: 3,
+    data_attributes: {
+      module: "gem-track-click",
+      "track-category": "account-signin",
+      "track-action": "signin",
+      "track-label": "password"
+    }
+  } %>
+<% end %>
+
+<%= sanitize(t("devise.sessions.new.reset_password", reset_password: reset_password_path)) %>

--- a/app/views/devise/sessions/phone_code.html.erb
+++ b/app/views/devise/sessions/phone_code.html.erb
@@ -1,50 +1,46 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("mfa.phone.code.sign_in_heading"),
-      heading_level: 1,
-      font_size: "xl",
-      margin_top: 0,
-      margin_bottom: 3,
-    } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("mfa.phone.code.sign_in_heading"),
+  heading_level: 1,
+  font_size: "xl",
+  margin_top: 0,
+  margin_bottom: 3,
+} %>
 
-    <% t("mfa.phone.code.description").each do |msg| %>
-      <p class="govuk-body"><%= msg %></p>
-    <% end %>
+<% t("mfa.phone.code.description").each do |msg| %>
+  <p class="govuk-body"><%= msg %></p>
+<% end %>
 
-    <%= form_with url: user_session_phone_verify_path, method: :post, html: { autocomplete: "off", "data-module" => "explicit-cross-domain-links" } do %>
-      <%= hidden_field_tag "from_confirmation_email", params[:from_confirmation_email] %>
+<%= form_with url: user_session_phone_verify_path, method: :post, html: { autocomplete: "off", "data-module" => "explicit-cross-domain-links" } do %>
+  <%= hidden_field_tag "from_confirmation_email", params[:from_confirmation_email] %>
 
-      <%= render "govuk_publishing_components/components/input", {
-        label: { text: t("mfa.phone.code.fields.phone_code.label") },
-        name: "phone_code",
-        maxlength: 5,
-        type: "number",
-        error_message: sanitize(@phone_code_error_message),
-        width: 5,
-      } %>
+  <%= render "govuk_publishing_components/components/input", {
+    label: { text: t("mfa.phone.code.fields.phone_code.label") },
+    name: "phone_code",
+    maxlength: 5,
+    type: "number",
+    error_message: sanitize(@phone_code_error_message),
+    width: 5,
+  } %>
 
-      <%= render "govuk_publishing_components/components/button", {
-        text: t("mfa.phone.code.fields.submit.label"),
-        margin_bottom: true,
-        data_attributes: {
-          module: "gem-track-click",
-          "track-category": "account-signin",
-          "track-action": "signin",
-          "track-label": "security-code"
-        }
-      } %>
-    <% end %>
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("mfa.phone.code.fields.submit.label"),
+    margin_bottom: true,
+    data_attributes: {
+      module: "gem-track-click",
+      "track-category": "account-signin",
+      "track-action": "signin",
+      "track-label": "security-code"
+    }
+  } %>
+<% end %>
 
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("mfa.phone.code.not_received.sign_in_heading"),
-      heading_level: 2,
-      margin_bottom: 4,
-      font_size: "m",
-    } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("mfa.phone.code.not_received.sign_in_heading"),
+  heading_level: 2,
+  margin_bottom: 4,
+  font_size: "m",
+} %>
 
-    <p class="govuk-body">
-      <%= sanitize(t("mfa.phone.code.not_received.sign_in_message", link: resend_phone_code_path)) %>
-    </p>
-  </div>
-</div>
+<p class="govuk-body">
+  <%= sanitize(t("mfa.phone.code.not_received.sign_in_message", link: resend_phone_code_path)) %>
+</p>

--- a/app/views/devise/sessions/phone_resend.html.erb
+++ b/app/views/devise/sessions/phone_resend.html.erb
@@ -1,32 +1,28 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/back_link", {
-      href: user_session_phone_code_path
-    } %>
+<%= render "govuk_publishing_components/components/back_link", {
+  href: user_session_phone_code_path
+} %>
 
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("mfa.phone.resend.heading"),
-      heading_level: 1,
-      font_size: "xl",
-      margin_top: 0,
-      margin_bottom: 3,
-    } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("mfa.phone.resend.heading"),
+  heading_level: 1,
+  font_size: "xl",
+  margin_top: 0,
+  margin_bottom: 3,
+} %>
 
-    <p class="govuk-body"><%= t("mfa.phone.resend.description") %></p>
+<p class="govuk-body"><%= t("mfa.phone.resend.description") %></p>
 
-    <%= form_with(url: user_session_phone_resend_path, method: :post) do %>
-      <%= hidden_field_tag "from_confirmation_email", params[:from_confirmation_email] %>
+<%= form_with(url: user_session_phone_resend_path, method: :post) do %>
+  <%= hidden_field_tag "from_confirmation_email", params[:from_confirmation_email] %>
 
-      <%= render "govuk_publishing_components/components/button", {
-        text: t("mfa.phone.resend.fields.submit.label"),
-        margin_bottom: true,
-        data_attributes: {
-          module: "gem-track-click",
-          "track-category": "account-signin",
-          "track-action": "signin",
-          "track-label": "resend-security-code"
-        }
-      } %>
-    <% end %>
-  </div>
-</div>
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("mfa.phone.resend.fields.submit.label"),
+    margin_bottom: true,
+    data_attributes: {
+      module: "gem-track-click",
+      "track-category": "account-signin",
+      "track-action": "signin",
+      "track-label": "resend-security-code"
+    }
+  } %>
+<% end %>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,27 +1,22 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("devise.unlocks.heading"),
+  heading_level: 1,
+  font_size: "l",
+  margin_bottom: 4,
+} %>
 
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("devise.unlocks.heading"),
-      heading_level: 1,
-      font_size: "l",
-      margin_bottom: 4,
-    } %>
+<%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: t("devise.unlocks.label")
+    },
+    name: "user[email]",
+    id: "user_email",
+    type: "email",
+    error_message: resource.errors.messages[:email][0],
+  } %>
 
-    <%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: t("devise.unlocks.label")
-        },
-        name: "user[email]",
-        id: "user_email",
-        type: "email",
-        error_message: resource.errors.messages[:email][0],
-      } %>
-
-      <%= render "govuk_publishing_components/components/button", {
-        text: t("devise.unlocks.resend")
-      } %>
-    <% end %>
-  </div>
-</div>
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("devise.unlocks.resend")
+  } %>
+<% end %>

--- a/app/views/edit_consent/cookie.html.erb
+++ b/app/views/edit_consent/cookie.html.erb
@@ -1,56 +1,51 @@
 <% content_for :title, t("devise.registrations.your_information.fields.cookie_consent.heading") %>
 <% content_for :location, "manage" %>
+<% content_for :account_navigation do %>
+  <%= render "account-navigation", page_is: yield(:location) %>
+<% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-third">
-    <%= render "account-navigation", page_is: yield(:location) %>
-  </div>
+<%= render "govuk_publishing_components/components/back_link", { href: account_manage_path } %>
+<%= form_with(
+  url: edit_user_consent_cookie_url,
+  method: :post,
+  data: {
+    module: "track-form",
+    "track-category": "account-manage"
+  }
+) do %>
 
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/back_link", { href: account_manage_path } %>
-    <%= form_with(
-      url: edit_user_consent_cookie_url,
-      method: :post,
-      data: {
-        module: "track-form",
-        "track-category": "account-manage"
+  <%= render "govuk_publishing_components/components/radio", {
+    name: "cookie_consent",
+    heading: yield(:title),
+    heading_size: "l",
+    is_page_heading: true,
+    items: [
+      {
+        value: "yes",
+        text: t("devise.registrations.your_information.fields.cookie_consent.yes"),
+        checked: current_user.cookie_consent,
+        data_attributes: {
+          "track-action": "personal-information-cookies"
+        }
+      },
+      {
+        value: "no",
+        text: t("devise.registrations.your_information.fields.cookie_consent.no"),
+        checked: !current_user.cookie_consent,
+        data_attributes: {
+          "track-action": "personal-information-cookies"
+        }
       }
-    ) do %>
+    ]
+  } %>
 
-      <%= render "govuk_publishing_components/components/radio", {
-        name: "cookie_consent",
-        heading: yield(:title),
-        heading_size: "l",
-        is_page_heading: true,
-        items: [
-          {
-            value: "yes",
-            text: t("devise.registrations.your_information.fields.cookie_consent.yes"),
-            checked: current_user.cookie_consent,
-            data_attributes: {
-              "track-action": "personal-information-cookies"
-            }
-          },
-          {
-            value: "no",
-            text: t("devise.registrations.your_information.fields.cookie_consent.no"),
-            checked: !current_user.cookie_consent,
-            data_attributes: {
-              "track-action": "personal-information-cookies"
-            }
-          }
-        ]
-      } %>
-
-      <%= render "govuk_publishing_components/components/button", {
-        text: t("devise.registrations.your_information.fields.submit.update_label"),
-        inline_layout: true,
-      } %>
-      <span class="govuk-body"><%= t("general.or") %></span>
-      <%= link_to t("general.cancel"),
-        account_manage_path,
-        class: "govuk-body govuk-link"
-      %>
-    <% end %>
-  </div>
-</div>
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("devise.registrations.your_information.fields.submit.update_label"),
+    inline_layout: true,
+  } %>
+  <span class="govuk-body"><%= t("general.or") %></span>
+  <%= link_to t("general.cancel"),
+    account_manage_path,
+    class: "govuk-body govuk-link"
+  %>
+<% end %>

--- a/app/views/edit_consent/feedback.html.erb
+++ b/app/views/edit_consent/feedback.html.erb
@@ -1,56 +1,51 @@
 <% content_for :title, t("devise.registrations.your_information.fields.feedback_consent.heading") %>
 <% content_for :location, "manage" %>
+<% content_for :account_navigation do %>
+  <%= render "account-navigation", page_is: yield(:location) %>
+<% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-third">
-    <%= render "account-navigation", page_is: yield(:location) %>
-  </div>
+<%= render "govuk_publishing_components/components/back_link", { href: account_manage_path } %>
+<%= form_with(
+  url: edit_user_consent_feedback_url,
+  method: :post,
+  data: {
+    module: "track-form",
+    "track-category": "account-manage"
+  }
+) do %>
 
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/back_link", { href: account_manage_path } %>
-    <%= form_with(
-      url: edit_user_consent_feedback_url,
-      method: :post,
-      data: {
-        module: "track-form",
-        "track-category": "account-manage"
+  <%= render "govuk_publishing_components/components/radio", {
+    name: "feedback_consent",
+    heading: yield(:title),
+    heading_size: "l",
+    is_page_heading: true,
+    items: [
+      {
+        value: "yes",
+        text: t("devise.registrations.your_information.fields.feedback_consent.yes"),
+        checked: current_user.feedback_consent,
+        data_attributes: {
+          "track-action": "personal-information-feedback"
+        }
+      },
+      {
+        value: "no",
+        text: t("devise.registrations.your_information.fields.feedback_consent.no"),
+        checked: !current_user.feedback_consent,
+        data_attributes: {
+          "track-action": "personal-information-feedback"
+        }
       }
-    ) do %>
+    ]
+  } %>
 
-      <%= render "govuk_publishing_components/components/radio", {
-        name: "feedback_consent",
-        heading: yield(:title),
-        heading_size: "l",
-        is_page_heading: true,
-        items: [
-          {
-            value: "yes",
-            text: t("devise.registrations.your_information.fields.feedback_consent.yes"),
-            checked: current_user.feedback_consent,
-            data_attributes: {
-              "track-action": "personal-information-feedback"
-            }
-          },
-          {
-            value: "no",
-            text: t("devise.registrations.your_information.fields.feedback_consent.no"),
-            checked: !current_user.feedback_consent,
-            data_attributes: {
-              "track-action": "personal-information-feedback"
-            }
-          }
-        ]
-      } %>
-
-      <%= render "govuk_publishing_components/components/button", {
-        text: t("devise.registrations.your_information.fields.submit.update_label"),
-        inline_layout: true,
-      } %>
-      <span class="govuk-body"><%= t("general.or") %></span>
-      <%= link_to t("general.cancel"),
-        account_manage_path,
-        class: "govuk-body govuk-link"
-      %>
-    <% end %>
-  </div>
-</div>
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("devise.registrations.your_information.fields.submit.update_label"),
+    inline_layout: true,
+  } %>
+  <span class="govuk-body"><%= t("general.or") %></span>
+  <%= link_to t("general.cancel"),
+    account_manage_path,
+    class: "govuk-body govuk-link"
+  %>
+<% end %>

--- a/app/views/edit_phone/code.html.erb
+++ b/app/views/edit_phone/code.html.erb
@@ -1,45 +1,41 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("mfa.phone.code.change_heading"),
-      heading_level: 1,
-      margin_top: 0,
-      margin_bottom: 3,
-    } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("mfa.phone.code.change_heading"),
+  heading_level: 1,
+  margin_top: 0,
+  margin_bottom: 3,
+} %>
 
-    <% t("mfa.phone.code.description_with_phone_number", phone_number: MultiFactorAuth.formatted_phone_number(current_user.unconfirmed_phone)).each do |msg| %>
-      <p class="govuk-body"><%= sanitize(msg) %></p>
-    <% end %>
+<% t("mfa.phone.code.description_with_phone_number", phone_number: MultiFactorAuth.formatted_phone_number(current_user.unconfirmed_phone)).each do |msg| %>
+  <p class="govuk-body"><%= sanitize(msg) %></p>
+<% end %>
 
-    <%= form_with(url: edit_user_registration_phone_verify_path, method: :post, html: { autocomplete: "off" }) do %>
-      <%= render "govuk_publishing_components/components/input", {
-        label: { text: t("mfa.phone.code.fields.phone_code.label") },
-        name: "phone_code",
-        maxlength: 6,
-        type: "number",
-        error_message: sanitize(@phone_code_error_message),
-        width: 5,
-      } %>
+<%= form_with(url: edit_user_registration_phone_verify_path, method: :post, html: { autocomplete: "off" }) do %>
+  <%= render "govuk_publishing_components/components/input", {
+    label: { text: t("mfa.phone.code.fields.phone_code.label") },
+    name: "phone_code",
+    maxlength: 6,
+    type: "number",
+    error_message: sanitize(@phone_code_error_message),
+    width: 5,
+  } %>
 
-      <%= render "govuk_publishing_components/components/button", {
-        text: t("mfa.phone.code.fields.submit.label"),
-        margin_bottom: true
-      } %>
-    <% end %>
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("mfa.phone.code.fields.submit.label"),
+    margin_bottom: true
+  } %>
+<% end %>
 
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("mfa.phone.code.not_received.change_heading"),
-      heading_level: 2,
-      margin_bottom: 4,
-      font_size: "m",
-    } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("mfa.phone.code.not_received.change_heading"),
+  heading_level: 2,
+  margin_bottom: 4,
+  font_size: "m",
+} %>
 
-    <p class="govuk-body">
-      <%= sanitize(t("mfa.phone.code.not_received.resend_message", link: edit_user_registration_phone_resend_path)) %>
-    </p>
+<p class="govuk-body">
+  <%= sanitize(t("mfa.phone.code.not_received.resend_message", link: edit_user_registration_phone_resend_path)) %>
+</p>
 
-    <p class="govuk-body">
-      <%= sanitize(t("mfa.phone.code.not_received.change_number_message", link: edit_user_registration_phone_path,  phone_number: MultiFactorAuth.formatted_phone_number(current_user.unconfirmed_phone))) %>
-    </p>
-  </div>
-</div>
+<p class="govuk-body">
+  <%= sanitize(t("mfa.phone.code.not_received.change_number_message", link: edit_user_registration_phone_path,  phone_number: MultiFactorAuth.formatted_phone_number(current_user.unconfirmed_phone))) %>
+</p>

--- a/app/views/edit_phone/resend.html.erb
+++ b/app/views/edit_phone/resend.html.erb
@@ -1,21 +1,17 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/back_link", { href: edit_user_registration_phone_code_path } %>
+<%= render "govuk_publishing_components/components/back_link", { href: edit_user_registration_phone_code_path } %>
 
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("mfa.phone.resend.heading"),
-      heading_level: 1,
-      font_size: "xl",
-      margin_top: 0,
-      margin_bottom: 3,
-    } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("mfa.phone.resend.heading"),
+  heading_level: 1,
+  font_size: "xl",
+  margin_top: 0,
+  margin_bottom: 3,
+} %>
 
-    <p class="govuk-body"><%= t("mfa.phone.resend.description") %></p>
+<p class="govuk-body"><%= t("mfa.phone.resend.description") %></p>
 
-    <%= form_with(url: edit_user_registration_phone_code_path, method: :post) do %>
-      <%= render "govuk_publishing_components/components/button", {
-        text: t("mfa.phone.resend.fields.submit.label"),
-      } %>
-    <% end %>
-  </div>
-</div>
+<%= form_with(url: edit_user_registration_phone_code_path, method: :post) do %>
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("mfa.phone.resend.fields.submit.label"),
+  } %>
+<% end %>

--- a/app/views/edit_phone/show.html.erb
+++ b/app/views/edit_phone/show.html.erb
@@ -1,55 +1,50 @@
 <% content_for :location, "manage" %>
+<% content_for :account_navigation do %>
+  <%= render "account-navigation", page_is: yield(:location) %>
+<% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-third">
-    <%= render "account-navigation", page_is: yield(:location) %>
-  </div>
+<%= render "govuk_publishing_components/components/back_link", { href: account_manage_path } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("mfa.phone.update.start.heading"),
+  heading_level: 1,
+  font_size: "l",
+  margin_bottom: 6,
+} %>
 
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/back_link", { href: account_manage_path } %>
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("mfa.phone.update.start.heading"),
-      heading_level: 1,
-      font_size: "l",
-      margin_bottom: 6,
-    } %>
+<p class="govuk-body">
+  <%= t("mfa.phone.update.start.message") %>
+</p>
 
-    <p class="govuk-body">
-      <%= t("mfa.phone.update.start.message") %>
-    </p>
+<%= render "govuk_publishing_components/components/inset_text", {
+  text: t("mfa.phone.update.start.current", phone_number: MultiFactorAuth.formatted_phone_number(current_user.phone))
+} %>
 
-    <%= render "govuk_publishing_components/components/inset_text", {
-      text: t("mfa.phone.update.start.current", phone_number: MultiFactorAuth.formatted_phone_number(current_user.phone))
-    } %>
+<%= form_with(url: edit_user_registration_phone_code_path, method: :post) do %>
+  <%= render "govuk_publishing_components/components/input", {
+    label: { text: t("mfa.phone.update.start.fields.phone.label") },
+    name: "phone",
+    type: "tel",
+    error_message: @phone_error_message,
+  } %>
 
-    <%= form_with(url: edit_user_registration_phone_code_path, method: :post) do %>
-      <%= render "govuk_publishing_components/components/input", {
-        label: { text: t("mfa.phone.update.start.fields.phone.label") },
-        name: "phone",
-        type: "tel",
-        error_message: @phone_error_message,
-      } %>
+  <%= render "govuk_publishing_components/components/show_password", {
+    label: {
+      text: t("devise.registrations.edit.fields.current_password.label"),
+    },
+    heading_size: "m",
+    hint: t("devise.registrations.edit.fields.current_password.hint"),
+    name: "current_password",
+    error_message: @password_error_message,
+    autocomplete: "current-password",
+  } %>
 
-      <%= render "govuk_publishing_components/components/show_password", {
-        label: {
-          text: t("devise.registrations.edit.fields.current_password.label"),
-        },
-        heading_size: "m",
-        hint: t("devise.registrations.edit.fields.current_password.hint"),
-        name: "current_password",
-        error_message: @password_error_message,
-        autocomplete: "current-password",
-      } %>
-
-      <%= render "govuk_publishing_components/components/button", {
-        text: t("mfa.phone.update.start.fields.submit.label"),
-        inline_layout: true,
-      } %>
-      <span class="govuk-body"><%= t("general.or") %></span>
-      <%= link_to t("general.cancel"),
-        account_manage_path,
-        class: "govuk-body govuk-link"
-      %>
-    <% end %>
-  </div>
-</div>
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("mfa.phone.update.start.fields.submit.label"),
+    inline_layout: true,
+  } %>
+  <span class="govuk-body"><%= t("general.or") %></span>
+  <%= link_to t("general.cancel"),
+    account_manage_path,
+    class: "govuk-body govuk-link"
+  %>
+<% end %>

--- a/app/views/feedback/show.html.erb
+++ b/app/views/feedback/show.html.erb
@@ -24,68 +24,64 @@
   } %>
 <% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("feedback.show.heading"),
-      heading_level: 1,
-      margin_bottom: 4,
-      font_size: "xl"
-    } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("feedback.show.heading"),
+  heading_level: 1,
+  margin_bottom: 4,
+  font_size: "xl"
+} %>
 
-    <% if defined?(@error_items) %>
-      <%= render "govuk_publishing_components/components/error_summary", {
-        id: "error-summary",
-        title: t("feedback.show.errors.summary"),
-        items: @error_items
-      } %>
-    <% end %>
+<% if defined?(@error_items) %>
+  <%= render "govuk_publishing_components/components/error_summary", {
+    id: "error-summary",
+    title: t("feedback.show.errors.summary"),
+    items: @error_items
+  } %>
+<% end %>
 
-    <p class="govuk-body"><%= t("feedback.show.caption") %></p>
+<p class="govuk-body"><%= t("feedback.show.caption") %></p>
 
-    <%= render "govuk_publishing_components/components/inset_text", {
-      text: sanitize(t("feedback.show.inset_text"))
-    } %>
+<%= render "govuk_publishing_components/components/inset_text", {
+  text: sanitize(t("feedback.show.inset_text"))
+} %>
 
-    <p class="govuk-body"><%= t("feedback.show.advice") %></p>
+<p class="govuk-body"><%= t("feedback.show.advice") %></p>
 
-    <%= form_tag do %>
-      <%= render "govuk_publishing_components/components/textarea", {
-        label: {
-          text: t("feedback.show.fields.comments.label"),
-          heading_size: "s",
-        },
-        name: "comments",
-        id: "comments",
-        error_message: error_items("comments", @error_items),
-        value: @form_responses[:comments],
-      } %>
+<%= form_tag do %>
+  <%= render "govuk_publishing_components/components/textarea", {
+    label: {
+      text: t("feedback.show.fields.comments.label"),
+      heading_size: "s",
+    },
+    name: "comments",
+    id: "comments",
+    error_message: error_items("comments", @error_items),
+    value: @form_responses[:comments],
+  } %>
 
-      <%= render "govuk_publishing_components/components/radio", {
-        heading: t("feedback.show.fields.user_requires_response.label"),
-        heading_size: "s",
-        items: [
-          {
-            value: "yes",
-            text: t("feedback.show.fields.user_requires_response.options.option_yes.label"),
-            checked: @form_responses[:user_requires_response] == "yes",
-            conditional: contact_details,
-          },
-          {
-            value: "no",
-            text: t("feedback.show.fields.user_requires_response.options.option_no.label"),
-            checked: @form_responses[:user_requires_response] == "no",
-          },
-        ],
-        name: "user_requires_response",
-        id: "user_requires_response",
-        error_message: error_items("user_requires_response", @error_items),
-      } %>
+  <%= render "govuk_publishing_components/components/radio", {
+    heading: t("feedback.show.fields.user_requires_response.label"),
+    heading_size: "s",
+    items: [
+      {
+        value: "yes",
+        text: t("feedback.show.fields.user_requires_response.options.option_yes.label"),
+        checked: @form_responses[:user_requires_response] == "yes",
+        conditional: contact_details,
+      },
+      {
+        value: "no",
+        text: t("feedback.show.fields.user_requires_response.options.option_no.label"),
+        checked: @form_responses[:user_requires_response] == "no",
+      },
+    ],
+    name: "user_requires_response",
+    id: "user_requires_response",
+    error_message: error_items("user_requires_response", @error_items),
+  } %>
 
-      <%= render "govuk_publishing_components/components/button", {
-        text: t("feedback.show.fields.submit.label"),
-        margin_bottom: 3,
-      } %>
-    <% end %>
-  </div>
-</div>
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("feedback.show.fields.submit.label"),
+    margin_bottom: 3,
+  } %>
+<% end %>

--- a/app/views/feedback/submit.html.erb
+++ b/app/views/feedback/submit.html.erb
@@ -1,12 +1,8 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/panel", {
-      title: t("feedback.submit.heading"),
-      heading_level: 1,
-    } %>
+<%= render "govuk_publishing_components/components/panel", {
+  title: t("feedback.submit.heading"),
+  heading_level: 1,
+} %>
 
-    <p class="govuk-body">
-      <%= sanitize(t("feedback.submit.call_to_action")) %>
-    </p>
-  </div>
-</div>
+<p class="govuk-body">
+  <%= sanitize(t("feedback.submit.call_to_action")) %>
+</p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -71,10 +71,18 @@
       phase: "alpha",
       message: message
     } %>
-
-    <main class="govuk-main-wrapper app-main-class" id="main-content" role="main">
-      <%= yield %>
-    </main>
+    <div class="govuk-grid-row govuk-main-wrapper">
+      <% if content_for?(:account_navigation) %>
+        <div class="govuk-grid-column-one-third">
+          <%= yield :account_navigation %>
+        </div>
+      <% end %>
+      <div class="govuk-grid-column-two-thirds">
+        <main class="app-main-class" id="main-content" role="main">
+          <%= yield %>
+        </main>
+      </div>
+    </div>
   </div>
 
   <% if feedback_enabled_page %>

--- a/app/views/manage/show.html.erb
+++ b/app/views/manage/show.html.erb
@@ -1,107 +1,102 @@
 <% content_for :title, t("account.manage.heading") %>
 <% content_for :location, "manage" %>
+<% content_for :account_navigation do %>
+  <%= render "account-navigation", page_is: yield(:location) %>
+<% end %>
 
 <% if show_confirmation_reminder? %>
   <%= render "email-confirmation-reminder" %>
 <% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-third">
-    <%= render "account-navigation", page_is: yield(:location) %>
-  </div>
+<%= render "govuk_publishing_components/components/heading", {
+  text: yield(:title),
+  heading_level: 1,
+  font_size: "l",
+  margin_bottom: 7,
+} %>
 
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: yield(:title),
-      heading_level: 1,
-      font_size: "l",
-      margin_bottom: 7,
-    } %>
+<% if flash[:notice] %>
+  <% if flash_as_notice(flash[:notice]) %>
+    <%= render "govuk_publishing_components/components/notice", { description_text: flash[:notice] } %>
+  <% else %>
+    <%= render "govuk_publishing_components/components/success_alert", { message: flash[:notice] } %>
+  <% end %>
+<% end%>
 
-    <% if flash[:notice] %>
-      <% if flash_as_notice(flash[:notice]) %>
-        <%= render "govuk_publishing_components/components/notice", { description_text: flash[:notice] } %>
-      <% else %>
-        <%= render "govuk_publishing_components/components/success_alert", { message: flash[:notice] } %>
-      <% end %>
-    <% end%>
-
-    <div class="accounts-summary-list">
-      <%= render "govuk_publishing_components/components/summary_list", {
-        title: t("account.manage.details.heading"),
-        heading_level: 2,
-        items: core_account_details
-      } %>
-    </div>
-
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("account.manage.privacy.heading"),
-      heading_level: 2,
-      font_size: "m",
-      margin_bottom: 4,
-    } %>
-
-    <div class="accounts-summary-list accounts-summary-list--wide">
-      <dl class="govuk-summary-list">
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            <p class="govuk-body accounts-summary-list__key-heading"><%= t("account.manage.privacy.cookies_question") %></p>
-            <p class="govuk-body accounts-summary-list__key-description"><%= t("account.manage.privacy.cookies_description") %></p>
-          </dt>
-          <dd class="govuk-summary-list__value">
-            <%= current_user.cookie_consent == true ? t("general.yes") : t("general.no") %>
-          </dd>
-          <dd class="govuk-summary-list__actions">
-            <a href="<%= edit_user_consent_cookie_path %>"
-              class="govuk-link"
-              title="<%= t("general.change") %> <%= t("account.manage.privacy.cookies_link_extra") %>"
-              data-module = "gem-track-click"
-              data-track-category = "account-manage"
-              data-track-action = "manage-account"
-              data-track-label = "personal-information-cookies">
-              <%= t("general.change") %>
-              <span class="govuk-visually-hidden"><%= t("account.manage.privacy.cookies_link_extra") %></span>
-            </a>
-          </dd>
-        </div>
-
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            <p class="govuk-body accounts-summary-list__key-heading"><%= t("account.manage.privacy.email_question") %></p>
-            <p class="govuk-body accounts-summary-list__key-description"><%= t("account.manage.privacy.email_description") %></p>
-          </dt>
-          <dd class="govuk-summary-list__value">
-            <%= current_user.feedback_consent == true ? t("general.yes") : t("general.no") %>
-          </dd>
-          <dd class="govuk-summary-list__actions">
-            <a href="<%= edit_user_consent_feedback_path %>"
-              class="govuk-link"
-              title="<%= t("general.change") %> <%= t("account.manage.privacy.email_link_extra") %>"
-              data-module = "gem-track-click"
-              data-track-category = "account-manage"
-              data-track-action = "manage-account"
-              data-track-label = "personal-information-feedback">
-              <%= t("general.change") %>
-              <span class="govuk-visually-hidden"><%= t("account.manage.privacy.email_link_extra") %></span>
-            </a>
-          </dd>
-        </div>
-      </dl>
-    </div>
-
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("account.manage.delete.heading"),
-      heading_level: 2,
-      font_size: "m",
-      margin_bottom: 4,
-    } %>
-
-    <p class="govuk-body"><%= t("account.manage.delete.description") %></p>
-
-    <p class="govuk-body">
-      <a href="<%= account_delete_path %>" class="govuk-link" data-module="gem-track-click" data-track-category="account-manage" data-track-action="manage-account" data-track-label="delete-account">
-        <%= t("account.manage.delete.link") %>
-      </a>
-    </p>
-  </div>
+<div class="accounts-summary-list">
+  <%= render "govuk_publishing_components/components/summary_list", {
+    title: t("account.manage.details.heading"),
+    heading_level: 2,
+    items: core_account_details
+  } %>
 </div>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("account.manage.privacy.heading"),
+  heading_level: 2,
+  font_size: "m",
+  margin_bottom: 4,
+} %>
+
+<div class="accounts-summary-list accounts-summary-list--wide">
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <p class="govuk-body accounts-summary-list__key-heading"><%= t("account.manage.privacy.cookies_question") %></p>
+        <p class="govuk-body accounts-summary-list__key-description"><%= t("account.manage.privacy.cookies_description") %></p>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= current_user.cookie_consent == true ? t("general.yes") : t("general.no") %>
+      </dd>
+      <dd class="govuk-summary-list__actions">
+        <a href="<%= edit_user_consent_cookie_path %>"
+          class="govuk-link"
+          title="<%= t("general.change") %> <%= t("account.manage.privacy.cookies_link_extra") %>"
+          data-module = "gem-track-click"
+          data-track-category = "account-manage"
+          data-track-action = "manage-account"
+          data-track-label = "personal-information-cookies">
+          <%= t("general.change") %>
+          <span class="govuk-visually-hidden"><%= t("account.manage.privacy.cookies_link_extra") %></span>
+        </a>
+      </dd>
+    </div>
+
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <p class="govuk-body accounts-summary-list__key-heading"><%= t("account.manage.privacy.email_question") %></p>
+        <p class="govuk-body accounts-summary-list__key-description"><%= t("account.manage.privacy.email_description") %></p>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= current_user.feedback_consent == true ? t("general.yes") : t("general.no") %>
+      </dd>
+      <dd class="govuk-summary-list__actions">
+        <a href="<%= edit_user_consent_feedback_path %>"
+          class="govuk-link"
+          title="<%= t("general.change") %> <%= t("account.manage.privacy.email_link_extra") %>"
+          data-module = "gem-track-click"
+          data-track-category = "account-manage"
+          data-track-action = "manage-account"
+          data-track-label = "personal-information-feedback">
+          <%= t("general.change") %>
+          <span class="govuk-visually-hidden"><%= t("account.manage.privacy.email_link_extra") %></span>
+        </a>
+      </dd>
+    </div>
+  </dl>
+</div>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("account.manage.delete.heading"),
+  heading_level: 2,
+  font_size: "m",
+  margin_bottom: 4,
+} %>
+
+<p class="govuk-body"><%= t("account.manage.delete.description") %></p>
+
+<p class="govuk-body">
+  <a href="<%= account_delete_path %>" class="govuk-link" data-module="gem-track-click" data-track-category="account-manage" data-track-action="manage-account" data-track-label="delete-account">
+    <%= t("account.manage.delete.link") %>
+  </a>
+</p>

--- a/app/views/security/report.html.erb
+++ b/app/views/security/report.html.erb
@@ -1,32 +1,26 @@
 <% content_for :title, t("account.security.report.heading") %>
 <% content_for :location, "security" %>
+<% content_for :account_navigation do %>
+  <%= render "account-navigation", page_is: yield(:location) %>
+<% end %>
+<%= render "govuk_publishing_components/components/back_link", {
+  href: account_security_path
+} %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-third">
-    <%= render "account-navigation", page_is: yield(:location) %>
-  </div>
+<%= render "govuk_publishing_components/components/heading", {
+  text: yield(:title),
+  heading_level: 1,
+  font_size: "l",
+  margin_bottom: 4,
+} %>
+<%= sanitize(t("account.security.report.description")) %>
 
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/back_link", {
-      href: account_security_path
-    } %>
+<%= render "govuk_publishing_components/components/button", {
+  text: t("account.security.report.action.report"),
+  href: feedback_form_path,
+  inline_layout: true
+} %>
 
-    <%= render "govuk_publishing_components/components/heading", {
-      text: yield(:title),
-      heading_level: 1,
-      font_size: "l",
-      margin_bottom: 4,
-    } %>
-    <%= sanitize(t("account.security.report.description")) %>
-
-    <%= render "govuk_publishing_components/components/button", {
-      text: t("account.security.report.action.report"),
-      href: feedback_form_path,
-      inline_layout: true
-    } %>
-
-    <p class="govuk-body gem-c-button--inline">
-      <%= sanitize(t("account.security.report.action.cancel", link: account_security_path)) %>
-    </p>
-  </div>
-</div>
+<p class="govuk-body gem-c-button--inline">
+  <%= sanitize(t("account.security.report.action.cancel", link: account_security_path)) %>
+</p>

--- a/app/views/security/show.html.erb
+++ b/app/views/security/show.html.erb
@@ -1,99 +1,93 @@
 <% content_for :title, t("account.security.heading") %>
 <% content_for :location, "security" %>
+<% content_for :account_navigation do %>
+  <%= render "account-navigation", page_is: yield(:location) %>
+<% end %>
 
 <% if show_confirmation_reminder? %>
   <%= render "email-confirmation-reminder" %>
 <% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-third">
-    <%= render "account-navigation", page_is: yield(:location) %>
-  </div>
+<%= render "govuk_publishing_components/components/heading", {
+  text: yield(:title),
+  heading_level: 1,
+  font_size: "l",
+  margin_bottom: 4,
+} %>
 
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: yield(:title),
-      heading_level: 1,
-      font_size: "l",
-      margin_bottom: 4,
-    } %>
-
-    <div class="govuk-!-margin-bottom-9">
-      <%= sanitize(t("account.security.description")) %>
-    </div>
-
-    <div class="govuk-!-margin-bottom-9">
-      <%= render "govuk_publishing_components/components/heading", {
-        text: t("account.security.account_use"),
-        heading_level: 2,
-        font_size: "m",
-        margin_bottom: 4,
-      } %>
-
-      <% if @data_exchanges.empty? %>
-        <p class="govuk-body">
-          <%= t("account.data_exchange.no_data_exchanged") %>
-        <p>
-      <% else %>
-        <dl class="govuk-summary-list">
-          <% @data_exchanges.each do |exchange| %>
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                <%= exchange[:application_name] %>
-              </dt>
-              <dd class="govuk-summary-list__value">
-                <span class="date-text">
-                  <%= date_with_time_ago(exchange[:created_at]) %>
-                </span>
-                <% unless exchange[:scopes].empty? %>
-                  <br>
-                  <%= t("account.data_exchange.used") %>
-                  <%= sanitize(exchange[:scopes].map { |scope| t("account.data_exchange.scope.#{scope}") }.to_sentence) %>
-                <% end %>
-              </dd>
-            </div>
-          <% end %>
-        </dl>
-      <% end %>
-    </div>
-
-    <% if @activity.empty? %>
-      <p class="govuk-body">
-        <%= t("account.security.no_activity_found") %>
-      <p>
-    <% else %>
-      <%= render "govuk_publishing_components/components/heading", {
-        text: t("account.security.activity"),
-        heading_level: 2,
-        font_size: "m",
-        margin_bottom: 4,
-      } %>
-
-      <dl class="govuk-summary-list">
-        <% @activity.each do |activity| %>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              <%= t("account.security.event.#{activity.name}") %>
-            </dt>
-            <dd class="govuk-summary-list__value">
-              <span class="date-text">
-                <%= date_with_time_ago(activity.created_at) %>
-              </span>
-              <br>
-                <%= activity.client %>
-              <br>
-              <%= "#{activity.ip_address_country} (#{activity.ip_address})" %>
-              <br>
-               <p class="govuk-body">
-                <a class="govuk-link" href="<%= account_security_report_path %>" data-module="gem-track-click" data-track-category="account-manage" data-track-action="security" data-track-label="not-me">
-                  <%= t("account.security.report_suspicious_activity") %>
-                </a>
-              </p>
-            </dd>
-          </div>
-        <% end %>
-      </dl>
-    <% end %>
-
-  </div>
+<div class="govuk-!-margin-bottom-9">
+  <%= sanitize(t("account.security.description")) %>
 </div>
+
+<div class="govuk-!-margin-bottom-9">
+  <%= render "govuk_publishing_components/components/heading", {
+    text: t("account.security.account_use"),
+    heading_level: 2,
+    font_size: "m",
+    margin_bottom: 4,
+  } %>
+
+  <% if @data_exchanges.empty? %>
+    <p class="govuk-body">
+      <%= t("account.data_exchange.no_data_exchanged") %>
+    <p>
+  <% else %>
+    <dl class="govuk-summary-list">
+      <% @data_exchanges.each do |exchange| %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            <%= exchange[:application_name] %>
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <span class="date-text">
+              <%= date_with_time_ago(exchange[:created_at]) %>
+            </span>
+            <% unless exchange[:scopes].empty? %>
+              <br>
+              <%= t("account.data_exchange.used") %>
+              <%= sanitize(exchange[:scopes].map { |scope| t("account.data_exchange.scope.#{scope}") }.to_sentence) %>
+            <% end %>
+          </dd>
+        </div>
+      <% end %>
+    </dl>
+  <% end %>
+</div>
+
+<% if @activity.empty? %>
+  <p class="govuk-body">
+    <%= t("account.security.no_activity_found") %>
+  <p>
+<% else %>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: t("account.security.activity"),
+    heading_level: 2,
+    font_size: "m",
+    margin_bottom: 4,
+  } %>
+
+  <dl class="govuk-summary-list">
+    <% @activity.each do |activity| %>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= t("account.security.event.#{activity.name}") %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <span class="date-text">
+            <%= date_with_time_ago(activity.created_at) %>
+          </span>
+          <br>
+            <%= activity.client %>
+          <br>
+          <%= "#{activity.ip_address_country} (#{activity.ip_address})" %>
+          <br>
+           <p class="govuk-body">
+            <a class="govuk-link" href="<%= account_security_report_path %>" data-module="gem-track-click" data-track-category="account-manage" data-track-action="security" data-track-label="not-me">
+              <%= t("account.security.report_suspicious_activity") %>
+            </a>
+          </p>
+        </dd>
+      </div>
+    <% end %>
+  </dl>
+<% end %>

--- a/app/views/standard_errors/generic.html.erb
+++ b/app/views/standard_errors/generic.html.erb
@@ -1,11 +1,7 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("standard_errors.#{@error}.heading"),
-      heading_level: 1,
-      margin_bottom: 3,
-    } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("standard_errors.#{@error}.heading"),
+  heading_level: 1,
+  margin_bottom: 3,
+} %>
 
-    <%= sanitize(t("standard_errors.#{@error}.content")) %>
-  </div>
-</div>
+<%= sanitize(t("standard_errors.#{@error}.content")) %>

--- a/spec/feature/change_phone_spec.rb
+++ b/spec/feature/change_phone_spec.rb
@@ -122,8 +122,10 @@ RSpec.feature "Change Phone" do
   end
 
   def go_to_change_number_page
-    within "#main-content" do
+    within ".accounts-menu" do
       click_on "Manage your account"
+    end
+    within "#main-content" do
       click_on "Change Mobile number"
     end
   end


### PR DESCRIPTION
## What
Restructured the markup so that the main content of the page on the account manager does not contain navigation.
Achieved this by moving the grid layout into the application layout file. The account navigation was moved into a `account_navigation` content block which, if present, is inserted before `main` in the application layout file. 
The `main` element is now a child element of the grid instead of containing the grid as it did before.


## Why
The account manager has a "Skip to main content" link, whose role is to help users skip over the navigation and reach the primary content on the page. 
The purpose of this navigation mechanism is to help the user jump over the navigation content and straight to the main information. However, in our case, the main information itself contains navigation content.


### Before: navigation inside `main`
<img width="1354" alt="Screenshot 2021-01-04 at 14 54 55" src="https://user-images.githubusercontent.com/7116819/104163496-6cf13100-53ee-11eb-8518-a1d69d0263dd.png">

### After: navigation outside `main`
<img width="1499" alt="Screenshot 2021-01-11 at 09 23 35" src="https://user-images.githubusercontent.com/7116819/104163698-bf325200-53ee-11eb-88db-55fea63623b7.png">


https://trello.com/c/hw4HVWsC/542-main-content-should-not-contain-navigation