### PR TITLE
Add autoscaling policy

### DIFF
--- a/concourse/autoscaling/paas-scaling-policy-production.json
+++ b/concourse/autoscaling/paas-scaling-policy-production.json
@@ -1,0 +1,22 @@
+{
+  "instance_min_count": 3,
+  "instance_max_count": 50,
+  "scaling_rules": [
+    {
+      "metric_type": "responsetime",
+      "breach_duration_secs": 60,
+      "threshold": 100,
+      "operator": "<",
+      "cool_down_secs": 120,
+      "adjustment": "-1"
+    },
+    {
+      "metric_type": "responsetime",
+      "breach_duration_secs": 60,
+      "threshold": 100,
+      "operator": ">=",
+      "cool_down_secs": 120,
+      "adjustment": "+1"
+    }
+  ]
+}

--- a/concourse/autoscaling/paas-scaling-policy-staging.json
+++ b/concourse/autoscaling/paas-scaling-policy-staging.json
@@ -1,0 +1,22 @@
+{
+  "instance_min_count": 1,
+  "instance_max_count": 3,
+  "scaling_rules": [
+    {
+      "metric_type": "responsetime",
+      "breach_duration_secs": 60,
+      "threshold": 50,
+      "operator": "<",
+      "cool_down_secs": 120,
+      "adjustment": "-1"
+    },
+    {
+      "metric_type": "responsetime",
+      "breach_duration_secs": 60,
+      "threshold": 50,
+      "operator": ">=",
+      "cool_down_secs": 120,
+      "adjustment": "+1"
+    }
+  ]
+}

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -162,7 +162,7 @@ jobs:
         file: git-main/concourse/tasks/deploy-to-govuk-paas.yml
         params:
           APP_DOMAIN: www.staging.publishing.service.gov.uk
-          APP_INSTANCES: 1
+          CF_APP_SCALING_POLICY: concourse/autoscaling/paas-scaling-policy-staging.json
           BASIC_AUTH_PASSWORD: ((basic-auth-password))
           BASIC_AUTH_USERNAME: ((basic-auth-username))
           CDN_DOMAIN: account.staging.publishing.service.gov.uk
@@ -236,7 +236,7 @@ jobs:
         file: git-main/concourse/tasks/deploy-to-govuk-paas.yml
         params:
           APP_DOMAIN: www.gov.uk
-          APP_INSTANCES: 20
+          CF_APP_SCALING_POLICY: concourse/autoscaling/paas-scaling-policy-production.json
           BIGQUERY_CREDENTIALS: ((bigquery-credentials-production))
           CDN_DOMAIN: account.publishing.service.gov.uk
           CF_SPACE: production
@@ -411,6 +411,7 @@ jobs:
           CF_SPACE: staging
           CDN_DOMAIN: account.staging.publishing.service.gov.uk
           HOSTNAME: attributes
+
   - name: resume-production
     plan:
       - get: git-main

--- a/concourse/tasks/deploy-to-govuk-paas.yml
+++ b/concourse/tasks/deploy-to-govuk-paas.yml
@@ -39,6 +39,8 @@ run:
       cf apply-manifest -f manifest.yml
       cf set-env $CF_APP_NAME CF_STARTUP_TIMEOUT "$CF_STARTUP_TIMEOUT"
 
+      cf attach-autoscaling-policy $CF_APP_NAME $CF_APP_SCALING_POLICY
+
       if [[ "${REQUIRE_BASIC_AUTH:-}" = "true" ]]; then
         cf set-env $CF_APP_NAME REQUIRE_BASIC_AUTH "$REQUIRE_BASIC_AUTH"
         cf set-env $CF_APP_NAME BASIC_AUTH_USERNAME "$BASIC_AUTH_USERNAME"


### PR DESCRIPTION
[Trello](https://trello.com/c/z8bMTe1W/534-spike-autoscaling-for-account-manager-and-attribute-service) / [Trello](https://trello.com/c/0Se2Ysev/572-deploy-auto-scaling)

[Architectural Design Record - 0009 - Autoscaling](https://github.com/alphagov/govuk-accounts-adrs/pull/15)

## What

This PR adds the ability for the account manager to autoscale based on response time.

## Why

We've been fairly overprovisioned for a while, a test this week scaling us back down to small numbers of instances showed no change in response times or other metrics, so we think we can save resources by allowing the account manager to scale down when it is quiet and also expand to meet increased demand from users.

## What happens next

- We will need to use `cf` to add autoscaling to our PaaS apps
- We will want to take some similar rules to these and apply them to the attribute store