### PR TITLE
Add an interstitial page and a reminder for users who have a password on the banlist

### DIFF
--- a/app/assets/stylesheets/accounts.scss
+++ b/app/assets/stylesheets/accounts.scss
@@ -144,7 +144,7 @@ $_current-indicator-width: 4px;
   margin-bottom: govuk-spacing(7);
 }
 
-.email-reminder {
+.user-reminder {
   padding: govuk-spacing(3);
   margin-bottom: govuk-spacing(7);
   background: govuk-colour("light-grey");

--- a/app/controllers/insecure_password_controller.rb
+++ b/app/controllers/insecure_password_controller.rb
@@ -1,0 +1,7 @@
+class InsecurePasswordController < ApplicationController
+  before_action :authenticate_user!
+
+  def show
+    redirect_to user_root_path unless current_user.banned_password_match
+  end
+end

--- a/app/views/account/show.html.erb
+++ b/app/views/account/show.html.erb
@@ -4,9 +4,7 @@
   <%= render "account-navigation", page_is: yield(:location) %>
 <% end %>
 
-<% if show_confirmation_reminder? %>
-  <%= render "email-confirmation-reminder" %>
-<% end %>
+<%= render "user-reminders" %>
 
 <% if flash[:notice] %>
   <% if flash_as_notice(flash[:notice]) %>

--- a/app/views/application/_email-confirmation-reminder.html.erb
+++ b/app/views/application/_email-confirmation-reminder.html.erb
@@ -1,6 +1,0 @@
-<section class="email-reminder" aria-label="Notice" role="region">
-  <p class="govuk-body govuk-!-margin-0">
-    <%= sanitize(t("confirm.intro.#{confirmation_banner_prompt_type}")) %>
-    <a href="<%= new_user_confirmation_path %>" class="govuk-link"><%= t("confirm.link_text") %></a>
-  </p>
-</section>

--- a/app/views/application/_user-reminders.html.erb
+++ b/app/views/application/_user-reminders.html.erb
@@ -1,0 +1,19 @@
+<% if show_confirmation_reminder? %>
+  <section class="user-reminder" aria-label="Notice" role="region">
+    <p class="govuk-body govuk-!-margin-0">
+      <%= sanitize(t("confirm.intro.#{confirmation_banner_prompt_type}")) %>
+      <a href="<%= new_user_confirmation_path %>" class="govuk-link"><%= t("confirm.link_text") %></a>
+    </p>
+  </section>
+<% end %>
+
+<% if current_user.banned_password_match %>
+  <section class="user-reminder" aria-label="Notice" role="region">
+    <p class="govuk-body govuk-!-font-weight-bold">
+      <%= t("insecure_password.notice.message") %>
+    </p>
+    <p class="govuk-body govuk-!-margin-bottom-0">
+      <a href="<%= edit_user_password_path %>" class="govuk-link"><%= t("insecure_password.notice.link") %></a>
+    </p>
+  </section>
+<% end %>

--- a/app/views/edit_phone/code.html.erb
+++ b/app/views/edit_phone/code.html.erb
@@ -2,7 +2,6 @@
 <%= render "govuk_publishing_components/components/heading", {
   text: yield(:title),
   heading_level: 1,
-  margin_top: 0,
   margin_bottom: 3,
 } %>
 

--- a/app/views/edit_phone/resend.html.erb
+++ b/app/views/edit_phone/resend.html.erb
@@ -6,7 +6,6 @@
   text: yield(:title),
   heading_level: 1,
   font_size: "xl",
-  margin_top: 0,
   margin_bottom: 3,
 } %>
 

--- a/app/views/insecure_password/show.html.erb
+++ b/app/views/insecure_password/show.html.erb
@@ -1,0 +1,24 @@
+<% content_for :title, t("insecure_password.interstitial.heading") %>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: yield(:title),
+  heading_level: 1,
+  font_size: "xl",
+  margin_bottom: 3,
+} %>
+
+<% t("insecure_password.interstitial.body").each do |msg| %>
+  <p class="govuk-body"><%= msg %></p>
+<% end %>
+
+<%= form_with url: edit_user_registration_password_path, method: :get do %>
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("insecure_password.interstitial.button"),
+    margin_bottom: true,
+  } %>
+<% end %>
+
+<p class="govuk-body">
+  <a class="govuk-link" href="<%= user_root_path %>"><%= t("insecure_password.interstitial.ignore.link") %></a>
+  <%= t("insecure_password.interstitial.ignore.outro") %>
+</p>

--- a/app/views/manage/show.html.erb
+++ b/app/views/manage/show.html.erb
@@ -4,9 +4,7 @@
   <%= render "account-navigation", page_is: yield(:location) %>
 <% end %>
 
-<% if show_confirmation_reminder? %>
-  <%= render "email-confirmation-reminder" %>
-<% end %>
+<%= render "user-reminders" %>
 
 <%= render "govuk_publishing_components/components/heading", {
   text: t("account.manage.heading"),

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -9,7 +9,6 @@
 <%= render "govuk_publishing_components/components/heading", {
   text: t("devise.passwords.edit.heading"),
   heading_level: 1,
-  margin_top: 0,
   margin_bottom: 3,
 } %>
 

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -4,7 +4,6 @@
   text: yield(:title),
   heading_level: 1,
   font_size: "l",
-  margin_top: 0,
   margin_bottom: 3,
 } %>
 

--- a/app/views/passwords/sent.html.erb
+++ b/app/views/passwords/sent.html.erb
@@ -4,7 +4,6 @@
   text: t("reset_sent.heading"),
   heading_level: 1,
   font_size: "l",
-  margin_top: 0,
   margin_bottom: 3,
 } %>
 
@@ -16,7 +15,6 @@
 <%= render "govuk_publishing_components/components/heading", {
   text: t("reset_sent.subheading"),
   heading_level: 2,
-  margin_top: 0,
   margin_bottom: 3,
 } %>
 

--- a/app/views/registrations/phone_code.html.erb
+++ b/app/views/registrations/phone_code.html.erb
@@ -4,7 +4,6 @@
   text: t("mfa.phone.code.sign_up_heading"),
   heading_level: 1,
   font_size: "xl",
-  margin_top: 0,
   margin_bottom: 3,
 } %>
 

--- a/app/views/registrations/phone_resend.html.erb
+++ b/app/views/registrations/phone_resend.html.erb
@@ -8,7 +8,6 @@
   text: t("mfa.phone.resend.heading"),
   heading_level: 1,
   font_size: "xl",
-  margin_top: 0,
   margin_bottom: 3,
 } %>
 

--- a/app/views/registrations/start.html.erb
+++ b/app/views/registrations/start.html.erb
@@ -12,7 +12,6 @@
     text: yield(:title),
     heading_level: 1,
     font_size: "xl",
-    margin_top: 0,
     margin_bottom: 3,
   } %>
 

--- a/app/views/registrations/transition_emails.html.erb
+++ b/app/views/registrations/transition_emails.html.erb
@@ -2,7 +2,6 @@
   text: t("devise.registrations.transition_emails.heading"),
   heading_level: 1,
   font_size: "xl",
-  margin_top: 0,
   margin_bottom: 3,
 } %>
 

--- a/app/views/security/paginated_activity.html.erb
+++ b/app/views/security/paginated_activity.html.erb
@@ -12,7 +12,6 @@
   title: yield(:title),
   context: t("account.security.page_numbering_header", current_page: page_navigation[:current_page], total_pages: page_navigation[:total_pages]),
   margin_bottom: 8,
-  margin_top: 0,
 } %>
 
 <% if page_navigation[:out_of_range] %>

--- a/app/views/security/paginated_activity.html.erb
+++ b/app/views/security/paginated_activity.html.erb
@@ -6,9 +6,7 @@
   <%= render "account-navigation", page_is: yield(:location) %>
 <% end %>
 
-<% if show_confirmation_reminder? %>
-  <%= render "email-confirmation-reminder" %>
-<% end %>
+<%= render "user-reminders" %>
 
 <%= render "govuk_publishing_components/components/title", {
   title: yield(:title),

--- a/app/views/security/paginated_mfa_tokens.html.erb
+++ b/app/views/security/paginated_mfa_tokens.html.erb
@@ -12,7 +12,6 @@
   title: yield(:title),
   context: t("account.security.page_numbering_header", current_page: page_navigation[:current_page], total_pages: page_navigation[:total_pages]),
   margin_bottom: 8,
-  margin_top: 0,
 } %>
 
 <% if page_navigation[:out_of_range] %>

--- a/app/views/security/paginated_mfa_tokens.html.erb
+++ b/app/views/security/paginated_mfa_tokens.html.erb
@@ -6,9 +6,7 @@
   <%= render "account-navigation", page_is: yield(:location) %>
 <% end %>
 
-<% if show_confirmation_reminder? %>
-  <%= render "email-confirmation-reminder" %>
-<% end %>
+<%= render "user-reminders" %>
 
 <%= render "govuk_publishing_components/components/title", {
   title: yield(:title),

--- a/app/views/security/show.html.erb
+++ b/app/views/security/show.html.erb
@@ -4,9 +4,7 @@
   <%= render "account-navigation", page_is: yield(:location) %>
 <% end %>
 
-<% if show_confirmation_reminder? %>
-  <%= render "email-confirmation-reminder" %>
-<% end %>
+<%= render "user-reminders" %>
 
 <%= render "govuk_publishing_components/components/heading", {
   text: yield(:title),

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -7,7 +7,6 @@
   text: t("devise.sessions.new.heading"),
   heading_level: 1,
   font_size: "xl",
-  margin_top: 0,
   margin_bottom: 3,
 } %>
 

--- a/app/views/sessions/phone_code.html.erb
+++ b/app/views/sessions/phone_code.html.erb
@@ -4,7 +4,6 @@
   text: t("mfa.phone.code.sign_in_heading"),
   heading_level: 1,
   font_size: "xl",
-  margin_top: 0,
   margin_bottom: 3,
 } %>
 

--- a/app/views/sessions/phone_resend.html.erb
+++ b/app/views/sessions/phone_resend.html.erb
@@ -8,7 +8,6 @@
   text: yield(:title),
   heading_level: 1,
   font_size: "xl",
-  margin_top: 0,
   margin_bottom: 3,
 } %>
 

--- a/config/locales/account/insecure_password.en.yml
+++ b/config/locales/account/insecure_password.en.yml
@@ -1,6 +1,16 @@
 ---
 en:
   insecure_password:
+    interstitial:
+      body:
+      - The password you’re currently using is too easy to guess. This means your account is not secure.
+      - You need to change your password to keep your account secure.
+      - A good way to create a strong and memorable password is to use 3 random words. You can use numbers, symbols and spaces.
+      button: Change your password now
+      heading: Your password is not secure
+      ignore:
+        link: Go to your GOV.UK account
+        outro: and change your password later.
     notice:
       link: Change your password
       message: Your account is not secure because your password is too easy to guess.

--- a/config/locales/account/insecure_password.en.yml
+++ b/config/locales/account/insecure_password.en.yml
@@ -1,0 +1,6 @@
+---
+en:
+  insecure_password:
+    notice:
+      link: Change your password
+      message: Your account is not secure because your password is too easy to guess.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,8 @@ Rails.application.routes.draw do
     get "/logout", to: redirect(path: "/sign-out")
 
     scope "/account" do
+      get "/insecure-password", to: "insecure_password#show", as: :insecure_password_interstitial
+
       get "/manage", to: "manage#show", as: :account_manage
       get "/security", to: "security#show", as: :account_security
       get "/security/activity/:page_number", to: "security#paginated_activity", as: :account_security_paginated_activity

--- a/db/migrate/20210203143644_make_login_state_redirect_path_nullable.rb
+++ b/db/migrate/20210203143644_make_login_state_redirect_path_nullable.rb
@@ -1,0 +1,10 @@
+class MakeLoginStateRedirectPathNullable < ActiveRecord::Migration[6.0]
+  def up
+    change_column_null :login_states, :redirect_path, true
+  end
+
+  def down
+    LoginState.where(redirect_path: nil).update_all(redirect_path: "/account")
+    change_column_null :login_states, :redirect_path, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_21_102522) do
+ActiveRecord::Schema.define(version: 2021_02_03_143644) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -64,7 +64,7 @@ ActiveRecord::Schema.define(version: 2021_01_21_102522) do
 
   create_table "login_states", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.string "redirect_path", null: false
+    t.string "redirect_path"
     t.uuid "jwt_id"
     t.datetime "created_at", precision: 6, default: -> { "now()" }, null: false
     t.datetime "updated_at", precision: 6, default: -> { "now()" }, null: false

--- a/spec/feature/insecure_password_spec.rb
+++ b/spec/feature/insecure_password_spec.rb
@@ -6,9 +6,13 @@ RSpec.feature "Insecure Passwords" do
     BannedPassword.import_list([user.password])
   end
 
-  it "shows the alert in the account manager" do
+  it "shows the interstitial page and the alert" do
     enter_email_address_and_password
     enter_mfa
+
+    expect(page).to have_text(I18n.t("insecure_password.interstitial.heading"))
+
+    continue_without_changing
 
     expect(page).to have_text(I18n.t("insecure_password.notice.message"))
   end
@@ -24,5 +28,9 @@ RSpec.feature "Insecure Passwords" do
     phone_code = the_user.reload.phone_code
     fill_in "phone_code", with: phone_code
     click_on I18n.t("mfa.phone.code.fields.submit.label")
+  end
+
+  def continue_without_changing
+    click_on I18n.t("insecure_password.interstitial.ignore.link")
   end
 end

--- a/spec/feature/insecure_password_spec.rb
+++ b/spec/feature/insecure_password_spec.rb
@@ -1,0 +1,28 @@
+RSpec.feature "Insecure Passwords" do
+  let!(:user) { FactoryBot.create(:user) }
+
+  before do
+    allow(Rails.configuration).to receive(:feature_flag_mfa).and_return(true)
+    BannedPassword.import_list([user.password])
+  end
+
+  it "shows the alert in the account manager" do
+    enter_email_address_and_password
+    enter_mfa
+
+    expect(page).to have_text(I18n.t("insecure_password.notice.message"))
+  end
+
+  def enter_email_address_and_password(email: user.email, password: user.password)
+    visit new_user_session_path
+    fill_in "email", with: email
+    fill_in "password", with: password
+    click_on I18n.t("devise.sessions.new.fields.submit.label")
+  end
+
+  def enter_mfa(the_user: user)
+    phone_code = the_user.reload.phone_code
+    fill_in "phone_code", with: phone_code
+    click_on I18n.t("mfa.phone.code.fields.submit.label")
+  end
+end


### PR DESCRIPTION
Users cannot register with a banned password, or change to one, but we need to encourage those users who signed up *before* we put the list in place to change theirs.

Interstitial page, shown after MFA success:

<img width="1071" alt="Screenshot 2021-02-03 at 14 54 43" src="https://user-images.githubusercontent.com/75235/106765329-96d5f600-6630-11eb-9ce3-7fd3c60af22f.png">

Nag shown on every account page:

<img width="1032" alt="Screenshot 2021-02-03 at 14 13 39" src="https://user-images.githubusercontent.com/75235/106765375-a2c1b800-6630-11eb-9020-977f153cb776.png">

---

[Trello card](https://trello.com/c/tUVg2rtt/606-build-new-change-your-common-password-flow)