### PR TITLE
Specify date format for report responses

### DIFF
--- a/app/controllers/api/v1/report/bigquery_controller.rb
+++ b/app/controllers/api/v1/report/bigquery_controller.rb
@@ -12,6 +12,9 @@ class Api::V1::Report::BigqueryController < Doorkeeper::ApplicationController
 
     BigqueryReportExportJob.perform_later(start_date, end_date)
 
-    render status: :accepted, json: { start_date: start_date, end_date: end_date }
+    render status: :accepted, json: {
+      start_date: start_date.strftime(Report::TIME_FORMAT),
+      end_date: end_date.strftime(Report::TIME_FORMAT),
+    }
   end
 end

--- a/app/controllers/api/v1/report/general_controller.rb
+++ b/app/controllers/api/v1/report/general_controller.rb
@@ -15,7 +15,11 @@ class Api::V1::Report::GeneralController < Doorkeeper::ApplicationController
     if params[:humanize]
       render json: [{ title: "Daily Statistics", text: report.humanize }]
     else
-      render json: report.report
+      out = report.report
+      render json: out.merge(
+        start_date: out[:start_date].strftime(Report::TIME_FORMAT),
+        end_date: out[:end_date].strftime(Report::TIME_FORMAT),
+      )
     end
   end
 end

--- a/app/controllers/api/v1/report/general_controller.rb
+++ b/app/controllers/api/v1/report/general_controller.rb
@@ -17,8 +17,8 @@ class Api::V1::Report::GeneralController < Doorkeeper::ApplicationController
     else
       out = report.report
       render json: out.merge(
-        start_date: out[:start_date].strftime(Report::TIME_FORMAT),
-        end_date: out[:end_date].strftime(Report::TIME_FORMAT),
+        start_date: start_date.strftime(Report::TIME_FORMAT),
+        end_date: end_date.strftime(Report::TIME_FORMAT),
       )
     end
   end

--- a/lib/report.rb
+++ b/lib/report.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Report
+  TIME_FORMAT = "%Y-%m-%d %H:%M:%S %:z"
+end

--- a/lib/report/general_statistics.rb
+++ b/lib/report/general_statistics.rb
@@ -21,11 +21,13 @@ module Report
     end
 
     def humanize
+      ended_at = end_date.strftime(Report::TIME_FORMAT)
+      started_at = start_date.strftime(Report::TIME_FORMAT)
       [
-        "Report up to #{@end_date}:",
+        "Report up to #{ended_at}:",
         humanize_report(report[:all]),
         "",
-        "Report between #{@start_date} and #{@end_date}:",
+        "Report between #{started_at} and #{ended_at}:",
         humanize_report(report[:interval]),
       ].flatten.join("\n")
     end

--- a/lib/report/general_statistics.rb
+++ b/lib/report/general_statistics.rb
@@ -15,8 +15,6 @@ module Report
       @report ||= {
         all: full_report(all_users, all_logins),
         interval: full_report(interval_users, interval_logins),
-        start_date: start_date,
-        end_date: end_date,
       }
     end
 

--- a/spec/requests/api/v1/report/bigquery_spec.rb
+++ b/spec/requests/api/v1/report/bigquery_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "/api/v1/report/bigquery" do
       travel_to Time.zone.local(2020, 1, 1, 10, 0, 0) do
         post api_v1_report_bigquery_path, params: params, headers: headers
         expect(response).to have_http_status(202)
-        expect(JSON.parse(response.body)["start_date"]).to eq("2019-12-31T15:00:00.000+00:00")
+        expect(JSON.parse(response.body)["start_date"]).to eq("2019-12-31 15:00:00 +00:00")
       end
     end
   end
@@ -61,7 +61,7 @@ RSpec.describe "/api/v1/report/bigquery" do
       travel_to Time.zone.local(2020, 1, 1, 10, 0, 0) do
         post api_v1_report_bigquery_path, params: params, headers: headers
         expect(response).to have_http_status(202)
-        expect(JSON.parse(response.body)["end_date"]).to eq("2020-01-01T15:00:00.000+00:00")
+        expect(JSON.parse(response.body)["end_date"]).to eq("2020-01-01 15:00:00 +00:00")
       end
     end
   end

--- a/spec/requests/api/v1/report/general_spec.rb
+++ b/spec/requests/api/v1/report/general_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "/api/v1/report/general" do
       travel_to Time.zone.local(2020, 1, 1, 10, 0, 0) do
         get api_v1_report_general_path, params: params, headers: headers
         expect(response).to be_successful
-        expect(JSON.parse(response.body)["start_date"]).to eq("2019-12-31T15:00:00.000+00:00")
+        expect(JSON.parse(response.body)["start_date"]).to eq("2019-12-31 15:00:00 +00:00")
       end
     end
   end
@@ -75,7 +75,7 @@ RSpec.describe "/api/v1/report/general" do
       travel_to Time.zone.local(2020, 1, 1, 10, 0, 0) do
         get api_v1_report_general_path, params: params, headers: headers
         expect(response).to be_successful
-        expect(JSON.parse(response.body)["end_date"]).to eq("2020-01-01T15:00:00.000+00:00")
+        expect(JSON.parse(response.body)["end_date"]).to eq("2020-01-01 15:00:00 +00:00")
       end
     end
   end
@@ -99,7 +99,7 @@ RSpec.describe "/api/v1/report/general" do
       body = JSON.parse(response.body)
       expect(body.count).to eq(1)
       expect(body.first["title"]).to eq("Daily Statistics")
-      expect(body.first["text"]).to start_with("Report up to #{end_date}")
+      expect(body.first["text"]).to start_with("Report up to 2020-01-01 15:00:00 +00:00")
     end
   end
 end


### PR DESCRIPTION
Rather than rely on automatic-stringification of dates in our
reporting code, instead use a given format.  This gives timestamps
which are slightly less verbose than the current output (no fragments
of a second), and solves a Ruby 3 compatibility issue, which changes
the default format.