### PR TITLE
Enforce email addresses end with a letter

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -181,11 +181,12 @@ Devise.setup do |config|
   config.password_length = 8..128
 
   # Check email has exactly one "@" and at least one "." following the
-  # "@".  This doesn't aim to check the email is correct (the only way
-  # you can check that is by sending a message to it and seeing if the
-  # user receives it), but prevents some common syntactic errors which
-  # could never correspond to a valid email address on the Internet.
-  config.email_regexp = /\A[^@\s]+@[^@\s]+\.[^@\s]+\z/
+  # "@", and ends with a letter.  This doesn't aim to check the email
+  # is correct (the only way you can check that is by sending a
+  # message to it and seeing if the user receives it), but prevents
+  # some common syntactic errors which could never correspond to a
+  # valid email address on the Internet.
+  config.email_regexp = /\A[^@\s]+@[^@\s]+\.[^@\s]+[a-z]\z/
 
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this

--- a/spec/feature/registration_spec.rb
+++ b/spec/feature/registration_spec.rb
@@ -143,6 +143,18 @@ RSpec.feature "Registration" do
     end
   end
 
+  context "when the email ends with a digit" do
+    let(:email) { "foo@bar1" }
+
+    it "shows an error" do
+      visit_registration_form
+      enter_email_address
+      submit_registration_form
+
+      expect(page).to have_text(I18n.t("activerecord.errors.models.user.attributes.email.invalid"))
+    end
+  end
+
   context "when the user already exists" do
     let!(:user) { FactoryBot.create(:user) }
 


### PR DESCRIPTION
We've got a few users with email addresses ending with a digit.  There
are no TLDs which end with a digit, so Notify rejects them.

[Sentry error](https://sentry.io/organizations/govuk/issues/1840494980/?project=5370953&query=is%3Aunresolved&statsPeriod=14d)