### PR TITLE
Remove jQuery

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,14 +39,16 @@ group :development, :test do
   gem "capybara"
   gem "dotenv-rails"
   gem "factory_bot_rails"
+  gem "govuk_test"
   gem "i18n-tasks", "~> 0.9.33"
+  gem "jasmine"
+  gem "jasmine_selenium_runner"
   gem "pry-rails"
   gem "rspec-rails"
 end
 
 group :test do
   gem "climate_control"
-  gem "govuk_test"
   gem "oauth2"
   gem "simplecov"
   gem "webmock"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,6 +213,15 @@ GEM
       terminal-table (>= 1.5.1)
     inflection (1.0.0)
     ipaddress (0.8.3)
+    jasmine (3.6.0)
+      jasmine-core (~> 3.6.0)
+      phantomjs
+      rack (>= 1.2.1)
+      rake
+    jasmine-core (3.6.0)
+    jasmine_selenium_runner (3.0.0)
+      jasmine (~> 3.0)
+      selenium-webdriver (~> 3.8)
     json-jwt (1.13.0)
       activesupport (>= 4.2)
       aes_key_wrap
@@ -280,6 +289,7 @@ GEM
     parser (2.7.2.0)
       ast (~> 2.4.1)
     pg (1.2.3)
+    phantomjs (2.1.1.0)
     plek (4.0.0)
     pry (0.13.1)
       coderay (~> 1.1)
@@ -524,6 +534,8 @@ DEPENDENCIES
   govuk_publishing_components
   govuk_test
   i18n-tasks (~> 0.9.33)
+  jasmine
+  jasmine_selenium_runner
   jwt
   kaminari
   listen

--- a/Rakefile
+++ b/Rakefile
@@ -7,4 +7,4 @@ require_relative "config/application"
 
 Rails.application.load_tasks
 
-task default: %i[spec lint]
+task default: %i[spec lint jasmine:ci]

--- a/app/assets/javascripts/analytics-track-form.js
+++ b/app/assets/javascripts/analytics-track-form.js
@@ -20,7 +20,12 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
             $checkedOption = $checkedOptions[i]
             var trackAction = $checkedOption.getAttribute('data-track-action')
             var checkedOptionId = $checkedOption.getAttribute('id')
-            var checkedOptionLabel = $submittedForm.querySelector('label[for="' + checkedOptionId + '"]').innerText.trim()
+            var checkedOptionLabel = $submittedForm.querySelector('label[for="' + checkedOptionId + '"]')
+            if (checkedOptionLabel) {
+              checkedOptionLabel = checkedOptionLabel.textContent.trim()
+            } else {
+             checkedOptionLabel =  "No label found"
+            }
             questionValue = checkedOptionLabel.length ? checkedOptionLabel : $checkedOption.value
 
             if (typeof ga === 'function') {

--- a/app/assets/javascripts/analytics-track-form.js
+++ b/app/assets/javascripts/analytics-track-form.js
@@ -9,23 +9,23 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   GOVUK.Modules.TrackForm = function () {
     this.start = function (element) {
-      track(element)
+      track(element[0])
     }
 
     function track (element) {
-      element.on('submit', function (event) {
+      element.addEventListener('submit', function(event) {
         var $checkedOption, questionValue
-        var $submittedForm = $(event.target)
-        var $checkedOptions = $submittedForm.find('input:checked')
-        var trackCategory = $submittedForm.data('track-category')
+        var $submittedForm = event.target
+        var $checkedOptions = $submittedForm.querySelectorAll('input:checked')
+        var trackCategory = $submittedForm.getAttribute('data-track-category')
 
         if ($checkedOptions.length) {
-          $checkedOptions.each(function (index) {
-            $checkedOption = $(this)
-            var trackAction = $checkedOption.data('track-action')
-            var checkedOptionId = $checkedOption.attr('id')
-            var checkedOptionLabel = $submittedForm.find('label[for="' + checkedOptionId + '"]').text().trim()
-            questionValue = checkedOptionLabel.length ? checkedOptionLabel : $checkedOption.val()
+          for (var i = 0; i < $checkedOptions.length; i++) {
+            $checkedOption = $checkedOptions[i]
+            var trackAction = $checkedOption.getAttribute('data-track-action')
+            var checkedOptionId = $checkedOption.getAttribute('id')
+            var checkedOptionLabel = $submittedForm.querySelector('label[for="' + checkedOptionId + '"]').innerText.trim()
+            questionValue = checkedOptionLabel.length ? checkedOptionLabel : $checkedOption.value
 
             if (typeof ga === 'function') {
               ga('send', {
@@ -35,7 +35,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
                 eventLabel: questionValue
               })
             }
-          })
+          }
         }
       })
     }

--- a/app/assets/javascripts/analytics-track-form.js
+++ b/app/assets/javascripts/analytics-track-form.js
@@ -9,11 +9,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   GOVUK.Modules.TrackForm = function () {
     this.start = function (element) {
-      track(element[0])
-    }
-
-    function track (element) {
-      element.addEventListener('submit', function(event) {
+      element[0].addEventListener('submit', function(event) {
         var $checkedOption, questionValue
         var $submittedForm = event.target
         var $checkedOptions = $submittedForm.querySelectorAll('input:checked')

--- a/app/assets/javascripts/analytics-track-form.js
+++ b/app/assets/javascripts/analytics-track-form.js
@@ -7,8 +7,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 (function (global, GOVUK) {
   'use strict'
 
-  var $ = global.jQuery
-
   GOVUK.Modules.TrackForm = function () {
     this.start = function (element) {
       track(element)

--- a/app/assets/javascripts/analytics.js
+++ b/app/assets/javascripts/analytics.js
@@ -8,12 +8,13 @@ window.GOVUK.analyticsVars.linkedDomains = ['www.gov.uk']
 if (typeof window.GOVUK.analyticsInit !== 'undefined') {
   window.GOVUK.analyticsInit()
 
-  if (window.GOVUK.cookie('cookies_preferences_set') && window.GOVUK.cookie('cookies_policy')) {
+  var cookieConsentRadio = document.querySelectorAll('input[name=cookie_consent]')
+  if (window.GOVUK.cookie('cookies_preferences_set') && window.GOVUK.cookie('cookies_policy') && cookieConsentRadio.length) {
     var currentConsentCookie = JSON.parse(window.GOVUK.cookie('cookies_policy'))
     if (currentConsentCookie.usage === true) {
-      $('input[name=cookie_consent][value=yes]').prop('checked', true)
+      document.querySelectorAll('input[name=cookie_consent][value=yes]')[0].checked = true
     } else {
-      $('input[name=cookie_consent][value=no]').prop('checked', true)
+      document.querySelectorAll('input[name=cookie_consent][value=no]')[0].checked = true
     }
   }
 }

--- a/app/assets/javascripts/analytics.js
+++ b/app/assets/javascripts/analytics.js
@@ -12,9 +12,9 @@ if (typeof window.GOVUK.analyticsInit !== 'undefined') {
   if (window.GOVUK.cookie('cookies_preferences_set') && window.GOVUK.cookie('cookies_policy') && cookieConsentRadio.length) {
     var currentConsentCookie = JSON.parse(window.GOVUK.cookie('cookies_policy'))
     if (currentConsentCookie.usage === true) {
-      document.querySelectorAll('input[name=cookie_consent][value=yes]')[0].checked = true
+      document.querySelector('input[name=cookie_consent][value=yes]').checked = true
     } else {
-      document.querySelectorAll('input[name=cookie_consent][value=no]')[0].checked = true
+      document.querySelector('input[name=cookie_consent][value=no]').checked = true
     }
   }
 }

--- a/spec/javascripts/modules/analytics-track-form-spec.js
+++ b/spec/javascripts/modules/analytics-track-form-spec.js
@@ -1,0 +1,48 @@
+describe('Form tracker', function () {
+  'use strict'
+
+  var form
+
+  beforeEach(function () {
+    if (typeof window.ga === 'undefined') {
+      window.ga = function () {}
+    }
+    spyOn(window, 'ga')
+
+    form = $('<form onsubmit="event.preventDefault()"/>').attr('data-track-category', 'dummy-category')
+    form.appendTo('body')
+  })
+
+  afterEach(function () {
+    form.remove()
+  })
+
+  it('sends chosen options to Google Analytics when submitting the form', function () {
+    var contents =
+      '<label for="test1">Test 1</label>' +
+      '<input type="checkbox" checked data-track-action="test1" id="test1"/>' +
+      '<label for="test2">Test 2</label>' +
+      '<input type="checkbox" checked data-track-action="test2" id="test2"/>' +
+      '<button type="submit">submit</button>'
+    form[0].innerHTML = contents
+    new GOVUK.Modules.TrackForm().start(form)
+
+    // need to submit the form like this otherwise jquery's submit overrides the JS version
+    var button = form[0].querySelector('button')
+    button.click()
+
+    expect(window.ga).toHaveBeenCalledWith('send', { hitType: 'event', eventCategory: 'dummy-category', eventAction: 'test1', eventLabel: 'Test 1' })
+    expect(window.ga).toHaveBeenCalledWith('send', { hitType: 'event', eventCategory: 'dummy-category', eventAction: 'test2', eventLabel: 'Test 2' })
+  })
+
+  it('does not send anything if the form does not contain the right things', function () {
+    var contents = '<button type="submit">submit</button>'
+    form[0].innerHTML = contents
+    new GOVUK.Modules.TrackForm().start(form)
+
+    var button = form[0].querySelector('button')
+    button.click()
+
+    expect(window.ga).not.toHaveBeenCalled()
+  })
+})

--- a/spec/javascripts/modules/analytics-track-form-spec.js
+++ b/spec/javascripts/modules/analytics-track-form-spec.js
@@ -35,6 +35,23 @@ describe('Form tracker', function () {
     expect(window.ga).toHaveBeenCalledWith('send', { hitType: 'event', eventCategory: 'dummy-category', eventAction: 'test2', eventLabel: 'Test 2' })
   })
 
+  it('sends chosen options to Google Analytics when submitting the form if the form is invalid', function () {
+    var contents =
+      '<label for="test1">Test 1</label>' +
+      '<input type="checkbox" checked data-track-action="test1" id="test1"/>' +
+      '<input type="checkbox" checked data-track-action="test2" id="test2"/>' +
+      '<button type="submit">submit</button>'
+    form[0].innerHTML = contents
+    new GOVUK.Modules.TrackForm().start(form)
+
+    // need to submit the form like this otherwise jquery's submit overrides the JS version
+    var button = form[0].querySelector('button')
+    button.click()
+
+    expect(window.ga).toHaveBeenCalledWith('send', { hitType: 'event', eventCategory: 'dummy-category', eventAction: 'test1', eventLabel: 'Test 1' })
+    expect(window.ga).toHaveBeenCalledWith('send', { hitType: 'event', eventCategory: 'dummy-category', eventAction: 'test2', eventLabel: 'No label found' })
+  })
+
   it('does not send anything if the form does not contain the right things', function () {
     var contents = '<button type="submit">submit</button>'
     form[0].innerHTML = contents

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -1,0 +1,145 @@
+# src_files
+#
+# Return an array of filepaths relative to src_dir to include before jasmine specs.
+# Default: []
+#
+# EXAMPLE:
+#
+# src_files:
+#   - lib/source1.js
+#   - lib/source2.js
+#   - 'dist/**/*.js'
+#
+src_files:
+  - assets/application.js
+
+# stylesheets
+#
+# Return an array of stylesheet filepaths relative to src_dir to include before jasmine specs.
+# Default: []
+#
+# EXAMPLE:
+#
+# stylesheets:
+#   - css/style.css
+#   - 'stylesheets/*.css'
+#
+stylesheets:
+  - assets/application.css
+
+# helpers
+#
+# Return an array of filepaths relative to spec_dir to include before jasmine specs.
+# Default: ["helpers/**/*.js"]
+#
+# EXAMPLE:
+#
+# helpers:
+#   - 'helpers/**/*.js'
+#
+helpers:
+  - 'helpers/**/*.js'
+
+# spec_files
+#
+# Return an array of filepaths relative to spec_dir to include.
+# Default: ["**/*[sS]pec.js"]
+#
+# EXAMPLE:
+#
+# spec_files:
+#   - '**/*[sS]pec.js'
+#
+spec_files:
+  - '**/*[sS]pec.js'
+
+# src_dir
+#
+# Source directory path. Your src_files must be returned relative to this path. Will use root if left blank.
+# Default: project root
+#
+# EXAMPLE:
+#
+# src_dir: public
+#
+src_dir:
+
+# spec_dir
+#
+# Spec directory path. Your spec_files must be returned relative to this path.
+# Default: spec/javascripts
+#
+# EXAMPLE:
+#
+# spec_dir: spec/javascripts
+#
+spec_dir:
+
+# spec_helper
+#
+# Ruby file that Jasmine server will require before starting.
+# Returned relative to your root path
+# Default spec/javascripts/support/jasmine_helper.rb
+#
+# EXAMPLE:
+#
+# spec_helper: spec/javascripts/support/jasmine_helper.rb
+#
+spec_helper: spec/javascripts/support/jasmine_helper.rb
+
+# boot_dir
+#
+# Boot directory path. Your boot_files must be returned relative to this path.
+# Default: Built in boot file
+#
+# EXAMPLE:
+#
+# boot_dir: spec/javascripts/support/boot
+#
+boot_dir:
+
+# boot_files
+#
+# Return an array of filepaths relative to boot_dir to include in order to boot Jasmine
+# Default: Built in boot file
+#
+# EXAMPLE
+#
+# boot_files:
+#   - '**/*.js'
+#
+boot_files:
+
+# rack_options
+#
+# Extra options to be passed to the rack server
+# by default, Port and AccessLog are passed.
+#
+# This is an advanced options, and left empty by default
+#
+# EXAMPLE
+#
+# rack_options:
+#   server: 'thin'
+
+# phantom_cli_options
+#
+# Extra options to be passed to the phantomjs cli,
+# e.g. to enable localStorage in PhantomJs 2.5
+#
+# EXAMPLE
+#
+# phantom_cli_options:
+#   local-storage-quota: 5000
+
+# random
+#
+# Run specs in semi-random order.
+# Default: true
+#
+# EXAMPLE:
+#
+# random: false
+#
+random:
+

--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -1,0 +1,24 @@
+# Use this file to set/override Jasmine configuration options
+# You can remove it if you don't need it.
+# This file is loaded *after* jasmine.yml is interpreted.
+#
+# Example: using a different boot file.
+# Jasmine.configure do |config|
+#    config.boot_dir = '/absolute/path/to/boot_dir'
+#    config.boot_files = lambda { ['/absolute/path/to/boot_dir/file.js'] }
+# end
+#
+# Example: prevent PhantomJS auto install, uses PhantomJS already on your path.
+require "jasmine_selenium_runner/configure_jasmine"
+
+class HeadlessChromeJasmineConfigurer < JasmineSeleniumRunner::ConfigureJasmine
+  def selenium_options
+    { options: GovukTest.headless_chrome_selenium_options }
+  end
+end
+
+Jasmine.configure do |config|
+  if ENV["TRAVIS"]
+    config.prevent_phantom_js_auto_install = true
+  end
+end

--- a/spec/javascripts/support/jasmine_selenium_runner.yml
+++ b/spec/javascripts/support/jasmine_selenium_runner.yml
@@ -1,0 +1,2 @@
+browser: chrome
+configuration_class: HeadlessChromeJasmineConfigurer

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,7 @@ require "capybara/rspec"
 require "webmock/rspec"
 
 Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
+GovukTest.configure
 
 SimpleCov.start do
   enable_coverage :branch


### PR DESCRIPTION
## What / why

Remove jQuery dependence from accounts. These scripts were added under a tight deadline so jQuery was acceptable, but our general strategy is to not add any new jQuery and slowly remove all the old stuff.

In order to remove the jQuery with confidence the first part of this PR is to add a jasmine testing infrastructure to accounts to ensure that the change hasn't broken anything.

I've not added a test for the code in `analytics.js` as it seemed overkill for such a small bit of code, but happy to discuss. For reference this sets the user preference for analytics when creating an account, if they have previously chosen an option on the cookie banner. For example, if the user lands at the first screen (create username + password) and rejects cookies through the cookie banner, when they get through to the screen allowing them to choose cookie settings, the 'no' option is automatically chosen by this JS. If they have not interacted with the cookie banner no option is prefilled.

## Visual changes

None.

Trello card: https://trello.com/c/yyp5Qedw/597-remove-jquery-dependence
