### PR TITLE
Recreate Gemfile.lock with older bundler version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -550,4 +550,4 @@ RUBY VERSION
    ruby 2.7.2p137
 
 BUNDLED WITH
-   2.2.3
+   2.1.4


### PR DESCRIPTION
This is to resolve this deployment issue:
https://cd.gds-reliability.engineering/teams/govuk-tools/pipelines/govuk-account-manager-prototype/jobs/deploy-app-staging/builds/596

The message is:
Warning: the running version of Bundler (2.1.4) is older than the
version that created the lockfile (2.2.3). We suggest you to upgrade to
the version that created the lockfile by running
`gem install bundler:2.2.3`.

My local version of bundler is newer than the one we currently have.
This meant that in my previous PR
(https://github.com/alphagov/govuk-account-manager-prototype/pull/657)
the Gemfile.lock file was created by bundler 2.2.3 instead of 2.1.4. We
will eventually update bundler to version 2.2.3 but for the moment
recreating the lockfile with the older version is faster.