### PR TITLE
Add tests for unlocking accounts

### DIFF
--- a/app/controllers/devise_unlocks_controller.rb
+++ b/app/controllers/devise_unlocks_controller.rb
@@ -6,7 +6,7 @@ class DeviseUnlocksController < Devise::UnlocksController
         if current_user
           redirect_to user_root_path
         else
-          redirect_to "/", flash: { notice: I18n.t("errors.messages.not_locked") }
+          redirect_to new_user_session_path, flash: { notice: I18n.t("errors.messages.not_locked") }
         end
         return
       end

--- a/spec/feature/change_phone_spec.rb
+++ b/spec/feature/change_phone_spec.rb
@@ -114,16 +114,6 @@ RSpec.feature "Change Phone" do
     expect(page).to have_text(I18n.t("devise.sessions.new.heading"))
   end
 
-  def log_in
-    visit new_user_session_path
-    fill_in "email", with: user.email
-    fill_in "password", with: user.password
-    click_on I18n.t("devise.sessions.new.fields.submit.label")
-
-    fill_in "phone_code", with: user.reload.phone_code
-    click_on I18n.t("mfa.phone.code.fields.submit.label")
-  end
-
   def go_to_change_number_page
     within ".accounts-menu" do
       click_on "Manage your account"

--- a/spec/requests/unlock_account_spec.rb
+++ b/spec/requests/unlock_account_spec.rb
@@ -1,0 +1,74 @@
+RSpec.describe "Unlock account" do
+  include ActiveJob::TestHelper
+
+  let!(:user) { FactoryBot.create(:user) }
+
+  before { clear_enqueued_jobs }
+
+  context "getting an unlock email" do
+    context "when the user's account gets locked" do
+      before do
+        user.lock_access!
+      end
+
+      it "sends the user a new confirmation email" do
+        assert_enqueued_jobs 1, only: NotifyDeliveryJob
+      end
+    end
+
+    context "when a locked user requests an unlock link" do
+      before do
+        user.lock_access!
+        clear_enqueued_jobs
+      end
+
+      it "sends the user a new confirmation email" do
+        request_unlock_link
+
+        assert_enqueued_jobs 1, only: NotifyDeliveryJob
+        expect(response.body).to have_content(I18n.t("devise.unlocks.send_instructions"))
+      end
+    end
+
+    context "when an unlocked user requests an unlock link" do
+      it "returns an error" do
+        request_unlock_link
+
+        expect(response.body).to have_content(I18n.t("errors.messages.not_locked"))
+      end
+    end
+  end
+
+  context "using an unlock email link" do
+    context "when a locked user unlocks their account" do
+      it "unlocks their account" do
+        unlock_token = user.lock_access!
+        click_unlock_link(unlock_token)
+
+        user.reload
+
+        expect(response.body).to have_content(I18n.t("devise.unlocks.unlocked"))
+        expect(user.access_locked?).to be false
+      end
+    end
+
+    context "when an unlocked and signed in user attempts to unlock their account" do
+      it "redirects to their account" do
+        sign_in user
+        click_unlock_link("an-already-used-token")
+
+        expect(response.body).to have_content(I18n.t("account.your_account.heading"))
+      end
+    end
+  end
+
+  def request_unlock_link
+    post user_unlock_path, params: { user: { email: user.email } }
+    follow_redirect!
+  end
+
+  def click_unlock_link(unlock_token)
+    get user_unlock_path, params: { unlock_token: unlock_token }
+    follow_redirect!
+  end
+end

--- a/spec/support/helpers/requests_helper.rb
+++ b/spec/support/helpers/requests_helper.rb
@@ -1,10 +1,14 @@
 module RequestsHelper
-  def log_in(username, password)
+  def log_in(username: user.email, password: user.password)
     visit new_user_session_path
     fill_in "email", with: username
-    click_on I18n.t("welcome.show.button.label")
     fill_in "password", with: password
     click_on I18n.t("devise.sessions.new.fields.submit.label")
+
+    if Rails.configuration.feature_flag_mfa
+      fill_in "phone_code", with: user.reload.phone_code
+      click_on I18n.t("mfa.phone.code.fields.submit.label")
+    end
   end
 end
 


### PR DESCRIPTION
There is currently no test coverage for the unlocking accounts feature, so adding a basic tests for that user flow.

Adding these tests caught an issue where we are telling already unlocked users to sign in, but sending them to the registration form.  This PR resolves that issue.