### PR TITLE
Fix warning about fragile `to_not raise_error(...)` test

### DIFF
--- a/spec/models/jwt_spec.rb
+++ b/spec/models/jwt_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe Jwt do
       let(:jwt_post_register_oauth) { nil }
 
       it "accepts" do
-        expect { Jwt.create!(jwt_payload: jwt) }.to_not raise_error(Jwt::InvalidJWT)
+        expect { Jwt.create!(jwt_payload: jwt) }.to_not raise_error
       end
     end
 


### PR DESCRIPTION
This is fragile because any other error will pass.  What we actually
care about is that no error is raised.