### PR TITLE
Remove references to touched_at in code & specs

### DIFF
--- a/app/controllers/devise_registration_controller.rb
+++ b/app/controllers/devise_registration_controller.rb
@@ -36,7 +36,6 @@ class DeviseRegistrationController < Devise::RegistrationsController
       RegistrationState.transaction do
         destroy_stale_states(session[:jwt_id]) if session[:jwt_id]
         @registration_state = RegistrationState.create!(
-          touched_at: Time.zone.now,
           state: state,
           previous_url: payload&.dig(:post_register_oauth).presence || params[:previous_url],
           jwt_id: session[:jwt_id],

--- a/spec/factories/registration_state.rb
+++ b/spec/factories/registration_state.rb
@@ -8,7 +8,6 @@ FactoryBot.define do
       yes_to_emails { true }
       cookie_consent { true }
       feedback_consent { true }
-      touched_at { Time.zone.now }
       state { "finish" }
     end
   end

--- a/spec/feature/registration_from_another_application_spec.rb
+++ b/spec/feature/registration_from_another_application_spec.rb
@@ -179,7 +179,7 @@ RSpec.feature "Registration (coming from another application)" do
   end
 
   def i_enter_phone_code
-    phone_code = RegistrationState.order(:touched_at).last.phone_code
+    phone_code = RegistrationState.order(:updated_at).last.phone_code
     fill_in "phone_code", with: phone_code
     click_on I18n.t("mfa.phone.code.fields.submit.label")
 

--- a/spec/feature/registration_spec.rb
+++ b/spec/feature/registration_spec.rb
@@ -408,13 +408,13 @@ RSpec.feature "Registration" do
   end
 
   def enter_mfa
-    phone_code = RegistrationState.order(:touched_at).last.phone_code
+    phone_code = RegistrationState.order(:updated_at).last.phone_code
     fill_in "phone_code", with: phone_code
     click_on I18n.t("mfa.phone.code.fields.submit.label")
   end
 
   def enter_incorrect_mfa
-    phone_code = RegistrationState.order(:touched_at).last.phone_code
+    phone_code = RegistrationState.order(:updated_at).last.phone_code
     fill_in "phone_code", with: "1#{phone_code}"
     click_on I18n.t("mfa.phone.code.fields.submit.label")
   end

--- a/spec/jobs/expire_jwt_job_spec.rb
+++ b/spec/jobs/expire_jwt_job_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe ExpireJwtJob do
     freeze_time do
       jwt = Jwt.create!(created_at: 61.minutes.ago, jwt_payload: "old", skip_parse_jwt_token: true)
       RegistrationState.create!(
-        touched_at: Time.zone.now,
         state: :start,
         email: "email@example.com",
         jwt_id: jwt.id,

--- a/spec/models/registration_state_spec.rb
+++ b/spec/models/registration_state_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe RegistrationState do
-  let(:registration_state) { FactoryBot.create(:registration_state, touched_at: Time.zone.now, state: :phone) }
+  let(:registration_state) { FactoryBot.create(:registration_state, state: :phone) }
 
   context "#phone" do
     it "is formatted in E.164 format on save" do


### PR DESCRIPTION
This field is nullable in the database now, so it doesn't need to be
used.

Should really have done this as part of #622, oh well.