### PR TITLE
Move JWT handling out of ApplicationController

### DIFF
--- a/app/controllers/concerns/accepts_jwt.rb
+++ b/app/controllers/concerns/accepts_jwt.rb
@@ -6,7 +6,9 @@ module AcceptsJwt
       if payload
         Jwt.create!(jwt_payload: payload).tap { |j| session[:jwt_id] = j.id }
       elsif session[:jwt_id]
-        Jwt.find_by(id: session[:jwt_id]) || session.delete(:jwt_id) && nil
+        Jwt.find_by(id: session[:jwt_id]) || session.delete(:jwt_id) && Jwt::Nil.new
+      else
+        Jwt::Nil.new
       end
   end
 end

--- a/app/controllers/concerns/accepts_jwt.rb
+++ b/app/controllers/concerns/accepts_jwt.rb
@@ -1,0 +1,12 @@
+module AcceptsJwt
+  extend ActiveSupport::Concern
+
+  def find_or_create_jwt(payload = nil)
+    @find_or_create_jwt ||=
+      if payload
+        Jwt.create!(jwt_payload: payload).tap { |j| session[:jwt_id] = j.id }
+      elsif session[:jwt_id]
+        Jwt.find_by(id: session[:jwt_id]) || session.delete(:jwt_id) && nil
+      end
+  end
+end

--- a/app/controllers/devise_registration_controller.rb
+++ b/app/controllers/devise_registration_controller.rb
@@ -1,4 +1,5 @@
 class DeviseRegistrationController < Devise::RegistrationsController
+  include AcceptsJwt
   include CookiesHelper
 
   # rubocop:disable Rails/LexicallyScopedActionFilter
@@ -21,9 +22,9 @@ class DeviseRegistrationController < Devise::RegistrationsController
   def start
     render :closed and return unless Rails.configuration.enable_registration
 
-    payload = get_payload
+    jwt = find_or_create_jwt
 
-    @criteria_keys = payload.dig(:attributes, :transition_checker_state, "criteria_keys") if payload
+    @criteria_keys = jwt&.jwt_payload&.dig("attributes", "transition_checker_state", "criteria_keys")
 
     return if request.get?
 
@@ -38,11 +39,11 @@ class DeviseRegistrationController < Devise::RegistrationsController
     if resource.valid?
       state = MultiFactorAuth.is_enabled? ? :phone : :your_information
       RegistrationState.transaction do
-        destroy_stale_states(session[:jwt_id]) if session[:jwt_id]
+        jwt&.destroy_stale_states
         @registration_state = RegistrationState.create!(
           state: state,
-          previous_url: payload&.dig(:post_register_oauth).presence || params[:previous_url],
-          jwt_id: session[:jwt_id],
+          previous_url: jwt&.jwt_payload&.dig("post_register_oauth").presence || params[:previous_url],
+          jwt: jwt,
           email: params.dig(:user, :email),
           encrypted_password: resource.send(:password_digest, params.dig(:user, :password)),
           phone: MultiFactorAuth.is_enabled? ? params.dig(:user, :phone) : nil,

--- a/app/controllers/devise_registration_controller.rb
+++ b/app/controllers/devise_registration_controller.rb
@@ -24,7 +24,7 @@ class DeviseRegistrationController < Devise::RegistrationsController
 
     jwt = find_or_create_jwt
 
-    @criteria_keys = jwt&.jwt_payload&.dig("attributes", "transition_checker_state", "criteria_keys")
+    @criteria_keys = jwt.jwt_payload.dig("attributes", "transition_checker_state", "criteria_keys")
 
     return if request.get?
 
@@ -39,11 +39,11 @@ class DeviseRegistrationController < Devise::RegistrationsController
     if resource.valid?
       state = MultiFactorAuth.is_enabled? ? :phone : :your_information
       RegistrationState.transaction do
-        jwt&.destroy_stale_states
+        jwt.destroy_stale_states
         @registration_state = RegistrationState.create!(
           state: state,
-          previous_url: jwt&.jwt_payload&.dig("post_register_oauth").presence || params[:previous_url],
-          jwt: jwt,
+          previous_url: jwt.jwt_payload.dig("post_register_oauth").presence || params[:previous_url],
+          jwt_id: jwt.id,
           email: params.dig(:user, :email),
           encrypted_password: resource.send(:password_digest, params.dig(:user, :password)),
           phone: MultiFactorAuth.is_enabled? ? params.dig(:user, :phone) : nil,

--- a/app/controllers/devise_sessions_controller.rb
+++ b/app/controllers/devise_sessions_controller.rb
@@ -27,12 +27,12 @@ class DeviseSessionsController < Devise::SessionsController
       end
 
       LoginState.transaction do
-        jwt&.destroy_stale_states
+        jwt.destroy_stale_states
         @login_state = LoginState.create!(
           created_at: Time.zone.now,
           user: resource,
-          redirect_path: after_login_path(jwt&.jwt_payload, resource),
-          jwt: jwt,
+          redirect_path: after_login_path(jwt.jwt_payload, resource),
+          jwt_id: jwt.id,
         )
         @login_state_id = login_state.id
       end
@@ -64,7 +64,7 @@ class DeviseSessionsController < Devise::SessionsController
       elsif user_exists
         @resource_error_messages[:password] = [I18n.t("activerecord.errors.models.user.attributes.password.blank")]
       elsif @email.present? && Devise.email_regexp.match?(@email)
-        redirect_to new_user_registration_start_path(user: { email: @email }) and return if jwt
+        redirect_to new_user_registration_start_path(user: { email: @email }) and return if jwt.id
 
         render "devise/registrations/transition_checker" and return if Rails.configuration.force_jwt_at_registration
 
@@ -131,7 +131,7 @@ protected
   end
 
   def after_login_path(payload, user)
-    payload&.dig("post_login_oauth").presence || after_sign_in_path_for(user)
+    payload.dig("post_login_oauth").presence || after_sign_in_path_for(user)
   end
 
   def login_state

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,13 +1,14 @@
 class WelcomeController < ApplicationController
+  include AcceptsJwt
   include UrlHelper
 
   skip_before_action :verify_authenticity_token
 
   def show
-    payload = get_payload(params[:jwt])
+    jwt = find_or_create_jwt(params[:jwt])
 
     if current_user
-      redirect_to add_param_to_url(after_login_path(payload, current_user), "_ga", params[:_ga])
+      redirect_to add_param_to_url(after_login_path(jwt&.jwt_payload, current_user), "_ga", params[:_ga])
       return
     end
 
@@ -17,6 +18,6 @@ class WelcomeController < ApplicationController
 protected
 
   def after_login_path(payload, user)
-    payload&.dig(:post_login_oauth).presence || after_sign_in_path_for(user)
+    payload&.dig("post_login_oauth").presence || after_sign_in_path_for(user)
   end
 end

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -8,7 +8,7 @@ class WelcomeController < ApplicationController
     jwt = find_or_create_jwt(params[:jwt])
 
     if current_user
-      redirect_to add_param_to_url(after_login_path(jwt&.jwt_payload, current_user), "_ga", params[:_ga])
+      redirect_to add_param_to_url(after_login_path(jwt.jwt_payload, current_user), "_ga", params[:_ga])
       return
     end
 
@@ -18,6 +18,6 @@ class WelcomeController < ApplicationController
 protected
 
   def after_login_path(payload, user)
-    payload&.dig("post_login_oauth").presence || after_sign_in_path_for(user)
+    payload.dig("post_login_oauth").presence || after_sign_in_path_for(user)
   end
 end

--- a/app/models/jwt.rb
+++ b/app/models/jwt.rb
@@ -24,6 +24,20 @@ class Jwt < ApplicationRecord
   class UidNotFound < InvalidJWT; end
   class InvalidOAuthRedirect < InvalidJWT; end
 
+  def destroy_stale_states
+    transaction do
+      RegistrationState.where(jwt_id: id).tap do |states|
+        states.update_all(jwt_id: nil)
+        states.destroy_all
+      end
+
+      LoginState.where(jwt_id: id).tap do |states|
+        states.update_all(jwt_id: nil)
+        states.destroy_all
+      end
+    end
+  end
+
 private
 
   def parse_jwt_token

--- a/app/models/jwt.rb
+++ b/app/models/jwt.rb
@@ -13,6 +13,16 @@ class Jwt < ApplicationRecord
 
   before_save :parse_jwt_token, unless: :skip_parse_jwt_token
 
+  class Nil
+    def id; end
+
+    def jwt_payload
+      {}
+    end
+
+    def destroy_stale_states; end
+  end
+
   class InvalidJWT < StandardError; end
   class InsufficientScopes < InvalidJWT; end
   class InvalidScopes < InvalidJWT; end


### PR DESCRIPTION
The get_payload method should be in a concern which is only included
by the three controllers which need it.

The destroy_stale_states method should be on a Jwt instance, and it
should also be in a transaction.