### PR TITLE
Add aria labels to account manager nav elements

### DIFF
--- a/app/views/application/_account-navigation.html.erb
+++ b/app/views/application/_account-navigation.html.erb
@@ -1,6 +1,6 @@
 <% page_is ||= nil %>
 
-<nav>
+<nav aria-label="Account management">
   <ul class="accounts-menu">
     <li class="accounts-menu__item <%= "accounts-menu__item--current" if page_is == "your-account" %>">
       <a class="accounts-menu__link govuk-link govuk-link--no-visited-state" href="<%= user_root_path %>"><%= t("navigation.menu_bar.account.link_text") %></a>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -59,6 +59,7 @@
   <%= render "govuk_publishing_components/components/layout_header", {
     product_name: "Account",
     navigation_items: navigation_items,
+    navigation_aria_label: "Account access",
   } %>
 
   <div class="govuk-width-container app-width-container">


### PR DESCRIPTION
The account manager prototype currently has two navigation landmarks, one being in the site header, and another being the account menu.

[WCAG SC 2.4.1](https://www.w3.org/WAI/WCAG21/Understanding/bypass-blocks) states that when there are multiple navigation landmarks of the same kind on a page, they should be labelled in order to help assistive tech users differentiate between them.

This adds relevant labels to these landmarks to improve navigation for screen reader users.

------

✨ **Important:**  ✨  depends on [this PR](https://github.com/alphagov/govuk_publishing_components/pull/1865) which introduces the ability to pass a custom aria label to the `layout_header` component.


------
### Before: not labelled, both `nav`s just say Navigation
<img width="1499" alt="Screenshot 2021-01-11 at 09 23 35" src="https://user-images.githubusercontent.com/7116819/104491756-98307780-55ca-11eb-8035-0c035cc875b1.png">


### After: `nav`s have labels, therefore they  are clearer
<img width="1678" alt="Screenshot 2021-01-13 at 18 07 50" src="https://user-images.githubusercontent.com/7116819/104491766-9b2b6800-55ca-11eb-8949-352e524d8092.png">




https://trello.com/c/1cnffruq