### PR TITLE
Add an endpoint to generate the general statistics report

### DIFF
--- a/app/controllers/api/v1/report/general_controller.rb
+++ b/app/controllers/api/v1/report/general_controller.rb
@@ -3,13 +3,12 @@ class Api::V1::Report::GeneralController < Doorkeeper::ApplicationController
 
   respond_to :json
 
-  rescue_from ActionController::ParameterMissing do
-    head 400
-  end
-
   def show
-    start_date = params.fetch(:start_date)
-    end_date = params.fetch(:end_date)
+    end_date = params[:end_date] ? Time.zone.parse(params[:end_date]) : Time.zone.parse("15:00:00")
+    head 400 and return if end_date.nil?
+
+    start_date = params[:start_date] ? Time.zone.parse(params[:start_date]) : 1.day.before(end_date)
+    head 400 and return if start_date.nil?
 
     report = Report::GeneralStatistics.new(start_date: start_date, end_date: end_date)
 

--- a/app/controllers/api/v1/report/general_controller.rb
+++ b/app/controllers/api/v1/report/general_controller.rb
@@ -1,0 +1,22 @@
+class Api::V1::Report::GeneralController < Doorkeeper::ApplicationController
+  before_action -> { doorkeeper_authorize! :reporting_access }
+
+  respond_to :json
+
+  rescue_from ActionController::ParameterMissing do
+    head 400
+  end
+
+  def show
+    start_date = params.fetch(:start_date)
+    end_date = params.fetch(:end_date)
+
+    report = Report::GeneralStatistics.new(start_date: start_date, end_date: end_date)
+
+    if params[:humanize]
+      render json: [{ title: "Daily Statistics", text: report.humanize }]
+    else
+      render json: report.report
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -112,6 +112,10 @@ Rails.application.routes.draw do
         get "/email-subscription", to: "emails#show"
         post "/email-subscription", to: "emails#update"
       end
+
+      namespace :report do
+        get "/general", to: "general#show"
+      end
     end
   end
 

--- a/config/scopes.yml
+++ b/config/scopes.yml
@@ -5,6 +5,7 @@ optional_scopes:
   - account_manager_access
   - deanonymise_tokens
   - email
+  - reporting_access
   - transition_checker
 hidden_scopes:
   - openid

--- a/lib/report/general_statistics.rb
+++ b/lib/report/general_statistics.rb
@@ -12,11 +12,76 @@ module Report
     end
 
     def report
-      {
+      @report ||= {
         all: full_report(all_users, all_logins),
         interval: full_report(interval_users, interval_logins),
       }
     end
+
+    def humanize
+      output = ""
+
+      output += "All registrations to #{@end_date}: \n#{report[:all][:users][:count]}\n\n"
+      output += "New registrations between #{@start_date} and #{@end_date}: \n#{report[:interval][:users][:count]}\n\n"
+
+      output += "Cookie consents to #{@end_date}:\n"
+      report[:all][:users][:cookie_consents].each do |value, count|
+        output += "#{value.to_s.humanize} #{count}\n"
+      end
+      output += "\n"
+
+      output += "Cookie consents for registrations between #{@start_date} and #{@end_date}:\n"
+      report[:interval][:users][:cookie_consents].each do |value, count|
+        output += "#{value.to_s.humanize} #{count}\n"
+      end
+      output += "\n"
+
+      output += "Feedback consents to #{@end_date}:\n"
+      report[:all][:users][:feedback_consents].each do |value, count|
+        output += "#{value.to_s.humanize} #{count}\n"
+      end
+      output += "\n"
+
+      output += "Feedback consents for registrations between #{@start_date} and #{@end_date}:\n"
+      report[:interval][:users][:feedback_consents].each do |value, count|
+        output += "#{value.to_s.humanize} #{count}\n"
+      end
+      output += "\n"
+
+      output += "Total number of logins to #{@end_date}: \n#{report[:all][:logins][:count]}\n\n"
+
+      output += "Total number of logins between #{@start_date} and #{@end_date}: \n#{report[:interval][:logins][:count]}\n\n"
+
+      output += "Accounts logged in to #{@end_date}: \n#{report[:all][:logins][:accounts]}\n\n"
+
+      output += "Accounts logged in between #{@start_date} and #{@end_date}: \n#{report[:all][:logins][:accounts]}\n\n"
+
+      output += "Number of logins per account to #{@end_date}:\n"
+      report[:all][:logins][:frequency].each do |frequency, count|
+        output += "Accounts logged into #{frequency} #{'time'.pluralize(frequency)}: #{count}\n"
+      end
+      output += "\n"
+
+      output += "Number of logins between #{@start_date} and #{@end_date}:\n"
+      report[:interval][:logins][:frequency].each do |frequency, count|
+        output += "Accounts logged into #{frequency} #{'time'.pluralize(frequency)}: #{count}\n"
+      end
+
+      output += "Number of logins per account to #{@end_date} (excluding logins immediately after confirming email):\n"
+      report[:all][:logins][:frequency_ex_confirm].each do |frequency, count|
+        output += "Accounts logged into #{frequency} #{'time'.pluralize(frequency)}: #{count}\n"
+      end
+      output += "\n"
+
+      output += "Number of logins between #{@start_date} and #{@end_date} (excluding logins immediately after confirming email):\n"
+      report[:interval][:logins][:frequency_ex_confirm].each do |frequency, count|
+        output += "Accounts logged into #{frequency} #{'time'.pluralize(frequency)}: #{count}\n"
+      end
+
+      output
+    end
+
+  protected
 
     def full_report(users, logins)
       {
@@ -33,8 +98,6 @@ module Report
         },
       }
     end
-
-  protected
 
     def all_users
       User.where("created_at < ?", end_date)

--- a/lib/report/general_statistics.rb
+++ b/lib/report/general_statistics.rb
@@ -43,7 +43,7 @@ module Report
           count: logins.count,
           accounts: logins.pluck(:user_id).uniq.count,
           frequency: logins.pluck(:user_id).tally.values.tally.sort,
-          frequency_ex_confirm: logins.where.not(analytics: "from_confirmation_email").pluck(:user_id).tally.values.tally.sort,
+          frequency_ex_confirm: logins.where("analytics IS NULL or analytics != 'from_confirmation_email'").pluck(:user_id).tally.values.tally.sort,
         },
       }
     end

--- a/lib/report/general_statistics.rb
+++ b/lib/report/general_statistics.rb
@@ -15,6 +15,8 @@ module Report
       @report ||= {
         all: full_report(all_users, all_logins),
         interval: full_report(interval_users, interval_logins),
+        start_date: start_date,
+        end_date: end_date,
       }
     end
 

--- a/lib/report/general_statistics.rb
+++ b/lib/report/general_statistics.rb
@@ -21,66 +21,13 @@ module Report
     end
 
     def humanize
-      output = ""
-
-      output += "All registrations to #{@end_date}: \n#{report[:all][:users][:count]}\n\n"
-      output += "New registrations between #{@start_date} and #{@end_date}: \n#{report[:interval][:users][:count]}\n\n"
-
-      output += "Cookie consents to #{@end_date}:\n"
-      report[:all][:users][:cookie_consents].each do |value, count|
-        output += "#{value.to_s.humanize} #{count}\n"
-      end
-      output += "\n"
-
-      output += "Cookie consents for registrations between #{@start_date} and #{@end_date}:\n"
-      report[:interval][:users][:cookie_consents].each do |value, count|
-        output += "#{value.to_s.humanize} #{count}\n"
-      end
-      output += "\n"
-
-      output += "Feedback consents to #{@end_date}:\n"
-      report[:all][:users][:feedback_consents].each do |value, count|
-        output += "#{value.to_s.humanize} #{count}\n"
-      end
-      output += "\n"
-
-      output += "Feedback consents for registrations between #{@start_date} and #{@end_date}:\n"
-      report[:interval][:users][:feedback_consents].each do |value, count|
-        output += "#{value.to_s.humanize} #{count}\n"
-      end
-      output += "\n"
-
-      output += "Total number of logins to #{@end_date}: \n#{report[:all][:logins][:count]}\n\n"
-
-      output += "Total number of logins between #{@start_date} and #{@end_date}: \n#{report[:interval][:logins][:count]}\n\n"
-
-      output += "Accounts logged in to #{@end_date}: \n#{report[:all][:logins][:accounts]}\n\n"
-
-      output += "Accounts logged in between #{@start_date} and #{@end_date}: \n#{report[:all][:logins][:accounts]}\n\n"
-
-      output += "Number of logins per account to #{@end_date}:\n"
-      report[:all][:logins][:frequency].each do |frequency, count|
-        output += "Accounts logged into #{frequency} #{'time'.pluralize(frequency)}: #{count}\n"
-      end
-      output += "\n"
-
-      output += "Number of logins between #{@start_date} and #{@end_date}:\n"
-      report[:interval][:logins][:frequency].each do |frequency, count|
-        output += "Accounts logged into #{frequency} #{'time'.pluralize(frequency)}: #{count}\n"
-      end
-
-      output += "Number of logins per account to #{@end_date} (excluding logins immediately after confirming email):\n"
-      report[:all][:logins][:frequency_ex_confirm].each do |frequency, count|
-        output += "Accounts logged into #{frequency} #{'time'.pluralize(frequency)}: #{count}\n"
-      end
-      output += "\n"
-
-      output += "Number of logins between #{@start_date} and #{@end_date} (excluding logins immediately after confirming email):\n"
-      report[:interval][:logins][:frequency_ex_confirm].each do |frequency, count|
-        output += "Accounts logged into #{frequency} #{'time'.pluralize(frequency)}: #{count}\n"
-      end
-
-      output
+      [
+        "Report up to #{@end_date}:",
+        humanize_report(report[:all]),
+        "",
+        "Report between #{@start_date} and #{@end_date}:",
+        humanize_report(report[:interval]),
+      ].flatten.join("\n")
     end
 
   protected
@@ -99,6 +46,31 @@ module Report
           frequency_ex_confirm: logins.where.not(analytics: "from_confirmation_email").pluck(:user_id).tally.values.tally.sort,
         },
       }
+    end
+
+    def humanize_report(data)
+      output = []
+      output << "  - all registrations: #{data[:users][:count]}"
+      output << "  - cookie consents:"
+      data[:users][:cookie_consents].each do |value, count|
+        output << "    - #{value.to_s.humanize}: #{count}"
+      end
+      output << "  - feedback consents:"
+      data[:users][:feedback_consents].each do |value, count|
+        output << "    - #{value.to_s.humanize}: #{count}"
+      end
+      output << "  - total number of logins: #{data[:logins][:count]}"
+      output << "  - accounts logged in to: #{data[:logins][:accounts]}"
+      output << "  - number of logins per account:"
+      data[:logins][:frequency].each do |frequency, count|
+        output << "    - #{frequency} #{'time'.pluralize(frequency)}: #{count}"
+      end
+      output << "  - number of logins per account (excluding logins immediately after confirming email):"
+      data[:logins][:frequency_ex_confirm].each do |frequency, count|
+        output << "    - #{frequency} #{'time'.pluralize(frequency)}: #{count}"
+      end
+
+      output
     end
 
     def all_users

--- a/lib/report/general_statistics.rb
+++ b/lib/report/general_statistics.rb
@@ -41,7 +41,7 @@ module Report
     end
 
     def interval_users
-      all_users.where("created_at BETWEEN ? AND ?", start_date, end_date)
+      all_users.where("created_at >= ?", start_date)
     end
 
     def all_logins
@@ -52,7 +52,7 @@ module Report
     end
 
     def interval_logins
-      all_logins.where("created_at BETWEEN ? AND ?", start_date, end_date)
+      all_logins.where("created_at >= ?", start_date)
     end
   end
 end

--- a/lib/tasks/statistics.rake
+++ b/lib/tasks/statistics.rake
@@ -1,7 +1,7 @@
 namespace :statistics do
   desc "Get information on all registrations and logins"
   task :general, %i[start_date end_date] => [:environment] do |_, args|
-    args.with_defaults(start_date: Time.zone.parse("15:00:00") - 1.day, end_date: Time.zone.parse("14:59:59"))
+    args.with_defaults(start_date: Time.zone.parse("15:00:00") - 1.day, end_date: Time.zone.parse("15:00:00"))
 
     report = Report::GeneralStatistics.report(
       start_date: args.start_date,

--- a/lib/tasks/statistics.rake
+++ b/lib/tasks/statistics.rake
@@ -3,75 +3,14 @@ namespace :statistics do
   task :general, %i[start_date end_date] => [:environment] do |_, args|
     args.with_defaults(start_date: Time.zone.parse("15:00:00") - 1.day, end_date: Time.zone.parse("15:00:00"))
 
-    report = Report::GeneralStatistics.report(
+    report = Report::GeneralStatistics.new(
       start_date: args.start_date,
       end_date: args.end_date,
     )
 
-    results = ""
-
-    results += "All registrations to #{args.end_date}: \n#{report[:all][:users][:count]}\n\n"
-    results += "New registrations between #{args.start_date} and #{args.end_date}: \n#{report[:interval][:users][:count]}\n\n"
-
-    results += "Cookie consents to #{args.end_date}:\n"
-    report[:all][:users][:cookie_consents].each do |value, count|
-      results += "#{value.to_s.humanize} #{count}\n"
-    end
-    results += "\n"
-
-    results += "Cookie consents for registrations between #{args.start_date} and #{args.end_date}:\n"
-    report[:interval][:users][:cookie_consents].each do |value, count|
-      results += "#{value.to_s.humanize} #{count}\n"
-    end
-    results += "\n"
-
-    results += "Feedback consents to #{args.end_date}:\n"
-    report[:all][:users][:feedback_consents].each do |value, count|
-      results += "#{value.to_s.humanize} #{count}\n"
-    end
-    results += "\n"
-
-    results += "Feedback consents for registrations between #{args.start_date} and #{args.end_date}:\n"
-    report[:interval][:users][:feedback_consents].each do |value, count|
-      results += "#{value.to_s.humanize} #{count}\n"
-    end
-    results += "\n"
-
-    results += "Total number of logins to #{args.end_date}: \n#{report[:all][:logins][:count]}\n\n"
-
-    results += "Total number of logins between #{args.start_date} and #{args.end_date}: \n#{report[:interval][:logins][:count]}\n\n"
-
-    results += "Accounts logged in to #{args.end_date}: \n#{report[:all][:logins][:accounts]}\n\n"
-
-    results += "Accounts logged in between #{args.start_date} and #{args.end_date}: \n#{report[:all][:logins][:accounts]}\n\n"
-
-    results += "Number of logins per account to #{args.end_date}:\n"
-    report[:all][:logins][:frequency].each do |frequency, count|
-      results += "Accounts logged into #{frequency} #{'time'.pluralize(frequency)}: #{count}\n"
-    end
-    results += "\n"
-
-    results += "Number of logins between #{args.start_date} and #{args.end_date}:\n"
-    report[:interval][:logins][:frequency].each do |frequency, count|
-      results += "Accounts logged into #{frequency} #{'time'.pluralize(frequency)}: #{count}\n"
-    end
-
-    results += "Number of logins per account to #{args.end_date} (excluding logins immediately after confirming email):\n"
-    report[:all][:logins][:frequency_ex_confirm].each do |frequency, count|
-      results += "Accounts logged into #{frequency} #{'time'.pluralize(frequency)}: #{count}\n"
-    end
-    results += "\n"
-
-    results += "Number of logins between #{args.start_date} and #{args.end_date} (excluding logins immediately after confirming email):\n"
-    report[:interval][:logins][:frequency_ex_confirm].each do |frequency, count|
-      results += "Accounts logged into #{frequency} #{'time'.pluralize(frequency)}: #{count}\n"
-    end
-
-    output = [{
+    puts [{
       title: "Daily Statistics",
-      text: results,
-    }]
-
-    puts output.to_json
+      text: report.humanize,
+    }].to_json
   end
 end

--- a/spec/factories/doorkeeper.rb
+++ b/spec/factories/doorkeeper.rb
@@ -1,5 +1,8 @@
 FactoryBot.define do
   factory :oauth_application, class: Doorkeeper::Application do
+    name { "Application" }
+    redirect_uri { "https://www.gov.uk" }
+    scopes { [] }
   end
 
   factory :oauth_access_token, class: Doorkeeper::AccessToken do

--- a/spec/requests/api/v1/report/general_spec.rb
+++ b/spec/requests/api/v1/report/general_spec.rb
@@ -1,0 +1,87 @@
+RSpec.describe "/api/v1/report/general" do
+  let(:user) { FactoryBot.create(:user) }
+
+  let(:application) { FactoryBot.create(:oauth_application) }
+
+  let(:token) do
+    FactoryBot.create(
+      :oauth_access_token,
+      resource_owner_id: user.id,
+      application_id: application.id,
+      scopes: %i[reporting_access],
+    )
+  end
+
+  let(:headers) do
+    {
+      Accept: "application/json",
+      Authorization: "Bearer #{token.token}",
+    }
+  end
+
+  let(:params) do
+    {
+      start_date: start_date,
+      end_date: end_date,
+      humanize: humanize,
+    }.compact
+  end
+
+  let(:start_date) { "2020-01-01 15:00:00" }
+  let(:end_date) { "2020-01-01 15:00:00" }
+  let(:humanize) { nil }
+
+  it "returns a JSON report" do
+    get api_v1_report_general_path, params: params, headers: headers
+    expect(response).to be_successful
+
+    empty_report = {
+      "users" => {
+        "count" => 0,
+        "cookie_consents" => {},
+        "feedback_consents" => {},
+      },
+      "logins" => {
+        "count" => 0,
+        "accounts" => 0,
+        "frequency" => [],
+        "frequency_ex_confirm" => [],
+      },
+    }
+
+    body = JSON.parse(response.body)
+    expect(body).to eq({ "all" => empty_report, "interval" => empty_report, "start_date" => start_date, "end_date" => end_date })
+  end
+
+  context "with the start_date missing" do
+    let(:start_date) { nil }
+
+    it "throws a 400" do
+      get api_v1_report_general_path, params: params, headers: headers
+      expect(response).to have_http_status(400)
+    end
+  end
+
+  context "with the end_date missing" do
+    let(:end_date) { nil }
+
+    it "throws a 400" do
+      get api_v1_report_general_path, params: params, headers: headers
+      expect(response).to have_http_status(400)
+    end
+  end
+
+  context "humanize=1" do
+    let(:humanize) { "1" }
+
+    it "returns humanized output" do
+      get api_v1_report_general_path, params: params, headers: headers
+      expect(response).to be_successful
+
+      body = JSON.parse(response.body)
+      expect(body.count).to eq(1)
+      expect(body.first["title"]).to eq("Daily Statistics")
+      expect(body.first["text"]).to start_with("All registrations to #{end_date}")
+    end
+  end
+end

--- a/spec/requests/api/v1/report/general_spec.rb
+++ b/spec/requests/api/v1/report/general_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe "/api/v1/report/general" do
       body = JSON.parse(response.body)
       expect(body.count).to eq(1)
       expect(body.first["title"]).to eq("Daily Statistics")
-      expect(body.first["text"]).to start_with("All registrations to #{end_date}")
+      expect(body.first["text"]).to start_with("Report up to #{end_date}")
     end
   end
 end


### PR DESCRIPTION
SSHing into the PaaS to run a rake task isn't great from a security perspective: ideally any such access wouldn't even be allowed by default, but we currently have a need to have Concourse SSH in once a day to run this task.

Even worse, we're planning to add more tasks which export data to Google BigQuery, and our current pattern for running those daily would be to add yet more Concourse tasks to SSH in!

To move away from this pattern, I've added an API endpoint to generate the general statistics report.  When this is deployed I'll generate an OAuth token, put it in the Concourse secrets, and update the job to curl `/api/v1/report/general`.