### PR TITLE
Install bullet gem to detect certain activerecord problems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem "sprockets-rails"
 gem "telephone_number"
 
 group :development, :test do
+  gem "bullet"
   gem "byebug"
   gem "capybara"
   gem "dotenv-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,9 @@ GEM
       msgpack (~> 1.0)
     brakeman (4.10.0)
     builder (3.2.4)
+    bullet (6.1.2)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     byebug (11.1.3)
     capybara (3.34.0)
       addressable
@@ -442,6 +445,7 @@ GEM
     unicorn (5.8.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)
+    uniform_notifier (1.13.2)
     warden (1.2.9)
       rack (>= 2.0.9)
     webdrivers (4.4.1)
@@ -472,6 +476,7 @@ DEPENDENCIES
   awesome_print
   aws-ip
   bootsnap
+  bullet
   byebug
   capybara
   climate_control

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.bullet_logger = true
+    Bullet.rails_logger = true
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded on

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -6,6 +6,12 @@
 # and recreated between test runs. Don't rely on the data there!
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.bullet_logger = true
+    Bullet.raise = true
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   config.assets.css_compressor = nil

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,6 +27,11 @@ RSpec.configure do |config|
   config.expose_dsl_globally = false
   config.infer_spec_type_from_file_location!
   config.use_transactional_fixtures = true
+
+  if Bullet.enable?
+    config.before(:each) { Bullet.start_request }
+    config.after(:each) { Bullet.end_request }
+  end
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
Bullet is able to detect:

- N+1 query problems
- Eager-loaded associations which are unused
- COUNT queries which could be avoided with a counter_cache

We don't currently have any of these problems, but we easily could do!

For example, if we were to change the security page to show the user
agent of each security activity,

    +          <br>
    +          <%= activity.user_agent&.name %>

Then we would have an N+1 query problem if we didn't also eager-load
the `user_agent` association, and indeed bullet detects this, throws
an exception, and tells you what to change:

     Bullet::Notification::UnoptimizedQueryError:
       user: root
       GET /account/security
       USE eager loading detected
         SecurityActivity => [:user_agent]
         Add to your query: .includes([:user_agent])
       Call stack
         /govuk/govuk-account-manager-prototype/app/views/security/show.html.erb:84:in `block in _app_views_security_show_html_erb__3613801695823746490_88320'
         /govuk/govuk-account-manager-prototype/app/views/security/show.html.erb:70:in `each'
         /govuk/govuk-account-manager-prototype/app/views/security/show.html.erb:70:in `_app_views_security_show_html_erb__3613801695823746490_88320'
         /govuk/govuk-account-manager-prototype/spec/requests/security_activity_spec.rb:198:in `expect_event_on_security_page'
         /govuk/govuk-account-manager-prototype/spec/requests/security_activity_spec.rb:31:in `block (2 levels) in <top (required)>'

Even though it's not found any problems in the app so far, I think
it's a useful future-proofing thing to bring in.