### PR TITLE
Update standard error heading

### DIFF
--- a/app/views/standard_errors/generic.html.erb
+++ b/app/views/standard_errors/generic.html.erb
@@ -1,7 +1,8 @@
 <%= render "govuk_publishing_components/components/heading", {
   text: t("standard_errors.#{@error}.heading"),
   heading_level: 1,
-  margin_bottom: 3,
+  margin_bottom: 6,
+  font_size: 'l',
 } %>
 
 <%= sanitize(t("standard_errors.#{@error}.content")) %>


### PR DESCRIPTION
Increase `standard_error` heading size and `margin_bottom` in order to more closely match the DS' error page layout example.

## Before
<img width="990" alt="Screenshot 2021-01-18 at 16 45 10" src="https://user-images.githubusercontent.com/7116819/104942906-e966af80-59ac-11eb-9598-3964ddeff05e.png">

## After
<img width="1010" alt="Screenshot 2021-01-18 at 16 51 07" src="https://user-images.githubusercontent.com/7116819/104943268-65f98e00-59ad-11eb-8e6b-430a776ac711.png">


https://trello.com/c/Mmv4gF5o