### PR TITLE
Return just the scopes if the deanonymised token has no user

### DIFF
--- a/app/controllers/api/v1/deanonymise_token_controller.rb
+++ b/app/controllers/api/v1/deanonymise_token_controller.rb
@@ -12,6 +12,8 @@ class Api::V1::DeanonymiseTokenController < Doorkeeper::ApplicationController
       head 404
     elsif token.expired?
       head 410
+    elsif token.resource_owner_id.nil?
+      render json: { scopes: token.scopes.to_a }
     else
       DataActivity.create!(
         user_id: token.resource_owner_id,

--- a/spec/requests/api/v1/deanonymise_token_spec.rb
+++ b/spec/requests/api/v1/deanonymise_token_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "/api/v1/deanonymise-token" do
   let(:privileged_token) do
     FactoryBot.create(
       :oauth_access_token,
-      resource_owner_id: user.id,
+      resource_owner_id: user&.id,
       application_id: application.id,
       scopes: %i[deanonymise_tokens],
     )
@@ -22,7 +22,7 @@ RSpec.describe "/api/v1/deanonymise-token" do
   let(:unprivileged_token) do
     FactoryBot.create(
       :oauth_access_token,
-      resource_owner_id: user.id,
+      resource_owner_id: user&.id,
       application_id: application.id,
       scopes: %i[openid],
     )
@@ -53,6 +53,18 @@ RSpec.describe "/api/v1/deanonymise-token" do
         scopes: check_token.scopes.to_a,
         true_subject_identifier: user.id,
       })
+    end
+
+    context "with no associated user" do
+      let(:user) { nil }
+
+      it "returns just the scopes" do
+        get api_v1_deanonymise_token_path, params: params, headers: headers
+        expect(response).to be_successful
+        expect(JSON.parse(response.body).deep_symbolize_keys).to eq({
+          scopes: check_token.scopes.to_a,
+        })
+      end
     end
 
     context "with an expired check token" do


### PR DESCRIPTION
This is needed for the BigQuery export, as the token Concourse uses
has no associated user.

There's precedent for this sort of special token: the token the
attribute-service has with the :deanonymise_tokens scope also has no
user.