### PR TITLE
Install autoscaling plugin before deploy

### DIFF
--- a/concourse/tasks/deploy-to-govuk-paas.yml
+++ b/concourse/tasks/deploy-to-govuk-paas.yml
@@ -39,6 +39,7 @@ run:
       cf apply-manifest -f manifest.yml
       cf set-env $CF_APP_NAME CF_STARTUP_TIMEOUT "$CF_STARTUP_TIMEOUT"
 
+      yes | cf install-plugin -r CF-Community app-autoscaler-plugin
       cf attach-autoscaling-policy $CF_APP_NAME $CF_APP_SCALING_POLICY
 
       if [[ "${REQUIRE_BASIC_AUTH:-}" = "true" ]]; then


### PR DESCRIPTION
Concourse tasks are stateless, so we'll need to install this on the environment each time before we are able to use `cf attach-autoscaling-policy`