### PR TITLE
Add tasks for suspend and resume production

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -320,6 +320,39 @@ jobs:
           CF_SPACE: staging
           CDN_DOMAIN: account.staging.publishing.service.gov.uk
           HOSTNAME: attributes
+
+  - name: suspend-production
+    plan:
+      - get: git-main
+      - task: map-account-url-to-error-page
+        file: git-main/concourse/tasks/map-route.yml
+        params:
+          CF_APP_NAME: govuk-account-static-errors
+          CF_SPACE: production
+          CDN_DOMAIN: account.publishing.service.gov.uk
+          HOSTNAME: www
+      - task: unmap-account-url-from-account-app
+        file: git-main/concourse/tasks/unmap-route.yml
+        params:
+          CF_APP_NAME: govuk-account-manager
+          CF_SPACE: production
+          CDN_DOMAIN: account.publishing.service.gov.uk
+          HOSTNAME: www
+      - task: map-attribute-url-to-error-page
+        file: git-main/concourse/tasks/map-route.yml
+        params:
+          CF_APP_NAME: govuk-account-static-errors
+          CF_SPACE: production
+          CDN_DOMAIN: account.publishing.service.gov.uk
+          HOSTNAME: attributes
+      - task: unmap-attribute-url-from-attribute-service
+        file: git-main/concourse/tasks/unmap-route.yml
+        params:
+          CF_APP_NAME: govuk-attribute-service
+          CF_SPACE: production
+          CDN_DOMAIN: account.publishing.service.gov.uk
+          HOSTNAME: attributes
+
   - name: resume-staging
     plan:
       - get: git-main
@@ -350,4 +383,35 @@ jobs:
           CF_APP_NAME: govuk-account-static-errors
           CF_SPACE: staging
           CDN_DOMAIN: account.staging.publishing.service.gov.uk
+          HOSTNAME: attributes
+  - name: resume-production
+    plan:
+      - get: git-main
+      - task: map-account-url-to-account-app
+        file: git-main/concourse/tasks/map-route.yml
+        params:
+          CF_APP_NAME: govuk-account-manager
+          CF_SPACE: production
+          CDN_DOMAIN: account.publishing.service.gov.uk
+          HOSTNAME: www
+      - task: unmap-account-url-from-error-page
+        file: git-main/concourse/tasks/unmap-route.yml
+        params:
+          CF_APP_NAME: govuk-account-static-errors
+          CF_SPACE: production
+          CDN_DOMAIN: account.publishing.service.gov.uk
+          HOSTNAME: www
+      - task: map-attribute-url-to-attribute-service
+        file: git-main/concourse/tasks/map-route.yml
+        params:
+          CF_APP_NAME: govuk-attribute-service
+          CF_SPACE: production
+          CDN_DOMAIN: account.publishing.service.gov.uk
+          HOSTNAME: attributes
+      - task: unmap-attribute-url-from-error-page
+        file: git-main/concourse/tasks/unmap-route.yml
+        params:
+          CF_APP_NAME: govuk-account-static-errors
+          CF_SPACE: production
+          CDN_DOMAIN: account.publishing.service.gov.uk
           HOSTNAME: attributes


### PR DESCRIPTION
[Trello](https://trello.com/c/LaSdrZyI/459-feature-turn-off-accounts)

Add suspend / resume for prod.

Initially I'd thought about chaining these, but I think it makes more sense for them to be separate. It means we can test suspend / resume on staging for an incident test without having to pause and jobs that might affect production.

Happy to revisit if folks think the concourse pipeline is looking a little cluttered by them?