### PR TITLE
Set up proper ActiveRecord timestamps for login/registration states

### DIFF
--- a/app/controllers/devise_registration_controller.rb
+++ b/app/controllers/devise_registration_controller.rb
@@ -308,9 +308,7 @@ protected
   def registration_state
     @registration_state ||=
       begin
-        RegistrationState.find(@registration_state_id).tap do |state|
-          state.update!(touched_at: Time.zone.now)
-        end
+        RegistrationState.find(@registration_state_id).tap(&:touch)
       rescue ActiveRecord::RecordNotFound
         session.delete(:registration_state_id)
         nil

--- a/app/jobs/expire_registration_state_job.rb
+++ b/app/jobs/expire_registration_state_job.rb
@@ -2,6 +2,6 @@ class ExpireRegistrationStateJob < ApplicationJob
   queue_as :default
 
   def perform
-    RegistrationState.where("touched_at < ?", 60.minutes.ago).delete_all
+    RegistrationState.where("updated_at < ?", 60.minutes.ago).delete_all
   end
 end

--- a/db/migrate/20210120111907_add_timestamps_to_registration_state.rb
+++ b/db/migrate/20210120111907_add_timestamps_to_registration_state.rb
@@ -1,0 +1,10 @@
+class AddTimestampsToRegistrationState < ActiveRecord::Migration[6.0]
+  def change
+    # this is so use of the field can be removed from the code without
+    # error, after the new code is deployed a new migration to remove
+    # the field will be made.
+    change_column_null :registration_states, :touched_at, true
+
+    add_timestamps :registration_states, default: -> { 'now()' }, null: false
+  end
+end

--- a/db/migrate/20210120111915_add_timestamps_to_login_state.rb
+++ b/db/migrate/20210120111915_add_timestamps_to_login_state.rb
@@ -1,0 +1,10 @@
+class AddTimestampsToLoginState < ActiveRecord::Migration[6.0]
+  def change
+    # this to recreate the column with the default rails timestamp
+    # settings, it's safe because the field never "disappears" (though
+    # the migration does reset its value)
+    remove_column :login_states, :created_at, default: -> { 'now()' }, null: false
+
+    add_timestamps :login_states, default: -> { 'now()' }, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_11_133439) do
+ActiveRecord::Schema.define(version: 2021_01_20_111915) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -63,10 +63,11 @@ ActiveRecord::Schema.define(version: 2021_01_11_133439) do
   end
 
   create_table "login_states", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.datetime "created_at", null: false
     t.bigint "user_id", null: false
     t.string "redirect_path", null: false
     t.uuid "jwt_id"
+    t.datetime "created_at", precision: 6, default: -> { "now()" }, null: false
+    t.datetime "updated_at", precision: 6, default: -> { "now()" }, null: false
     t.index ["user_id"], name: "index_login_states_on_user_id"
   end
 
@@ -126,7 +127,7 @@ ActiveRecord::Schema.define(version: 2021_01_11_133439) do
   end
 
   create_table "registration_states", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.datetime "touched_at", null: false
+    t.datetime "touched_at"
     t.integer "state", null: false
     t.string "email", null: false
     t.string "previous_url"
@@ -139,6 +140,8 @@ ActiveRecord::Schema.define(version: 2021_01_11_133439) do
     t.boolean "cookie_consent"
     t.boolean "feedback_consent"
     t.uuid "jwt_id"
+    t.datetime "created_at", precision: 6, default: -> { "now()" }, null: false
+    t.datetime "updated_at", precision: 6, default: -> { "now()" }, null: false
   end
 
   create_table "security_activities", force: :cascade do |t|

--- a/spec/jobs/expire_registration_state_job_spec.rb
+++ b/spec/jobs/expire_registration_state_job_spec.rb
@@ -3,8 +3,8 @@ RSpec.describe ExpireRegistrationStateJob do
 
   it "deletes hour-old state" do
     freeze_time do
-      RegistrationState.create!(touched_at: 61.minutes.ago, email: "old", state: :start)
-      RegistrationState.create!(touched_at: 30.minutes.ago, email: "new", state: :start)
+      RegistrationState.create!(updated_at: 61.minutes.ago, email: "old", state: :start)
+      RegistrationState.create!(updated_at: 30.minutes.ago, email: "new", state: :start)
 
       described_class.perform_now
 


### PR DESCRIPTION
Once this is deployed, a second migration to remove the `touched_at`
field can be released.