### PR TITLE
Ensure tel number doesn't wrap on phone edit page

### DIFF
--- a/app/views/edit_phone/show.html.erb
+++ b/app/views/edit_phone/show.html.erb
@@ -16,7 +16,7 @@
 </p>
 
 <%= render "govuk_publishing_components/components/inset_text", {
-  text: t("mfa.phone.update.start.current", phone_number: MultiFactorAuth.formatted_phone_number(current_user.phone))
+  text: sanitize(t("mfa.phone.update.start.current", phone_number: MultiFactorAuth.formatted_phone_number(current_user.phone)))
 } %>
 
 <%= form_with(url: edit_user_registration_phone_code_path, method: :post) do %>

--- a/config/locales/mfa.en.yml
+++ b/config/locales/mfa.en.yml
@@ -51,7 +51,7 @@ en:
         heading: Send a new security code
       update:
         start:
-          current: 'The phone number currently stored in your GOV.UK account is: %{phone_number}'
+          current: 'The phone number currently stored in your GOV.UK account is: <span class="govuk-!-display-inline-block">%{phone_number}</span>'
           fields:
             phone:
               label: Enter new phone number


### PR DESCRIPTION
On the **Change your phone number** page, the current phone number is breaking on to the next line making it hard to read on the desktop variant.
<img width="666" alt="Screenshot 2021-01-15 at 15 56 33" src="https://user-images.githubusercontent.com/7116819/104749255-7e1da300-574a-11eb-8191-92929ad3891d.png">


This adds an `inline-block` wrapper around the number to prevent it breaking in the middle.

<img width="675" alt="Screenshot 2021-01-15 at 15 58 04" src="https://user-images.githubusercontent.com/7116819/104749258-7f4ed000-574a-11eb-8f86-da7c0b782974.png">