### PR TITLE
Conditionally route to signup with JWT

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -12,7 +12,9 @@ class WelcomeController < ApplicationController
       return
     end
 
-    redirect_to add_param_to_url(new_user_registration_start_path, "_ga", params[:_ga])
+    path_to_redirect_to = jwt.jwt_payload.present? ? new_user_registration_start_path : new_user_session_path
+
+    redirect_to add_param_to_url(path_to_redirect_to, "_ga", params[:_ga])
   end
 
 protected

--- a/spec/requests/welcome_spec.rb
+++ b/spec/requests/welcome_spec.rb
@@ -1,23 +1,84 @@
 RSpec.describe "welcome" do
-  describe "GET" do
-    it "redirects to registration page" do
-      get welcome_path
-
-      expect(response).to redirect_to(new_user_registration_start_path)
-    end
+  let(:application) do
+    FactoryBot.create(
+      :oauth_application,
+      name: "name",
+      redirect_uri: redirect_uri,
+      scopes: application_scopes,
+    )
   end
 
-  context "the user is logged in" do
-    let(:user) { FactoryBot.create(:user) }
+  let(:application_scopes) { %i[test_scope_read test_scope_write] }
 
-    before do
-      sign_in(user)
+  let(:private_key) do
+    private_key = OpenSSL::PKey::EC.new "prime256v1"
+    private_key.generate_key
+  end
+
+  let(:public_key) { OpenSSL::PKey::EC.new private_key }
+
+  let(:application_key) do
+    ApplicationKey.create!(
+      application_uid: application.uid,
+      key_id: SecureRandom.uuid,
+      pem: public_key.to_pem,
+    )
+  end
+
+  let(:redirect_uri) { Rails.application.config.redirect_base_url }
+
+  let(:jwt_post_login_oauth_path) { "/oauth/authorize?some-query-string" }
+
+  let(:jwt_post_login_oauth) { redirect_uri + jwt_post_login_oauth_path }
+
+  let(:jwt) do
+    payload = {
+      uid: application.uid,
+      key: application_key.key_id,
+      scopes: [],
+      attributes: {},
+      post_login_oauth: jwt_post_login_oauth,
+    }
+    JWT.encode payload.compact, private_key, "ES256"
+  end
+
+  describe "GET" do
+    context "when the user types the url directly or clicks the link in the banner" do
+      before { get welcome_path }
+
+      it "redirects the user to the account login page" do
+        expect(response).to redirect_to(new_user_session_path)
+      end
     end
 
-    it "redirects the user to the account page" do
-      get welcome_path
+    context "when the user arrives from the Brexit checker with a valid jwt" do
+      before { post welcome_path, params: { "jwt" => jwt } }
 
-      expect(response).to redirect_to(user_root_path)
+      it "redirects the user to the account registration page" do
+        expect(response).to redirect_to(new_user_registration_start_path)
+      end
+    end
+
+    context "the user is logged in" do
+      let(:user) { FactoryBot.create(:user) }
+
+      before { sign_in(user) }
+
+      context "when the user types the url directly or clicks the link in the banner" do
+        before { get welcome_path }
+
+        it "redirects the user to the account page" do
+          expect(response).to redirect_to(user_root_path)
+        end
+      end
+
+      context "when the user arrives from the Brexit checker with a valid jwt" do
+        before { post welcome_path, params: { "jwt" => jwt } }
+
+        it "redirects the user to the Jwt post login oauth route" do
+          expect(response).to redirect_to(jwt_post_login_oauth_path)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
The header has an anchor-tag in the product name / crown that links to
the application root path (`/`). Before this commit, users who clicked
this link were routed to the signup page. This is not currently
desirable because we only want users to reach this page if they're
coming from the Brexit checker. This is because signing up without the
Brexit checker data results in an empty account, which is not useful for
the user.

We initially hoped we could redirect the user based on the href in the
account header. However, we use a [component][1] that has a hard coded
[href][2] so we cannot add conditionality at the view layer.

We then looked at doing this at the controller level. Visitors to the
root path are sent to the WelcomeController. This controller parses a
JWT and checks if the user is logged in. The new logic only applies if
the user is not logged in. If the user is logged in, the flow proceeds
as it did before.

Since JWT objects are only used in the context of the signup form, we
added a conditional statement to check if a JWT can be found with a
payload. If so, we progress to signup, otherwise we redirect the user to
login.

This works irrespective of if the JWT has arrived as a HTTP parameter,
or if it has been found by an id stored in the session.

[1]: https://github.com/alphagov/govuk-account-manager-prototype/blob/d49d5fa449029549ba75a967f7a5755dc72339e9/app/views/layouts/application.html.erb#L58-L62
[2]: https://github.com/alphagov/govuk_publishing_components/blob/19cd9a8e08563039f4e3e57a0a105884aa2be557/app/views/govuk_publishing_components/components/layout_header/_header_logo.html.erb#L2

Trello card: https://trello.com/c/mbhGiEIV/592-update-the-govuk-account-link-to-take-users-to-the-sign-in-journey

Co-authored-by: Huw Diprose <Huw.Diprose@digital.cabinet-office.gov.uk>
Co-authored-by: Alan Gabbianelli <Alan.Gabbianelli@digital.cabinet-office.gov.uk>