### PR TITLE
Remove deploy time scaling for week starting 18 Jan 2021

### DIFF
--- a/concourse/tasks/deploy-to-govuk-paas.yml
+++ b/concourse/tasks/deploy-to-govuk-paas.yml
@@ -39,8 +39,6 @@ run:
       cf apply-manifest -f manifest.yml
       cf set-env $CF_APP_NAME CF_STARTUP_TIMEOUT "$CF_STARTUP_TIMEOUT"
 
-      cf scale -i "$APP_INSTANCES" $CF_APP_NAME
-
       if [[ "${REQUIRE_BASIC_AUTH:-}" = "true" ]]; then
         cf set-env $CF_APP_NAME REQUIRE_BASIC_AUTH "$REQUIRE_BASIC_AUTH"
         cf set-env $CF_APP_NAME BASIC_AUTH_USERNAME "$BASIC_AUTH_USERNAME"


### PR DESCRIPTION
[Trello](https://trello.com/c/jVkMRZHj/563-run-scaling-test-throughout-week)

We're gathering data this week to inform autoscaling strategies, we'd
want to scale manually for this period to gather more data