### PR TITLE
Move expiration durations into constants & queries into scopes

### DIFF
--- a/app/jobs/expire_ephemeral_state_job.rb
+++ b/app/jobs/expire_ephemeral_state_job.rb
@@ -2,6 +2,6 @@ class ExpireEphemeralStateJob < ApplicationJob
   queue_as :default
 
   def perform
-    EphemeralState.where("created_at < ?", 60.minutes.ago).delete_all
+    EphemeralState.expired.delete_all
   end
 end

--- a/app/jobs/expire_jwt_job.rb
+++ b/app/jobs/expire_jwt_job.rb
@@ -2,6 +2,6 @@ class ExpireJwtJob < ApplicationJob
   queue_as :default
 
   def perform
-    Jwt.without_login_states.without_registration_states.where("jwts.created_at < ?", 60.minutes.ago).delete_all
+    Jwt.expired.delete_all
   end
 end

--- a/app/jobs/expire_login_state_job.rb
+++ b/app/jobs/expire_login_state_job.rb
@@ -2,6 +2,6 @@ class ExpireLoginStateJob < ApplicationJob
   queue_as :default
 
   def perform
-    LoginState.where("created_at < ?", 60.minutes.ago).delete_all
+    LoginState.expired.delete_all
   end
 end

--- a/app/jobs/expire_registration_state_job.rb
+++ b/app/jobs/expire_registration_state_job.rb
@@ -2,6 +2,6 @@ class ExpireRegistrationStateJob < ApplicationJob
   queue_as :default
 
   def perform
-    RegistrationState.where("updated_at < ?", 60.minutes.ago).delete_all
+    RegistrationState.expired.delete_all
   end
 end

--- a/app/models/ephemeral_state.rb
+++ b/app/models/ephemeral_state.rb
@@ -1,6 +1,9 @@
 class EphemeralState < ApplicationRecord
   belongs_to :user
 
+  EXPIRATION_AGE = 60.minutes
+  scope :expired, -> { where("created_at < ?", EXPIRATION_AGE.ago) }
+
   def to_hash
     {
       _ga: ga_client_id,

--- a/app/models/jwt.rb
+++ b/app/models/jwt.rb
@@ -4,8 +4,12 @@ class Jwt < ApplicationRecord
   has_one :registration_state, dependent: :destroy
   has_one :login_state, dependent: :destroy
 
-  scope :without_login_states, -> { left_joins(:login_state).where("login_states.jwt_id IS NULL") }
-  scope :without_registration_states, -> { left_joins(:registration_state).where("registration_states.jwt_id IS NULL") }
+  EXPIRATION_AGE = 60.minutes
+  scope :expired, (lambda do
+    left_joins(:login_state).where("login_states.jwt_id IS NULL")
+      .left_joins(:registration_state).where("registration_states.jwt_id IS NULL")
+      .where("jwts.created_at < ?", EXPIRATION_AGE.ago)
+  end)
 
   before_save :parse_jwt_token, unless: :skip_parse_jwt_token
 

--- a/app/models/login_state.rb
+++ b/app/models/login_state.rb
@@ -1,4 +1,7 @@
 class LoginState < ApplicationRecord
   belongs_to :user
   belongs_to :jwt, optional: true, dependent: :destroy
+
+  EXPIRATION_AGE = 60.minutes
+  scope :expired, -> { where("created_at < ?", EXPIRATION_AGE.ago) }
 end

--- a/app/models/registration_state.rb
+++ b/app/models/registration_state.rb
@@ -10,6 +10,9 @@ class RegistrationState < ApplicationRecord
   belongs_to :jwt, optional: true, dependent: :destroy
   delegate :jwt_payload, to: :jwt, allow_nil: true
 
+  EXPIRATION_AGE = 60.minutes
+  scope :expired, -> { where("updated_at < ?", EXPIRATION_AGE.ago) }
+
   before_save :format_phone_number
 
   def format_phone_number

--- a/spec/jobs/expire_jwt_job_spec.rb
+++ b/spec/jobs/expire_jwt_job_spec.rb
@@ -3,46 +3,14 @@ RSpec.describe ExpireJwtJob do
 
   let!(:user) { FactoryBot.create(:user) }
 
-  it "deletes hour-old state" do
+  it "deletes old state" do
     freeze_time do
-      Jwt.create!(created_at: 61.minutes.ago, jwt_payload: "old", skip_parse_jwt_token: true)
-      Jwt.create!(created_at: 30.minutes.ago, jwt_payload: "new", skip_parse_jwt_token: true)
+      Jwt.create!(created_at: (Jwt::EXPIRATION_AGE + 1.minute).ago, jwt_payload: "old", skip_parse_jwt_token: true)
+      Jwt.create!(created_at: Jwt::EXPIRATION_AGE.ago, jwt_payload: "new", skip_parse_jwt_token: true)
 
-      described_class.perform_now
+      expect { described_class.perform_now }.to(change { Jwt.expired.count })
 
-      expect(Jwt.count).to eq(1)
       expect(Jwt.pluck(:jwt_payload)).to eq(%w[new])
-    end
-  end
-
-  it "doesn't delete jwts attached to a RegistrationState" do
-    freeze_time do
-      jwt = Jwt.create!(created_at: 61.minutes.ago, jwt_payload: "old", skip_parse_jwt_token: true)
-      RegistrationState.create!(
-        state: :start,
-        email: "email@example.com",
-        jwt_id: jwt.id,
-      )
-
-      described_class.perform_now
-
-      expect(Jwt.last).to eq(jwt)
-    end
-  end
-
-  it "doesn't delete jwts attached to a LoginState" do
-    freeze_time do
-      jwt = Jwt.create!(created_at: 61.minutes.ago, jwt_payload: "old", skip_parse_jwt_token: true)
-      LoginState.create!(
-        created_at: Time.zone.now,
-        user: user,
-        redirect_path: "/",
-        jwt_id: jwt.id,
-      )
-
-      described_class.perform_now
-
-      expect(Jwt.last).to eq(jwt)
     end
   end
 end

--- a/spec/jobs/expire_registration_state_job_spec.rb
+++ b/spec/jobs/expire_registration_state_job_spec.rb
@@ -1,14 +1,13 @@
 RSpec.describe ExpireRegistrationStateJob do
   include ActiveSupport::Testing::TimeHelpers
 
-  it "deletes hour-old state" do
+  it "deletes old state" do
     freeze_time do
-      RegistrationState.create!(updated_at: 61.minutes.ago, email: "old", state: :start)
-      RegistrationState.create!(updated_at: 30.minutes.ago, email: "new", state: :start)
+      RegistrationState.create!(updated_at: (RegistrationState::EXPIRATION_AGE + 1.minute).ago, email: "old", state: :start)
+      RegistrationState.create!(updated_at: RegistrationState::EXPIRATION_AGE.ago, email: "new", state: :start)
 
-      described_class.perform_now
+      expect { described_class.perform_now }.to(change { RegistrationState.expired.count })
 
-      expect(RegistrationState.count).to eq(1)
       expect(RegistrationState.pluck(:email)).to eq(%w[new])
     end
   end


### PR DESCRIPTION
I'm a fan of jobs being a couple of lines at most, just calling some function on another thing.  I'm also a fan of avoiding weird magic numbers.  So let's simplify by moving all the expiration durations into the relevant models and having the jobs just filter on a scope.

I've moved some of the JWT expiration specs into the model spec from the job spec, as they're now testing that the scope does the right thing.