### PR TITLE
Set location on the Delete your account view

### DIFF
--- a/app/views/delete/show.html.erb
+++ b/app/views/delete/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t("account.delete.heading") %>
-<% content_for :location, nil %>
+<% content_for :location, "manage" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-third">


### PR DESCRIPTION
The "Delete this GOV.UK account" view has an account nav on the left hand side however none of the nav items is highlighted. 

The "Manage your account" link should be highlighted as the delete page is a subpage of the Manage section.

### Before
<img width="1020" alt="Screenshot 2021-01-11 at 16 10 25" src="https://user-images.githubusercontent.com/7116819/104209396-8fed0680-5429-11eb-96a0-295393e9f9cb.png">

### After
<img width="1070" alt="Screenshot 2021-01-11 at 16 24 51" src="https://user-images.githubusercontent.com/7116819/104209400-90859d00-5429-11eb-8488-732cf757a644.png">
