### PR TITLE
Use symbolic response codes

### DIFF
--- a/app/controllers/api/v1/deanonymise_token_controller.rb
+++ b/app/controllers/api/v1/deanonymise_token_controller.rb
@@ -4,14 +4,14 @@ class Api::V1::DeanonymiseTokenController < Doorkeeper::ApplicationController
   respond_to :json
 
   rescue_from ActionController::ParameterMissing do
-    head 400
+    head :bad_request
   end
 
   def show
     if token.nil?
-      head 404
+      head :not_found
     elsif token.expired?
-      head 410
+      head :gone
     elsif token.resource_owner_id.nil?
       render json: { scopes: token.scopes.to_a }
     else

--- a/app/controllers/api/v1/ephemeral_state_controller.rb
+++ b/app/controllers/api/v1/ephemeral_state_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::EphemeralStateController < Doorkeeper::ApplicationController
       # if we're here the token is valid, so the EphemeralState did
       # exist once, but now it's gone - so a 410 is more appropriate
       # than a 404.
-      head 410
+      head :gone
       return
     end
 

--- a/app/controllers/api/v1/report/bigquery_controller.rb
+++ b/app/controllers/api/v1/report/bigquery_controller.rb
@@ -5,10 +5,10 @@ class Api::V1::Report::BigqueryController < Doorkeeper::ApplicationController
 
   def create
     end_date = params[:end_date] ? Time.zone.parse(params[:end_date]) : Time.zone.parse("15:00:00")
-    head 400 and return if end_date.nil?
+    head :bad_request and return if end_date.nil?
 
     start_date = params[:start_date] ? Time.zone.parse(params[:start_date]) : 1.day.before(end_date)
-    head 400 and return if start_date.nil?
+    head :bad_request and return if start_date.nil?
 
     BigqueryReportExportJob.perform_later(start_date, end_date)
 

--- a/app/controllers/api/v1/report/general_controller.rb
+++ b/app/controllers/api/v1/report/general_controller.rb
@@ -5,10 +5,10 @@ class Api::V1::Report::GeneralController < Doorkeeper::ApplicationController
 
   def show
     end_date = params[:end_date] ? Time.zone.parse(params[:end_date]) : Time.zone.parse("15:00:00")
-    head 400 and return if end_date.nil?
+    head :bad_request and return if end_date.nil?
 
     start_date = params[:start_date] ? Time.zone.parse(params[:start_date]) : 1.day.before(end_date)
-    head 400 and return if start_date.nil?
+    head :bad_request and return if start_date.nil?
 
     report = Report::GeneralStatistics.new(start_date: start_date, end_date: end_date)
 

--- a/spec/requests/api/v1/deanonymise_token_spec.rb
+++ b/spec/requests/api/v1/deanonymise_token_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe "/api/v1/deanonymise-token" do
 
       it "throws a 410" do
         get api_v1_deanonymise_token_path, params: params, headers: headers
-        expect(response).to have_http_status(410)
+        expect(response).to have_http_status(:gone)
       end
     end
 
@@ -93,14 +93,14 @@ RSpec.describe "/api/v1/deanonymise-token" do
 
       it "throws a 404" do
         get api_v1_deanonymise_token_path, params: params, headers: headers
-        expect(response).to have_http_status(404)
+        expect(response).to have_http_status(:not_found)
       end
     end
 
     context "with no check token" do
       it "throws a 400" do
         get api_v1_deanonymise_token_path, headers: headers
-        expect(response).to have_http_status(400)
+        expect(response).to have_http_status(:bad_request)
       end
     end
   end
@@ -110,7 +110,7 @@ RSpec.describe "/api/v1/deanonymise-token" do
 
     it "throws a 403" do
       get api_v1_deanonymise_token_path, params: params, headers: headers
-      expect(response).to have_http_status(403)
+      expect(response).to have_http_status(:forbidden)
     end
   end
 end

--- a/spec/requests/api/v1/ephemeral_state_spec.rb
+++ b/spec/requests/api/v1/ephemeral_state_spec.rb
@@ -45,6 +45,6 @@ RSpec.describe "/api/v1/ephemeral-state" do
     EphemeralState.create!(user: user, token: token.token, ga_client_id: "hello world")
     get api_v1_ephemeral_state_path, headers: headers
     get api_v1_ephemeral_state_path, headers: headers
-    expect(response).to have_http_status(410)
+    expect(response).to have_http_status(:gone)
   end
 end

--- a/spec/requests/api/v1/report/bigquery_spec.rb
+++ b/spec/requests/api/v1/report/bigquery_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "/api/v1/report/bigquery" do
 
     it "returns a 400" do
       post api_v1_report_bigquery_path, params: params, headers: headers
-      expect(response).to have_http_status(400)
+      expect(response).to have_http_status(:bad_request)
     end
   end
 end

--- a/spec/requests/api/v1/report/general_spec.rb
+++ b/spec/requests/api/v1/report/general_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe "/api/v1/report/general" do
 
     it "returns a 400" do
       get api_v1_report_general_path, params: params, headers: headers
-      expect(response).to have_http_status(400)
+      expect(response).to have_http_status(:bad_request)
     end
   end
 

--- a/spec/requests/api/v1/transition_checker/emails_spec.rb
+++ b/spec/requests/api/v1/transition_checker/emails_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "/api/v1/transition-checker/*" do
 
       it "returns a 204" do
         get api_v1_transition_checker_email_subscription_path, headers: headers
-        expect(response).to have_http_status(204)
+        expect(response).to have_http_status(:no_content)
       end
 
       context "the subscription is disabled" do
@@ -53,7 +53,7 @@ RSpec.describe "/api/v1/transition-checker/*" do
 
         it "returns a 410" do
           get api_v1_transition_checker_email_subscription_path, headers: headers
-          expect(response).to have_http_status(410)
+          expect(response).to have_http_status(:gone)
         end
       end
 
@@ -62,7 +62,7 @@ RSpec.describe "/api/v1/transition-checker/*" do
 
         it "returns a 204" do
           get api_v1_transition_checker_email_subscription_path, headers: headers
-          expect(response).to have_http_status(204)
+          expect(response).to have_http_status(:no_content)
         end
       end
     end
@@ -70,7 +70,7 @@ RSpec.describe "/api/v1/transition-checker/*" do
     context "without an email subscription" do
       it "returns a 404" do
         get api_v1_transition_checker_email_subscription_path, headers: headers
-        expect(response).to have_http_status(404)
+        expect(response).to have_http_status(:not_found)
       end
     end
   end


### PR DESCRIPTION
I did this in my refactoring PR for the attribute-service, so it seems reasonable to do it here too.