### PR TITLE
Stop using the composite_primary_keys gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ ruby File.read(".ruby-version").strip
 
 gem "aws-ip"
 gem "bootsnap"
-gem "composite_primary_keys"
 gem "devise"
 gem "doorkeeper"
 gem "doorkeeper-openid_connect"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,8 +84,6 @@ GEM
     childprocess (3.0.0)
     climate_control (0.2.0)
     coderay (1.1.3)
-    composite_primary_keys (12.0.6)
-      activerecord (~> 6.0.0)
     concurrent-ruby (1.1.8)
     connection_pool (2.2.3)
     crack (0.4.5)
@@ -492,7 +490,6 @@ DEPENDENCIES
   byebug
   capybara
   climate_control
-  composite_primary_keys
   devise
   doorkeeper
   doorkeeper-openid_connect

--- a/app/models/application_key.rb
+++ b/app/models/application_key.rb
@@ -1,6 +1,4 @@
 class ApplicationKey < ApplicationRecord
-  self.primary_keys = :application_uid, :key_id
-
   def to_key
     OpenSSL::PKey::EC.new(pem)
   end

--- a/app/models/jwt.rb
+++ b/app/models/jwt.rb
@@ -34,7 +34,9 @@ private
     application = Doorkeeper::Application.by_uid(payload["uid"])
     raise UidNotFound unless application
 
-    signing_key = ApplicationKey.find([payload["uid"], payload["key"]])
+    signing_key = ApplicationKey.find_by(application_uid: payload["uid"], key_id: payload["key"])
+    raise KeyNotFound unless signing_key
+
     payload, = JWT.decode jwt_payload, signing_key.to_key, true, { algorithm: "ES256" }
 
     scopes = payload.fetch("scopes", []).map(&:to_sym)
@@ -67,7 +69,5 @@ private
     }
   rescue JWT::DecodeError
     raise JWTDecodeError
-  rescue ActiveRecord::RecordNotFound
-    raise KeyNotFound
   end
 end

--- a/db/migrate/20210121000409_recreate_application_keys_table_with_one_primary_key.rb
+++ b/db/migrate/20210121000409_recreate_application_keys_table_with_one_primary_key.rb
@@ -1,0 +1,32 @@
+class RecreateApplicationKeysTableWithOnePrimaryKey < ActiveRecord::Migration[6.0]
+  def up
+    # read all the keys into memory before destroying the table - this
+    # is fine at the moment.
+    application_keys = ApplicationKey.all.map do |key|
+      {
+        application_uid: key.application_uid,
+        key_id: key.key_id,
+        pem: key.pem
+      }
+    end
+
+    drop_table :application_keys
+
+    create_table :application_keys do |t|
+      t.string :application_uid, null: false
+      t.uuid   :key_id,          null: false
+      t.string :pem,             null: false
+
+      t.timestamps default: -> { 'now()' }, null: false
+
+      t.index :application_uid
+      t.index :key_id
+    end
+
+    ApplicationKey.insert_all(application_keys)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration, "cannot be reversed without reinstalling the composite_primary_keys gem"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,11 +16,14 @@ ActiveRecord::Schema.define(version: 2021_01_21_102522) do
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
-  create_table "application_keys", primary_key: ["application_uid", "key_id"], force: :cascade do |t|
+  create_table "application_keys", force: :cascade do |t|
     t.string "application_uid", null: false
     t.uuid "key_id", null: false
     t.string "pem", null: false
+    t.datetime "created_at", precision: 6, default: -> { "now()" }, null: false
+    t.datetime "updated_at", precision: 6, default: -> { "now()" }, null: false
     t.index ["application_uid"], name: "index_application_keys_on_application_uid"
+    t.index ["key_id"], name: "index_application_keys_on_key_id"
   end
 
   create_table "banned_passwords", force: :cascade do |t|


### PR DESCRIPTION
We're not getting much use out of this gem, and it's not compatible
with rails 6.1 yet (admittedly, they are working on it).  As it is a
surprisingly complex gem for little gain I think it's more of a
liability than a help, at least for our use-case where we only have a
single table with a composite primary key.

This will not be an error-free migration: any JWTs which are
validated *after* the migration but *before* the code deploy will
error; but I'm not sure there is a nice way to do this with
zero-downtime, and deploys are much faster now that we've scaled down
anyway.