### PR TITLE
Show current email if no unconfirmed email on re-confirmation

### DIFF
--- a/app/controllers/devise_confirmations_controller.rb
+++ b/app/controllers/devise_confirmations_controller.rb
@@ -40,7 +40,7 @@ class DeviseConfirmationsController < Devise::ConfirmationsController
 
   def after_resending_confirmation_instructions_path_for(_resource_name)
     session[:confirmations] = {
-      email: resource.unconfirmed_email,
+      email: resource.unconfirmed_email || resource.email,
       user_is_confirmed: resource.confirmed?,
     }
     confirmation_email_sent_path

--- a/spec/feature/resend_confirmation_spec.rb
+++ b/spec/feature/resend_confirmation_spec.rb
@@ -1,0 +1,21 @@
+RSpec.feature "Resending confirmation email" do
+  include ActiveJob::TestHelper
+
+  let!(:user) { FactoryBot.create(:user) }
+
+  before { clear_enqueued_jobs }
+
+  it "sends the user a new confirmation email" do
+    enter_email_address
+
+    assert_enqueued_jobs 1, only: NotifyDeliveryJob
+    expect(page).to have_text(I18n.t("reset_sent.subheading"))
+    expect(page).to have_text(user.email)
+  end
+
+  def enter_email_address(email: user.email)
+    visit new_user_confirmation_path
+    fill_in "email", with: email
+    click_on I18n.t("devise.confirmations.resend.button")
+  end
+end


### PR DESCRIPTION
We are currently showing the user's unconfirmed email address when asking them to check their email. However, for users who are requesting a new confirmation email for an unconfirmed account, we are sending the email to the email saved on their account.

Trello card: https://trello.com/c/YZlQlLqu