### PR TITLE
Use the new bulk attributes endpoint to update userinfo

### DIFF
--- a/app/jobs/set_attributes_job.rb
+++ b/app/jobs/set_attributes_job.rb
@@ -3,12 +3,10 @@ class SetAttributesJob < ApplicationJob
 
   def perform(access_token_id, attributes)
     token = Doorkeeper::AccessToken.find(access_token_id)
-    attributes.each do |key, value|
-      RestClient.put(
-        "#{ENV['ATTRIBUTE_SERVICE_URL']}/v1/attributes/#{key}",
-        { value: value.to_json },
-        { accept: :json, authorization: "Bearer #{token.token}" },
-      )
-    end
+    RestClient.post(
+      "#{ENV['ATTRIBUTE_SERVICE_URL']}/v1/attributes",
+      { attributes: attributes.transform_values(&:to_json) },
+      { accept: :json, authorization: "Bearer #{token.token}" },
+    )
   end
 end

--- a/lib/remote_user_info.rb
+++ b/lib/remote_user_info.rb
@@ -17,14 +17,9 @@ class RemoteUserInfo
   end
 
   def update_profile!
-    RestClient.put(
-      "#{ENV['ATTRIBUTE_SERVICE_URL']}/v1/attributes/email",
-      { value: @user.email.to_json },
-      { accept: :json, authorization: "Bearer #{token.token}" },
-    )
-    RestClient.put(
-      "#{ENV['ATTRIBUTE_SERVICE_URL']}/v1/attributes/email_verified",
-      { value: @user.confirmed?.to_json },
+    RestClient.post(
+      "#{ENV['ATTRIBUTE_SERVICE_URL']}/v1/attributes",
+      { attributes: { email: @user.email.to_json, email_verified: @user.confirmed?.to_json } },
       { accept: :json, authorization: "Bearer #{token.token}" },
     )
   end

--- a/spec/lib/remote_user_info_spec.rb
+++ b/spec/lib/remote_user_info_spec.rb
@@ -36,17 +36,14 @@ RSpec.describe RemoteUserInfo do
 
     context "#update_profile!" do
       it "calls the attribute service to set the profile attributes" do
-        email_stub = stub_request(:put, "#{attribute_service_url}/v1/attributes/email")
-          .with(headers: { accept: "application/json", authorization: "Bearer #{bearer_token}" }, body: { value: user.email.to_json })
-          .to_return(status: 200)
-        email_verified_stub = stub_request(:put, "#{attribute_service_url}/v1/attributes/email_verified")
-          .with(headers: { accept: "application/json", authorization: "Bearer #{bearer_token}" }, body: { value: user.confirmed?.to_json })
+        body = { attributes: { email: user.email.to_json, email_verified: user.confirmed?.to_json } }
+        stub = stub_request(:post, "#{attribute_service_url}/v1/attributes")
+          .with(headers: { accept: "application/json", authorization: "Bearer #{bearer_token}" }, body: body)
           .to_return(status: 200)
 
         described_class.new(user).update_profile!
 
-        expect(email_stub).to have_been_made
-        expect(email_verified_stub).to have_been_made
+        expect(stub).to have_been_made
       end
     end
   end


### PR DESCRIPTION
This reduces the number of network round-trips from 4 (2 requests to
attribute-service, each of which makes 1 request to account-manager to
check the token) to 2.