### PR TITLE
Record the country of a security activity's IP address in the database

### DIFF
--- a/app/controllers/security_controller.rb
+++ b/app/controllers/security_controller.rb
@@ -2,7 +2,7 @@ class SecurityController < ApplicationController
   before_action :authenticate_user!
 
   def show
-    @activity = current_user.security_activities.show_on_security_page.order(created_at: :desc)
+    @activity = current_user.security_activities.show_on_security_page.order(created_at: :desc).map(&:fill_missing_country)
     @data_exchanges = dedup_nearby(current_user.data_activities.where.not(oauth_application_id: AccountManagerApplication.application.id).order(created_at: :desc))
       .compact
       .map { |a| activity_to_exchange(a) }

--- a/app/helpers/security_helper.rb
+++ b/app/helpers/security_helper.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-require "geocoder"
-
-module SecurityHelper
-  def ip_to_country(ip)
-    Geocoder.search(ip)&.first&.country
-  end
-end

--- a/app/models/security_activity.rb
+++ b/app/models/security_activity.rb
@@ -114,6 +114,14 @@ class SecurityActivity < ApplicationRecord
     }.compact
   end
 
+  def fill_missing_country
+    if ip_address_country.nil?
+      update!(ip_address_country: SecurityActivity.ip_to_country(ip_address))
+    end
+
+    self
+  end
+
 protected
 
   def validate_event_mappable

--- a/app/models/security_activity.rb
+++ b/app/models/security_activity.rb
@@ -1,3 +1,5 @@
+require "geocoder"
+
 class SecurityActivity < ApplicationRecord
   EVENTS = [
     # logging in
@@ -28,7 +30,7 @@ class SecurityActivity < ApplicationRecord
   EVENTS_REQUIRING_APPLICATION = EVENTS.select(&:require_application?)
   EVENTS_REQUIRING_FACTOR = EVENTS.select(&:require_factor?)
 
-  VALID_OPTIONS = %i[user user_id oauth_application oauth_application_id ip_address user_agent user_agent_id factor notes analytics].freeze
+  VALID_OPTIONS = %i[user user_id oauth_application oauth_application_id ip_address ip_address_country user_agent user_agent_id factor notes analytics].freeze
 
   VALID_FACTORS = %w[sms].freeze
 
@@ -62,9 +64,19 @@ class SecurityActivity < ApplicationRecord
       attributes.merge!(user_agent_id: UserAgent.find_or_create_by!(name: options[:user_agent_name]).id)
     end
 
+    if attributes[:ip_address] && !attributes[:ip_address_country]
+      attributes[:ip_address_country] = ip_to_country(attributes[:ip_address])
+    end
+
     event = SecurityActivity.create!(attributes)
     event.log
     event
+  end
+
+  def self.ip_to_country(ip_address)
+    Rails.cache.fetch("security_activities/ip_address/#{ip_address}", expires_in: 1.day) do
+      Geocoder.search(ip_address)&.first&.country
+    end
   end
 
   def self.of_type(event)

--- a/app/views/security/show.html.erb
+++ b/app/views/security/show.html.erb
@@ -82,7 +82,7 @@
               <br>
                 <%= activity.client %>
               <br>
-              <%= "#{ip_to_country(activity.ip_address)} (#{activity.ip_address})" %>
+              <%= "#{activity.ip_address_country} (#{activity.ip_address})" %>
               <br>
                <p class="govuk-body">
                 <a class="govuk-link" href="<%= account_security_report_path %>" data-module="gem-track-click" data-track-category="account-manage" data-track-action="security" data-track-label="not-me">

--- a/db/migrate/20210111133439_add_country_to_security_activity.rb
+++ b/db/migrate/20210111133439_add_country_to_security_activity.rb
@@ -1,0 +1,5 @@
+class AddCountryToSecurityActivity < ActiveRecord::Migration[6.0]
+  def change
+    add_column :security_activities, :ip_address_country, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_08_094047) do
+ActiveRecord::Schema.define(version: 2021_01_11_133439) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -152,6 +152,7 @@ ActiveRecord::Schema.define(version: 2021_01_08_094047) do
     t.string "notes"
     t.string "factor"
     t.string "analytics"
+    t.string "ip_address_country"
     t.index ["oauth_application_id"], name: "index_security_activities_on_oauth_application_id"
     t.index ["user_agent_id"], name: "index_security_activities_on_user_agent_id"
     t.index ["user_id"], name: "index_security_activities_on_user_id"

--- a/spec/models/security_activity_spec.rb
+++ b/spec/models/security_activity_spec.rb
@@ -150,10 +150,10 @@ RSpec.describe SecurityActivity do
           status: 200,
           body: {
             ip: ip_address,
-            country: "US",
+            country: "Narnia",
           }.to_json,
         )
-        expect(activity.ip_address_country).to_not be_nil
+        expect(activity.ip_address_country).to eq("Narnia")
       end
     end
   end

--- a/spec/requests/data_exchange_spec.rb
+++ b/spec/requests/data_exchange_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-RSpec.describe "/account/your-data" do
+RSpec.describe "/account/security" do
   let(:user) { FactoryBot.create(:user) }
 
   let(:application) do
@@ -46,6 +46,26 @@ RSpec.describe "/account/your-data" do
       get account_security_path(client: application, scope: "openid email transition_checker")
 
       expect(response.body).not_to have_content(I18n.t("account.data_exchange.scope.transition_checker"))
+    end
+
+    it "fills in missing countries for security activities" do
+      activity = SecurityActivity.create!(
+        event_type: SecurityActivity::LOGIN_SUCCESS.id,
+        user_id: user.id,
+        ip_address: "1.1.1.1",
+      )
+
+      stub_request(:get, "http://ipinfo.io/#{activity.ip_address}/geo").to_return(
+        status: 200,
+        body: {
+          ip: activity.ip_address,
+          country: "Narnia",
+        }.to_json,
+      )
+
+      get account_security_path
+
+      expect(activity.reload.ip_address_country).to eq("Narnia")
     end
   end
 end


### PR DESCRIPTION
Currently we query an external API to geolocate each IP address every time we load the security page.  This is pretty slow, making the page take multiple seconds to load.  Even worse, if multiple events have the same IP, we'll geolocate the address for each one!

This PR adds a new field to the security activities table to hold the country name, which we look up (and cache) when the activity is created.  I decided to go for this denormalised approach, rather than having a table to map IP addresses to country names (like the user agent table) because IP addresses can migrate between countries, and so we can't fully denormalise it.

The field is intentionally nullable, in case the geolocation service doesn't return a result.  We don't handle that well in the frontend currently... but we didn't previously.

---

[Trello card](https://trello.com/c/beW4fOWk/548-make-security-page-less-slow)