### PR TITLE
Fix layout header JS reference

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -6,7 +6,7 @@
 //= require govuk_publishing_components/components/details
 //= require govuk_publishing_components/components/error-summary
 //= require govuk_publishing_components/components/govspeak
-//= require govuk_publishing_components/components/header
+//= require govuk_publishing_components/components/layout-header
 //= require govuk_publishing_components/components/radio
 //= require govuk_publishing_components/components/show-password
 //= require govuk_publishing_components/analytics/explicit-cross-domain-links


### PR DESCRIPTION
- this file has been renamed to fit component conventions, so updating here to match

Change was made to components gem here: https://github.com/alphagov/govuk_publishing_components/pull/1848 and will be followed soon by a breaking change. This PR removes that risk.