### PR TITLE
Scale down to 5 worker instances

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -247,7 +247,7 @@ jobs:
           PLEK_SERVICE_EMAIL_ALERT_API_URI: https://email-alert-api.publishing.service.gov.uk
           SECRET_KEY_BASE: ((secret-key-base-production))
           WEBSITE_ROOT: https://www.gov.uk
-          WORKER_INSTANCES: 20
+          WORKER_INSTANCES: 5
         on_success:
           try:
             put: grafana-annotate-deploy


### PR DESCRIPTION
These workers are mostly used for sending emails and text messages,
for running scheduled database cleanup tasks, and once a day one of
them spends a couple of minutes generating the BigQuery report.

All of these things are quick.  The workers are idle most of the time.
We don't need 20 of them, so I divided the count by 4 somewhat
arbitrarily.