### PR TITLE
Format phone number when saving RegistrationState

### DIFF
--- a/app/models/registration_state.rb
+++ b/app/models/registration_state.rb
@@ -9,4 +9,10 @@ class RegistrationState < ApplicationRecord
 
   belongs_to :jwt, optional: true, dependent: :destroy
   delegate :jwt_payload, to: :jwt, allow_nil: true
+
+  before_save :format_phone_number
+
+  def format_phone_number
+    self.phone = MultiFactorAuth.e164_number(phone) if phone
+  end
 end

--- a/spec/models/registration_state_spec.rb
+++ b/spec/models/registration_state_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe RegistrationState do
+  let(:registration_state) { FactoryBot.create(:registration_state, touched_at: Time.zone.now, state: :phone) }
+
+  context "#phone" do
+    it "is formatted in E.164 format on save" do
+      registration_state.update!(phone: "07958 123 456")
+
+      expect(registration_state.phone).to eq("+447958123456")
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -39,4 +39,12 @@ RSpec.describe User do
         .to_return(status: 200)
     end
   end
+
+  context "#phone" do
+    it "is formatted in E.164 format on save" do
+      user.update!(phone: "07958 123 456")
+
+      expect(user.phone).to eq("+447958123456")
+    end
+  end
 end


### PR DESCRIPTION
We are currently sending a hotchpotch of differently formatted phone numbers to Notify when users first register. This is because the formatting to E.164 format only occurs once the User is created.

Therefore we should also format the number during the registration, to ensure the correctly formatted number is sent to Notify.