### PR TITLE
Amend page titles and add meta descriptions

### DIFF
--- a/app/views/delete/confirmation.html.erb
+++ b/app/views/delete/confirmation.html.erb
@@ -1,7 +1,7 @@
-<% content_for :title, t("account.delete.confirmation.heading") %>
+<% content_for :title, t("account.delete.confirmation.page_title") %>
 
 <%= render "govuk_publishing_components/components/heading", {
-  text: yield(:title),
+  text: t("account.delete.confirmation.heading"),
   heading_level: 1,
   font_size: "l",
   margin_bottom: 4,

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t("devise.passwords.edit.heading") %>
+<% content_for :title, t("devise.passwords.edit.page_title") %>
 
 <% unless @reset_password_token_valid %>
   <%= render "govuk_publishing_components/components/error_alert", {
@@ -7,7 +7,7 @@
 <% end %>
 
 <%= render "govuk_publishing_components/components/heading", {
-  text: yield(:title),
+  text: t("devise.passwords.edit.heading"),
   heading_level: 1,
   margin_top: 0,
   margin_bottom: 3,

--- a/app/views/devise/passwords/sent.html.erb
+++ b/app/views/devise/passwords/sent.html.erb
@@ -1,7 +1,7 @@
-<% content_for :title, t("reset_sent.heading") %>
+<% content_for :title, t("reset_sent.page_title") %>
 
 <%= render "govuk_publishing_components/components/heading", {
-  text: yield(:title),
+  text: t("reset_sent.heading"),
   heading_level: 1,
   font_size: "l",
   margin_top: 0,

--- a/app/views/devise/registrations/phone_code.html.erb
+++ b/app/views/devise/registrations/phone_code.html.erb
@@ -1,7 +1,7 @@
-<% content_for :title, t("mfa.phone.code.sign_up_heading") %>
+<% content_for :title, t("mfa.phone.code.page_title") %>
 
 <%= render "govuk_publishing_components/components/heading", {
-  text: yield(:title),
+  text: t("mfa.phone.code.sign_up_heading"),
   heading_level: 1,
   font_size: "xl",
   margin_top: 0,

--- a/app/views/devise/registrations/start.html.erb
+++ b/app/views/devise/registrations/start.html.erb
@@ -1,4 +1,7 @@
 <% content_for :title, t("devise.registrations.start.heading") %>
+<% content_for :meta_tags do %>
+  <meta name="description" content='<%= t("devise.registrations.start.meta_description") %>'>
+<% end %>
 
 <%= form_with(url: new_user_registration_start_path, method: :post) do %>
   <% if resource || @resource_error_messages %>

--- a/app/views/devise/registrations/transition_checker.html.erb
+++ b/app/views/devise/registrations/transition_checker.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, t("devise.registrations.transition_checker.page_title") %>
 <%= render "govuk_publishing_components/components/heading", {
   text: t("devise.registrations.transition_checker.heading"),
   heading_level: 1,

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,7 +1,10 @@
-<% content_for :title, t("devise.sessions.new.heading") %>
+<% content_for :title, t("devise.sessions.new.page_title") %>
+<% content_for :meta_tags do %>
+  <meta name="description" content='<%= t("devise.sessions.new.meta_description") %>'>
+<% end %>
 
 <%= render "govuk_publishing_components/components/heading", {
-  text: yield(:title),
+  text: t("devise.sessions.new.heading"),
   heading_level: 1,
   font_size: "xl",
   margin_top: 0,

--- a/app/views/devise/sessions/phone_code.html.erb
+++ b/app/views/devise/sessions/phone_code.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, t("mfa.phone.code.page_title") %>
+
 <%= render "govuk_publishing_components/components/heading", {
   text: t("mfa.phone.code.sign_in_heading"),
   heading_level: 1,

--- a/app/views/devise/sessions/phone_resend.html.erb
+++ b/app/views/devise/sessions/phone_resend.html.erb
@@ -1,9 +1,11 @@
+<% content_for :title, t("mfa.phone.resend.heading") %>
+
 <%= render "govuk_publishing_components/components/back_link", {
   href: user_session_phone_code_path
 } %>
 
 <%= render "govuk_publishing_components/components/heading", {
-  text: t("mfa.phone.resend.heading"),
+  text: yield(:title),
   heading_level: 1,
   font_size: "xl",
   margin_top: 0,

--- a/app/views/edit_consent/cookie.html.erb
+++ b/app/views/edit_consent/cookie.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t("devise.registrations.your_information.fields.cookie_consent.heading") %>
+<% content_for :title, t("devise.registrations.your_information.fields.cookie_consent.page_title") %>
 <% content_for :location, "manage" %>
 <% content_for :account_navigation do %>
   <%= render "account-navigation", page_is: yield(:location) %>

--- a/app/views/edit_consent/feedback.html.erb
+++ b/app/views/edit_consent/feedback.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t("devise.registrations.your_information.fields.feedback_consent.heading") %>
+<% content_for :title, t("devise.registrations.your_information.fields.feedback_consent.page_title") %>
 <% content_for :location, "manage" %>
 <% content_for :account_navigation do %>
   <%= render "account-navigation", page_is: yield(:location) %>
@@ -16,7 +16,7 @@
 
   <%= render "govuk_publishing_components/components/radio", {
     name: "feedback_consent",
-    heading: yield(:title),
+    heading: t("devise.registrations.your_information.fields.feedback_consent.heading"),
     heading_size: "l",
     is_page_heading: true,
     items: [

--- a/app/views/edit_phone/code.html.erb
+++ b/app/views/edit_phone/code.html.erb
@@ -1,5 +1,6 @@
+<% content_for :title, t("mfa.phone.code.change_heading") %>
 <%= render "govuk_publishing_components/components/heading", {
-  text: t("mfa.phone.code.change_heading"),
+  text: yield(:title),
   heading_level: 1,
   margin_top: 0,
   margin_bottom: 3,

--- a/app/views/edit_phone/resend.html.erb
+++ b/app/views/edit_phone/resend.html.erb
@@ -1,7 +1,9 @@
+<% content_for :title, t("mfa.phone.resend.heading") %>
+
 <%= render "govuk_publishing_components/components/back_link", { href: edit_user_registration_phone_code_path } %>
 
 <%= render "govuk_publishing_components/components/heading", {
-  text: t("mfa.phone.resend.heading"),
+  text: yield(:title),
   heading_level: 1,
   font_size: "xl",
   margin_top: 0,

--- a/app/views/edit_phone/show.html.erb
+++ b/app/views/edit_phone/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, t("mfa.phone.update.start.heading") %>
 <% content_for :location, "manage" %>
 <% content_for :account_navigation do %>
   <%= render "account-navigation", page_is: yield(:location) %>
@@ -5,7 +6,7 @@
 
 <%= render "govuk_publishing_components/components/back_link", { href: account_manage_path } %>
 <%= render "govuk_publishing_components/components/heading", {
-  text: t("mfa.phone.update.start.heading"),
+  text: yield(:title),
   heading_level: 1,
   font_size: "l",
   margin_bottom: 6,

--- a/app/views/feedback/show.html.erb
+++ b/app/views/feedback/show.html.erb
@@ -1,3 +1,8 @@
+<% content_for :title, t("feedback.show.page_title") %>
+<% content_for :meta_tags do %>
+  <meta name="description" content='<%= t("feedback.show.meta_description") %>'>
+<% end %>
+
 <% contact_details = capture do %>
   <%= render "govuk_publishing_components/components/input", {
     label: {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,9 +8,8 @@
   <title><%= content_for?(:title) ? "#{yield(:title)} - GOV.UK Account" : "GOV.UK Account" %></title>
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="theme-color" content="blue">
-
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-
+  <%= yield :meta_tags %>
   <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
   <link rel="mask-icon" href="/assets/images/govuk-mask-icon.svg" color="#0b0c0c">
   <link rel="apple-touch-icon" sizes="180x180" href="/assets/images/govuk-apple-touch-icon-180x180.png">

--- a/app/views/manage/show.html.erb
+++ b/app/views/manage/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t("account.manage.heading") %>
+<% content_for :title, t("account.manage.page_title") %>
 <% content_for :location, "manage" %>
 <% content_for :account_navigation do %>
   <%= render "account-navigation", page_is: yield(:location) %>
@@ -9,7 +9,7 @@
 <% end %>
 
 <%= render "govuk_publishing_components/components/heading", {
-  text: yield(:title),
+  text: t("account.manage.heading"),
   heading_level: 1,
   font_size: "l",
   margin_bottom: 7,

--- a/config/locales/account/delete.en.yml
+++ b/config/locales/account/delete.en.yml
@@ -7,6 +7,7 @@ en:
         description_1: You’ve successfully deleted your GOV.UK account.
         description_2: If you did not mean to do this, <a class="govuk-link" href="%{link}">contact us</a>.
         heading: Success
+        page_title: Deleted GOV.UK Account
         return_link: <a class="govuk-link" href="%{link}">Go to the GOV.UK homepage</a>.
       description: 'This will permanently delete this account and all the information stored in it, including:'
       doomed:

--- a/config/locales/account/feedback.en.yml
+++ b/config/locales/account/feedback.en.yml
@@ -39,6 +39,8 @@ en:
               label: 'Yes'
       heading: Give feedback about your GOV.UK account
       inset_text: If your question or feedback is not about a GOV.UK account, for example you want to ask about tax or a visa application, you need to use <a href="https://www.gov.uk/contact" class="govuk-link">different contact details</a>.
+      meta_description: Use this form to give feedback or ask a question about your GOV.UK account.
+      page_title: Give feedback
     submit:
       call_to_action: |
         <p class="govuk-body">Your feedback has been sent to the GOV.UK Account team.</p>

--- a/config/locales/account/login.en.yml
+++ b/config/locales/account/login.en.yml
@@ -26,6 +26,8 @@ en:
           submit:
             label: Continue
         heading: Sign in to your GOV.UK account
+        meta_description: Sign in to your GOV.UK account. GOV.UK accounts are a trial. At the moment you can only use the GOV.UK account with the Brexit checker.
+        page_title: Sign in
         register: <p class="govuk-body">You can <a class="govuk-link" href="%{register}">sign up for a new account</a> if this is your first visit.</p>
         reset_password: <p class="govuk-body govuk-!-margin-bottom-0">You can <a class="govuk-link" href="%{reset_password}">change your password</a> if you’ve forgotten it.</p>
     unlocks:

--- a/config/locales/account/manage.en.yml
+++ b/config/locales/account/manage.en.yml
@@ -10,6 +10,7 @@ en:
         heading: Account details
         unconfirmed: unconfirmed
       heading: Manage your account
+      page_title: Manage your GOV.UK account
       privacy:
         cookies_description: For example what pages you visit and what you click on
         cookies_link_extra: your cookie settings

--- a/config/locales/account/password_edit.en.yml
+++ b/config/locales/account/password_edit.en.yml
@@ -14,6 +14,7 @@ en:
     passwords:
       edit:
         heading: Reset your password
+        page_title: Create a new password
         password:
           hint: Your password must be at least 8 characters and hard to guess.
           label: Create a new password
@@ -37,5 +38,6 @@ en:
     content_with_email: We’ve sent a link for resetting your password to %{email}. The link will expire in 6 hours.
     content_without_email: We’ve sent an email to the address you provided with instructions for changing your password.
     heading: Reset your password - check your email
+    page_title: Password reset email sent
     subheading: If you did not get the email
     try_again: <p class="govuk-body">We can <a class="govuk-link" href="%{link}"">send the password reset email again</a> if you did not get it.</p>

--- a/config/locales/account/registration.en.yml
+++ b/config/locales/account/registration.en.yml
@@ -23,6 +23,7 @@ en:
           submit:
             label: Continue
         heading: Create a GOV.UK account
+        meta_description: Create a GOV.UK account to save the actions you need to take for Brexit. GOV.UK accounts are a trial. At the moment you can only use the GOV.UK account with the Brexit checker.
         secure_password_tip:
           text: |
             <p class="govuk-body">A good way to create a secure and memorable password is to use 3 random words.</p>
@@ -33,6 +34,7 @@ en:
       transition_checker:
         heading: This email address does not have a GOV.UK account
         message: To create an account, you need to <a class="govuk-link" href="%{link}">answer a few questions in the Brexit checker</a> and subscribe to email updates.
+        page_title: You do not have a GOV.UK account
       transition_emails:
         description: |
           <p class="govuk-body">The emails will give you a personalised list of actions for you, your family and your business.</p>
@@ -74,12 +76,14 @@ en:
             heading: Can we use cookies to learn about how you use GOV.UK while you’re signed in to your account?
             hint: You’ll be able to update this later in your privacy settings if you’re not sure or you change your mind.
             'no': 'No'
+            page_title: Change your cookie settings
             'yes': 'Yes'
           feedback_consent:
             heading: Can we email you to ask for feedback about your account?
             hint: You can update this later in your privacy settings if you’re not sure or you change your mind.
             message: As we add more features to your account, we would like to email you to find out any thoughts or suggestions you might have.
             'no': 'No'
+            page_title: Change your feedback settings
             section_heading: Feedback about your GOV.UK account
             'yes': 'Yes'
           submit:

--- a/config/locales/mfa.en.yml
+++ b/config/locales/mfa.en.yml
@@ -38,6 +38,7 @@ en:
           sign_in_message: We can <a class="govuk-link" href="%{link}">send a new security code</a> if you’re having trouble with the code.
           sign_up_heading: Resend security code or change your mobile number
           sign_up_message: We can <a class="govuk-link" href="%{link}">send a new security code</a> if you’re having trouble with the code or if it was sent to the wrong mobile number.
+        page_title: Enter your security code
         sign_in_heading: Check your phone
         sign_up_heading: Check your phone
       resend:


### PR DESCRIPTION
## What 
Amend page titles for the pages that need it. Add meta descriptions for the pages that appear as search engine results.

## Why

Page titles on the account manager prototype are currently either blank (defaulting to "GOVUK Account") which is a WCAG fail, or are using the page heading as a page title, which is not always appropriate.

There has been a [content audit](https://docs.google.com/spreadsheets/d/18AlXCQv2wCfV2zv0KeYWvO__7AG4GZ8XLfOPSefMTbs/edit#gid=0) of all the page titles on the GOV.UK Account journey. This implements the changes suggested as a result of the content audit.

The addition of meta descriptions will make GOVUK Account pages look more legitimate in search engine results, or if they happen to be shared on social media. The current meta descriptions are generated from the existing content on the page which reads rather disorganised.
From Google search results:

<img width="668" alt="Screenshot 2021-01-19 at 15 04 25" src="https://user-images.githubusercontent.com/7116819/105377788-17ddc800-5c03-11eb-8d4a-3903bf65f56b.png">



https://trello.com/c/BVKJVRST