### PR TITLE
Retry timed-out attribute service requests

### DIFF
--- a/lib/remote_user_info.rb
+++ b/lib/remote_user_info.rb
@@ -9,7 +9,9 @@ class RemoteUserInfo
 
   def user_info
     uri = "#{ENV['ATTRIBUTE_SERVICE_URL']}/oidc/user_info"
-    response = RestClient.get uri, { accept: :json, authorization: "Bearer #{token.token}" }
+    response = with_retries do
+      RestClient.get uri, { accept: :json, authorization: "Bearer #{token.token}" }
+    end
     JSON.parse(response.body).deep_symbolize_keys
   rescue StandardError => e
     Raven.capture_exception(e)
@@ -17,21 +19,36 @@ class RemoteUserInfo
   end
 
   def update_profile!
-    RestClient.post(
-      "#{ENV['ATTRIBUTE_SERVICE_URL']}/v1/attributes",
-      { attributes: { email: @user.email.to_json, email_verified: @user.confirmed?.to_json } },
-      { accept: :json, authorization: "Bearer #{token.token}" },
-    )
+    with_retries do
+      RestClient.post(
+        "#{ENV['ATTRIBUTE_SERVICE_URL']}/v1/attributes",
+        { attributes: { email: @user.email.to_json, email_verified: @user.confirmed?.to_json } },
+        { accept: :json, authorization: "Bearer #{token.token}" },
+      )
+    end
   end
 
   def destroy!
-    RestClient.delete(
-      "#{ENV['ATTRIBUTE_SERVICE_URL']}/v1/attributes/all",
-      { accept: :json, authorization: "Bearer #{token.token}" },
-    )
+    with_retries do
+      RestClient.delete(
+        "#{ENV['ATTRIBUTE_SERVICE_URL']}/v1/attributes/all",
+        { accept: :json, authorization: "Bearer #{token.token}" },
+      )
+    end
   end
 
   def token
     @token ||= AccountManagerApplication.user_token(@user.id)
+  end
+
+protected
+
+  def with_retries(attempts = 3)
+    yield
+  rescue RestClient::Exceptions::Timeout, RestClient::ServerBrokeConnection, RestClient::BadGateway, RestClient::GatewayTimeout => e
+    attempts -= 1
+    retry unless attempts.zero?
+
+    raise e
   end
 end

--- a/spec/lib/remote_user_info_spec.rb
+++ b/spec/lib/remote_user_info_spec.rb
@@ -11,22 +11,10 @@ RSpec.describe RemoteUserInfo do
     end
   end
 
-  context "the attribute service is down" do
-    before do
-      stub_request(:get, "#{attribute_service_url}/oidc/user_info")
-        .with(headers: { accept: "application/json", authorization: "Bearer #{bearer_token}" })
-        .to_return(status: 500)
-    end
+  context "#user_info" do
+    let(:attributes) { { attribute: "value" } }
 
-    it "returns nil" do
-      expect(described_class.call(user)).to be_nil
-    end
-  end
-
-  context "the attribute service is up" do
     it "calls the attribute service" do
-      attributes = { attribute: "value" }
-
       stub_request(:get, "#{attribute_service_url}/oidc/user_info")
         .with(headers: { accept: "application/json", authorization: "Bearer #{bearer_token}" })
         .to_return(body: attributes.to_json)
@@ -34,16 +22,85 @@ RSpec.describe RemoteUserInfo do
       expect(described_class.call(user)).to eq(attributes)
     end
 
-    context "#update_profile!" do
-      it "calls the attribute service to set the profile attributes" do
-        body = { attributes: { email: user.email.to_json, email_verified: user.confirmed?.to_json } }
-        stub = stub_request(:post, "#{attribute_service_url}/v1/attributes")
+    context "the attribute service is down" do
+      before do
+        stub_request(:get, "#{attribute_service_url}/oidc/user_info")
+          .with(headers: { accept: "application/json", authorization: "Bearer #{bearer_token}" })
+          .to_return(status: 500)
+      end
+
+      it "returns nil" do
+        expect(described_class.call(user)).to be_nil
+      end
+    end
+
+    context "the attribute service sporadically times out" do
+      let(:final_status) { 200 }
+
+      before do
+        stub_request(:get, "#{attribute_service_url}/oidc/user_info")
+          .with(headers: { accept: "application/json", authorization: "Bearer #{bearer_token}" })
+          .to_return(status: 504)
+        stub_request(:get, "#{attribute_service_url}/oidc/user_info")
+          .with(headers: { accept: "application/json", authorization: "Bearer #{bearer_token}" })
+          .to_return(status: 504)
+        stub_request(:get, "#{attribute_service_url}/oidc/user_info")
+          .with(headers: { accept: "application/json", authorization: "Bearer #{bearer_token}" })
+          .to_return(status: final_status, body: attributes.to_json)
+      end
+
+      it "tries 3 times" do
+        expect(described_class.call(user)).to eq(attributes)
+      end
+
+      context "the 3rd attempt fails" do
+        let(:final_status) { 504 }
+
+        it "returns nil" do
+          expect(described_class.call(user)).to be_nil
+        end
+      end
+    end
+  end
+
+  context "#update_profile!" do
+    let(:body) { { attributes: { email: user.email.to_json, email_verified: user.confirmed?.to_json } } }
+
+    it "calls the attribute service to set the profile attributes" do
+      stub = stub_request(:post, "#{attribute_service_url}/v1/attributes")
+        .with(headers: { accept: "application/json", authorization: "Bearer #{bearer_token}" }, body: body)
+        .to_return(status: 200)
+
+      described_class.new(user).update_profile!
+      expect(stub).to have_been_made
+    end
+
+    context "the attribute service sporadically times out" do
+      let(:final_status) { 200 }
+
+      before do
+        stub_request(:post, "#{attribute_service_url}/v1/attributes")
           .with(headers: { accept: "application/json", authorization: "Bearer #{bearer_token}" }, body: body)
-          .to_return(status: 200)
+          .to_return(status: 504)
+        stub_request(:post, "#{attribute_service_url}/v1/attributes")
+          .with(headers: { accept: "application/json", authorization: "Bearer #{bearer_token}" }, body: body)
+          .to_return(status: 504)
+        @stub = stub_request(:post, "#{attribute_service_url}/v1/attributes")
+          .with(headers: { accept: "application/json", authorization: "Bearer #{bearer_token}" }, body: body)
+          .to_return(status: final_status)
+      end
 
+      it "tries 3 times" do
         described_class.new(user).update_profile!
+        expect(@stub).to have_been_made
+      end
 
-        expect(stub).to have_been_made
+      context "the 3rd attempt fails" do
+        let(:final_status) { 504 }
+
+        it "re-throws the exception" do
+          expect { described_class.new(user).update_profile! }.to raise_error(RestClient::GatewayTimeout)
+        end
       end
     end
   end


### PR DESCRIPTION
We're currently experiencing an AWS outage which is making requests to one AZ fail.  But we have multiple instances, so we should retry and only throw an error if we're consistently failing to get a response.

- [Sentry: `RestClient::Exceptions::ReadTimeout`](https://sentry.io/organizations/govuk/issues/2191552217/?project=5370953&referrer=slack)
- [Sentry: `RestClient::BadGateway`](https://sentry.io/organizations/govuk/issues/2191639399/?project=5370953&referrer=slack)
- [Sentry: `RestClient::GatewayTimeout`](https://sentry.io/organizations/govuk/issues/2191656017/?project=5370953&referrer=slack)