### PR TITLE
Extend MFA code expiration from 10 min to 30 mins

### DIFF
--- a/config/locales/mfa.en.yml
+++ b/config/locales/mfa.en.yml
@@ -13,7 +13,7 @@ en:
       phone:
         nochange: Your account is already using this mobile number. Enter a different number.
       phone_code:
-        expired: The security code you’ve entered has expired. Security codes expire after 10 minutes. We can <a class="govuk-link" href="%{resend_link}">send a new security code</a>.
+        expired: The security code you’ve entered has expired. Security codes expire after 30 minutes. We can <a class="govuk-link" href="%{resend_link}">send a new security code</a>.
         invalid: The security code you’ve entered is not correct. Try entering the code again.
         too_many_attempts: You’ve entered the wrong security code too many times. You need to <a class="govuk-link" href="%{resend_link}">get a new security code</a>.
     phone:

--- a/lib/multi_factor_auth.rb
+++ b/lib/multi_factor_auth.rb
@@ -1,6 +1,6 @@
 module MultiFactorAuth
   ALLOWED_ATTEMPTS = 6
-  EXPIRATION_AGE = 10.minutes
+  EXPIRATION_AGE = 30.minutes
   INTERNATIONAL_CODE_REGEX = /^00/.freeze
   VALID_DOMESTIC_COUNTRIES = %i[gb gg je im].freeze
 

--- a/spec/feature/change_phone_spec.rb
+++ b/spec/feature/change_phone_spec.rb
@@ -106,9 +106,12 @@ RSpec.feature "Change Phone" do
       enter_password
       travel(MultiFactorAuth::EXPIRATION_AGE + 1.second)
       enter_mfa
-
-      expect(page).to have_text(Rails::Html::FullSanitizer.new.sanitize(I18n.t("mfa.errors.phone_code.expired")))
+      user_is_returned_to_login_screen
     end
+  end
+
+  def user_is_returned_to_login_screen
+    expect(page).to have_text(I18n.t("devise.sessions.new.heading"))
   end
 
   def log_in

--- a/spec/feature/login_spec.rb
+++ b/spec/feature/login_spec.rb
@@ -127,8 +127,7 @@ RSpec.feature "Logging in" do
       enter_email_address_and_password
       travel(MultiFactorAuth::EXPIRATION_AGE + 1.second)
       enter_mfa
-
-      expect(page).to have_text(Rails::Html::FullSanitizer.new.sanitize(I18n.t("mfa.errors.phone_code.expired")))
+      user_is_returned_to_login_screen
     end
   end
 
@@ -191,6 +190,10 @@ RSpec.feature "Logging in" do
         expect(page).to have_text(I18n.t("devise.failure.no_account"))
       end
     end
+  end
+
+  def user_is_returned_to_login_screen
+    expect(page).to have_text(I18n.t("devise.sessions.new.heading"))
   end
 
   def enter_email_address_and_password(email: user.email, password: user.password)

--- a/spec/feature/registration_spec.rb
+++ b/spec/feature/registration_spec.rb
@@ -305,8 +305,7 @@ RSpec.feature "Registration" do
       submit_registration_form
       travel(MultiFactorAuth::EXPIRATION_AGE + 1.second)
       enter_mfa
-
-      expect(page).to have_text(Rails::Html::FullSanitizer.new.sanitize(I18n.t("mfa.errors.phone_code.expired")))
+      user_is_returned_to_registration_start
     end
   end
 
@@ -350,6 +349,10 @@ RSpec.feature "Registration" do
 
       expect(page).to have_text(I18n.t("devise.registrations.closed.heading"))
     end
+  end
+
+  def user_is_returned_to_registration_start
+    expect(page).to have_text(I18n.t("devise.registrations.start.heading"))
   end
 
   def visit_registration_form


### PR DESCRIPTION
[Trello](https://trello.com/c/eH7xwMn7/550-extend-2fa-code-expiry-time-to-1-hour)



There is a noticeable point of user friction with MFA phone codes, some
users are mentioning not recieving them in time or saying it takes a
long time for them to arrive.

We do know that some codes are being sent internationally which could
cause a delay.

We can try extending this to 30 mins and seeing if that results in a
better balance between security and friction for the user as evidenced
by zendesk queries and timestamp gaps between a user being issued an MFA
token and any attempt to provide a code to the server for validation.

For now this bumps the number up on the basis that any issues a user is
having at 10 mins will not be harder at 30 mins. But will now look to
build an evidence base to inform any follow up changes.