### PR TITLE
Ask for MFA again when changing core credentials

### DIFF
--- a/app/controllers/concerns/requires_recent_mfa.rb
+++ b/app/controllers/concerns/requires_recent_mfa.rb
@@ -1,0 +1,24 @@
+module RequiresRecentMfa
+  class MissingMfaMethod < StandardError; end
+
+  extend ActiveSupport::Concern
+
+  def has_done_mfa_recently?
+    return true unless MultiFactorAuth.is_enabled?
+
+    session[:has_done_mfa]
+  end
+
+  def redo_mfa(after_redo_mfa_url)
+    session[:after_redo_mfa_url] = after_redo_mfa_url
+    session.delete(:has_done_mfa)
+
+    case MultiFactorAuth.choose_mfa_method(current_user)
+    when :phone
+      MultiFactorAuth.generate_and_send_code(current_user)
+      redirect_to redo_mfa_phone_code_path
+    else
+      raise MissingMfaMethod, current_user.id
+    end
+  end
+end

--- a/app/controllers/concerns/requires_recent_mfa.rb
+++ b/app/controllers/concerns/requires_recent_mfa.rb
@@ -5,6 +5,7 @@ module RequiresRecentMfa
 
   def has_done_mfa_recently?
     return true unless MultiFactorAuth.is_enabled?
+    return true if Rails.env.test? && Rails.application.config.allow_insecure_change_credential
 
     session[:has_done_mfa]
   end

--- a/app/controllers/edit_phone_controller.rb
+++ b/app/controllers/edit_phone_controller.rb
@@ -7,17 +7,13 @@ class EditPhoneController < ApplicationController
 
   def show; end
 
-  def code; end
-
-  def code_send
-    phone_number = current_user.unconfirmed_phone
+  def confirm
+    unless current_user.valid_password? params[:current_password]
+      @password_error_message = I18n.t("activerecord.errors.models.user.attributes.password.#{params[:current_password].blank? ? 'blank' : 'invalid'}")
+    end
 
     if params[:phone]
       phone_number = MultiFactorAuth.e164_number(params[:phone])
-
-      unless current_user.valid_password? params[:current_password]
-        @password_error_message = I18n.t("activerecord.errors.models.user.attributes.password.#{params[:current_password].blank? ? 'blank' : 'invalid'}")
-      end
 
       if phone_number == current_user.phone
         @phone_error_message = I18n.t("mfa.errors.phone.nochange")
@@ -26,14 +22,23 @@ class EditPhoneController < ApplicationController
       unless MultiFactorAuth.valid? phone_number
         @phone_error_message = I18n.t("activerecord.errors.models.user.attributes.phone.invalid")
       end
-
-      render :show and return if @password_error_message || @phone_error_message
+    else
+      @phone_error_message = I18n.t("activerecord.errors.models.user.attributes.phone.blank")
     end
 
-    current_user.transaction do
+    if @password_error_message || @phone_error_message
+      render :show
+    else
       current_user.update!(unconfirmed_phone: phone_number)
-      MultiFactorAuth.generate_and_send_code(current_user, use_unconfirmed: true)
     end
+  end
+
+  def code; end
+
+  def code_send
+    redirect_to edit_user_registration_phone and return unless current_user.unconfirmed_phone
+
+    MultiFactorAuth.generate_and_send_code(current_user, use_unconfirmed: true)
 
     render :code
   end

--- a/app/controllers/edit_phone_controller.rb
+++ b/app/controllers/edit_phone_controller.rb
@@ -1,6 +1,9 @@
 class EditPhoneController < ApplicationController
+  include RequiresRecentMfa
+
   before_action :authenticate_user!
   before_action :enforce_has_phone!
+  before_action :enforce_recent_mfa!
 
   def show; end
 
@@ -62,5 +65,9 @@ protected
 
   def enforce_has_phone!
     redirect_to user_root_path unless current_user.phone
+  end
+
+  def enforce_recent_mfa!
+    redo_mfa edit_user_registration_phone_path unless has_done_mfa_recently?
   end
 end

--- a/app/controllers/redo_mfa_controller.rb
+++ b/app/controllers/redo_mfa_controller.rb
@@ -1,0 +1,7 @@
+class RedoMfaController < ApplicationController
+  def stop
+    session.delete(:after_redo_mfa_url)
+
+    redirect_to account_manage_path
+  end
+end

--- a/app/controllers/redo_mfa_phone_controller.rb
+++ b/app/controllers/redo_mfa_phone_controller.rb
@@ -1,0 +1,40 @@
+class RedoMfaPhoneController < ApplicationController
+  before_action :authenticate_user!
+  before_action :ensure_redirect_url!
+
+  attr_reader :after_redo_mfa_url
+
+  def code; end
+
+  def verify
+    case MultiFactorAuth.verify_code(current_user, params[:phone_code])
+    when :ok
+      record_security_event(SecurityActivity::ADDITIONAL_FACTOR_VERIFICATION_SUCCESS, user: current_user, factor: :sms)
+
+      session[:has_done_mfa] = true
+      session.delete(:after_redo_mfa_url)
+      current_user.update!(last_mfa_success: Time.zone.now)
+
+      redirect_to after_redo_mfa_url
+    else
+      record_security_event(SecurityActivity::ADDITIONAL_FACTOR_VERIFICATION_FAILURE, user: current_user, factor: :sms)
+      @phone_code_error_message = I18n.t("mfa.errors.phone_code.#{state}", resend_link: redo_mfa_phone_resend)
+      render :code
+    end
+  end
+
+  def resend; end
+
+  def resend_code
+    MultiFactorAuth.generate_and_send_code(current_user)
+    redirect_to redo_mfa_phone_code_path
+  end
+
+protected
+
+  def ensure_redirect_url!
+    @after_redo_mfa_url = session[:after_redo_mfa_url]
+
+    redirect_to user_root_path if after_redo_mfa_url.blank?
+  end
+end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -9,6 +9,7 @@ class RegistrationsController < Devise::RegistrationsController
   # rubocop:enable Rails/LexicallyScopedActionFilter
 
   before_action :enforce_recent_mfa_for_email!, only: :edit_email
+  before_action :enforce_recent_mfa_for_password!, only: :edit_password
   before_action :enforce_recent_mfa_for_update!, only: :update
 
   before_action :check_registration_state, only: %i[
@@ -357,6 +358,10 @@ protected
 
   def enforce_recent_mfa_for_email!
     redo_mfa edit_user_registration_email_path unless has_done_mfa_recently?
+  end
+
+  def enforce_recent_mfa_for_password!
+    redo_mfa edit_user_registration_password_path unless has_done_mfa_recently?
   end
 
   def enforce_recent_mfa_for_update!

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,6 +11,13 @@ module ApplicationHelper
     "#{datetime.strftime('%d %B %Y at %H:%M')} (#{time_ago_in_words(datetime)} ago)"
   end
 
+  def redacted_phone_number(phone_number)
+    formatted_number = MultiFactorAuth.formatted_phone_number(phone_number)
+    prefix = formatted_number[0..-4].gsub(/[^\s]/, "x")
+    suffix = formatted_number[-3..]
+    "#{prefix}#{suffix}"
+  end
+
   def navigation_items
     if user_signed_in?
       [

--- a/app/views/edit_phone/code.html.erb
+++ b/app/views/edit_phone/code.html.erb
@@ -5,7 +5,7 @@
   margin_bottom: 3,
 } %>
 
-<% t("mfa.phone.code.description_with_phone_number", phone_number: MultiFactorAuth.formatted_phone_number(current_user.unconfirmed_phone)).each do |msg| %>
+<% t("mfa.phone.code.description").each do |msg| %>
   <p class="govuk-body"><%= sanitize(msg) %></p>
 <% end %>
 
@@ -34,8 +34,4 @@
 
 <p class="govuk-body">
   <%= sanitize(t("mfa.phone.code.not_received.resend_message", link: edit_user_registration_phone_resend_path)) %>
-</p>
-
-<p class="govuk-body">
-  <%= sanitize(t("mfa.phone.code.not_received.change_number_message", link: edit_user_registration_phone_path,  phone_number: MultiFactorAuth.formatted_phone_number(current_user.unconfirmed_phone))) %>
 </p>

--- a/app/views/edit_phone/confirm.html.erb
+++ b/app/views/edit_phone/confirm.html.erb
@@ -1,0 +1,28 @@
+<% content_for :title, t("mfa.phone.update.confirm.heading") %>
+<% content_for :location, "manage" %>
+<% content_for :account_navigation do %>
+  <%= render "account-navigation", page_is: yield(:location) %>
+<% end %>
+
+<%= render "govuk_publishing_components/components/back_link", { href: edit_user_registration_phone_path } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: yield(:title),
+  heading_level: 1,
+  font_size: "l",
+  margin_bottom: 6,
+} %>
+
+<% t("mfa.phone.update.confirm.description", phone_number: MultiFactorAuth.formatted_phone_number(current_user.unconfirmed_phone)).each do |msg| %>
+  <p class="govuk-body"><%= sanitize(msg) %></p>
+<% end %>
+
+<%= form_with(url: edit_user_registration_phone_code_path, method: :post) do %>
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("mfa.phone.update.confirm.fields.submit.label"),
+    margin_bottom: true
+  } %>
+<% end %>
+
+<p class="govuk-body">
+  <%= sanitize(t("mfa.phone.code.not_received.change_number_message", link: edit_user_registration_phone_path)) %>
+</p>

--- a/app/views/edit_phone/show.html.erb
+++ b/app/views/edit_phone/show.html.erb
@@ -20,7 +20,7 @@
   text: sanitize(t("mfa.phone.update.start.current", phone_number: MultiFactorAuth.formatted_phone_number(current_user.phone)))
 } %>
 
-<%= form_with(url: edit_user_registration_phone_code_path, method: :post) do %>
+<%= form_with(url: edit_user_registration_phone_confirm_path, method: :post) do %>
   <%= render "govuk_publishing_components/components/input", {
     label: { text: t("mfa.phone.update.start.fields.phone.label") },
     name: "phone",

--- a/app/views/edit_phone/show.html.erb
+++ b/app/views/edit_phone/show.html.erb
@@ -13,12 +13,8 @@
 } %>
 
 <p class="govuk-body">
-  <%= t("mfa.phone.update.start.message") %>
+  <%= sanitize(t("mfa.phone.update.start.current", phone_number: MultiFactorAuth.formatted_phone_number(current_user.phone))) %>
 </p>
-
-<%= render "govuk_publishing_components/components/inset_text", {
-  text: sanitize(t("mfa.phone.update.start.current", phone_number: MultiFactorAuth.formatted_phone_number(current_user.phone)))
-} %>
 
 <%= form_with(url: edit_user_registration_phone_confirm_path, method: :post) do %>
   <%= render "govuk_publishing_components/components/input", {
@@ -27,6 +23,10 @@
     type: "tel",
     error_message: @phone_error_message,
   } %>
+
+  <p class="govuk-body">
+    <%= t("mfa.phone.update.start.message") %>
+  </p>
 
   <%= render "govuk_publishing_components/components/show_password", {
     label: {

--- a/app/views/redo_mfa_phone/code.html.erb
+++ b/app/views/redo_mfa_phone/code.html.erb
@@ -1,0 +1,45 @@
+<% content_for :title, t("mfa.phone.code.redo_heading") %>
+
+<%= render "govuk_publishing_components/components/back_link", {
+  href: redo_mfa_stop_path
+} %>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: yield(:title),
+  heading_level: 1,
+  font_size: "xl",
+  margin_bottom: 3,
+} %>
+
+<p class="govuk-body"><%= t("mfa.phone.code.redo_description_preamble") %></p>
+
+<% t("mfa.phone.code.description_with_phone_number", phone_number: MultiFactorAuth.formatted_phone_number(current_user.phone)).each do |msg| %>
+  <p class="govuk-body"><%= sanitize(msg) %></p>
+<% end %>
+
+<%= form_with url: redo_mfa_phone_verify_path, method: :post, html: { autocomplete: "off" } do %>
+  <%= render "govuk_publishing_components/components/input", {
+    label: { text: t("mfa.phone.code.fields.phone_code.label") },
+    name: "phone_code",
+    maxlength: 5,
+    type: "number",
+    error_message: sanitize(@phone_code_error_message),
+    width: 5,
+  } %>
+
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("mfa.phone.code.fields.submit.label"),
+    margin_bottom: true,
+  } %>
+<% end %>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("mfa.phone.code.not_received.redo_heading"),
+  heading_level: 2,
+  margin_bottom: 4,
+  font_size: "m",
+} %>
+
+<p class="govuk-body">
+  <%= sanitize(t("mfa.phone.code.not_received.resend_message", link: redo_mfa_phone_resend_path)) %>
+</p>

--- a/app/views/redo_mfa_phone/code.html.erb
+++ b/app/views/redo_mfa_phone/code.html.erb
@@ -13,7 +13,7 @@
 
 <p class="govuk-body"><%= t("mfa.phone.code.redo_description_preamble") %></p>
 
-<% t("mfa.phone.code.description_with_phone_number", phone_number: MultiFactorAuth.formatted_phone_number(current_user.phone)).each do |msg| %>
+<% t("mfa.phone.code.description_with_phone_number", phone_number: redacted_phone_number(current_user.phone)).each do |msg| %>
   <p class="govuk-body"><%= sanitize(msg) %></p>
 <% end %>
 

--- a/app/views/redo_mfa_phone/resend.html.erb
+++ b/app/views/redo_mfa_phone/resend.html.erb
@@ -1,0 +1,20 @@
+<% content_for :title, t("mfa.phone.resend.heading") %>
+
+<%= render "govuk_publishing_components/components/back_link", {
+  href: redo_mfa_phone_code_path
+} %>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: yield(:title),
+  heading_level: 1,
+  font_size: "xl",
+  margin_bottom: 3,
+} %>
+
+<p class="govuk-body"><%= t("mfa.phone.resend.description") %></p>
+
+<%= form_with(url: redo_mfa_phone_resend_path, method: :post) do %>
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("mfa.phone.resend.fields.submit.label"),
+  } %>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -72,6 +72,8 @@ module GovukAccountManagerPrototype
 
     config.feature_flag_bypass_mfa = false
 
+    config.allow_insecure_change_credential = false
+
     config.i18n.load_path += Dir[Rails.root.join("config/locales/**/*.yml").to_s]
 
     config.i18n.default_locale = :en

--- a/config/locales/mfa.en.yml
+++ b/config/locales/mfa.en.yml
@@ -35,12 +35,15 @@ en:
         not_received:
           change_heading: If you did not get the text message or want to use a different mobile number
           change_number_message: You can <a class="govuk-link" href="%{link}">use a different mobile number</a> if %{phone_number} is not correct.
+          redo_heading: Resend security code
           resend_message: We can <a class="govuk-link" href="%{link}">send another security code</a> if you did not get it.
           sign_in_heading: Resend security code
           sign_in_message: We can <a class="govuk-link" href="%{link}">send a new security code</a> if you’re having trouble with the code.
           sign_up_heading: Resend security code or change your mobile number
           sign_up_message: We can <a class="govuk-link" href="%{link}">send a new security code</a> if you’re having trouble with the code or if it was sent to the wrong mobile number.
         page_title: Enter your security code
+        redo_description_preamble: Before you can make changes to your account, we need to confirm it’s you. This check helps us keep your account secure.
+        redo_heading: Confirm it’s you
         sign_in_heading: Check your phone
         sign_up_heading: Check your phone
       resend:

--- a/config/locales/mfa.en.yml
+++ b/config/locales/mfa.en.yml
@@ -66,14 +66,14 @@ en:
               label: Send security code
           heading: Confirm your new number
         start:
-          current: 'The phone number currently stored in your GOV.UK account is: <span class="govuk-!-display-inline-block">%{phone_number}</span>'
+          current: 'The phone number currently stored in your GOV.UK account is: <span class="govuk-!-font-weight-bold">%{phone_number}</span>'
           fields:
             phone:
-              label: Enter new phone number
+              label: Enter new mobile phone number
             submit:
               label: Continue
           heading: Change your phone number
-          message: We’ll send you a security code by text message. You’ll need this code to finish changing the phone number for your account.
+          message: We’ll send a security code to your new number by text message. You’ll need this code to finish changing the phone number for your account.
     text_message:
       security_code:
         body: "%{phone_code} is your security code."

--- a/config/locales/mfa.en.yml
+++ b/config/locales/mfa.en.yml
@@ -33,10 +33,10 @@ en:
           submit:
             label: Continue
         not_received:
-          change_heading: If you did not get the text message or want to use a different mobile number
-          change_number_message: You can <a class="govuk-link" href="%{link}">use a different mobile number</a> if %{phone_number} is not correct.
+          change_heading: Resend security code
+          change_number_message: You can <a class="govuk-link" href="%{link}">use a different mobile number</a> if this one is not correct.
           redo_heading: Resend security code
-          resend_message: We can <a class="govuk-link" href="%{link}">send another security code</a> if you did not get it.
+          resend_message: We can <a class="govuk-link" href="%{link}">send another security code</a> if you’re having trouble with the code.
           sign_in_heading: Resend security code
           sign_in_message: We can <a class="govuk-link" href="%{link}">send a new security code</a> if you’re having trouble with the code.
           sign_up_heading: Resend security code or change your mobile number
@@ -56,6 +56,15 @@ en:
             label: Send a new security code
         heading: Send a new security code
       update:
+        confirm:
+          description:
+          - We need to confirm that you have access to the new number before we can finish updating your account.
+          - You’ll need to enter the security code we’ll send by text message to <span class="govuk-!-font-weight-bold">%{phone_number}</span>.
+          - You must do this in the next 30 minutes.
+          fields:
+            submit:
+              label: Send security code
+          heading: Confirm your new number
         start:
           current: 'The phone number currently stored in your GOV.UK account is: <span class="govuk-!-display-inline-block">%{phone_number}</span>'
           fields:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,17 @@ Rails.application.routes.draw do
       patch "/", to: "registrations#update", as: :user_registration
       put   "/", to: "registrations#update"
 
+      scope "/mfa" do
+        get "/abort", to: "redo_mfa#stop", as: :redo_mfa_stop
+
+        scope "/phone" do
+          get  "/code", to: "redo_mfa_phone#code", as: :redo_mfa_phone_code
+          post "/verify", to: "redo_mfa_phone#verify", as: :redo_mfa_phone_verify
+          get  "/resend", to: "redo_mfa_phone#resend", as: :redo_mfa_phone_resend
+          post "/resend", to: "redo_mfa_phone#resend_code"
+        end
+      end
+
       scope "/edit" do
         get  "/email", to: "registrations#edit_email", as: :edit_user_registration_email
         get  "/password", to: "registrations#edit_password", as: :edit_user_registration_password

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,6 +57,7 @@ Rails.application.routes.draw do
 
         scope "/phone" do
           get  "/", to: "edit_phone#show", as: :edit_user_registration_phone
+          post "/confirm", to: "edit_phone#confirm", as: :edit_user_registration_phone_confirm
           get  "/code", to: "edit_phone#code", as: :edit_user_registration_phone_code
           post "/code", to: "edit_phone#code_send"
           post "/verify", to: "edit_phone#verify", as: :edit_user_registration_phone_verify

--- a/lib/multi_factor_auth.rb
+++ b/lib/multi_factor_auth.rb
@@ -102,4 +102,10 @@ module MultiFactorAuth
     end
     false
   end
+
+  def self.choose_mfa_method(user)
+    raise Disabled unless is_enabled?
+
+    :phone if user.phone.present?
+  end
 end

--- a/spec/feature/change_phone_spec.rb
+++ b/spec/feature/change_phone_spec.rb
@@ -13,6 +13,7 @@ RSpec.feature "Change Phone" do
     go_to_change_number_page
     enter_new_phone_number
     enter_password
+    send_code
     enter_mfa
 
     expect(page).to have_text(I18n.t("account.manage.heading"))
@@ -24,6 +25,7 @@ RSpec.feature "Change Phone" do
     go_to_change_number_page
     enter_new_phone_number
     enter_password
+    send_code
     enter_mfa
     visit_security_page
 
@@ -80,6 +82,7 @@ RSpec.feature "Change Phone" do
       go_to_change_number_page
       enter_new_phone_number
       enter_password
+      send_code
       enter_incorrect_mfa
 
       expect(page).to have_text(I18n.t("mfa.errors.phone_code.invalid"))
@@ -91,6 +94,7 @@ RSpec.feature "Change Phone" do
         go_to_change_number_page
         enter_new_phone_number
         enter_password
+        send_code
         (MultiFactorAuth::ALLOWED_ATTEMPTS + 1).times { enter_incorrect_mfa }
 
         expect(page).to have_text(Rails::Html::FullSanitizer.new.sanitize(I18n.t("mfa.errors.phone_code.too_many_attempts")))
@@ -104,6 +108,7 @@ RSpec.feature "Change Phone" do
       go_to_change_number_page
       enter_new_phone_number
       enter_password
+      send_code
       travel(MultiFactorAuth::EXPIRATION_AGE + 1.second)
       enter_mfa
       user_is_returned_to_login_screen
@@ -147,6 +152,10 @@ RSpec.feature "Change Phone" do
   def enter_incorrect_password
     fill_in "current_password", with: "1#{user.password}"
     click_on I18n.t("mfa.phone.update.start.fields.submit.label")
+  end
+
+  def send_code
+    click_on I18n.t("mfa.phone.update.confirm.fields.submit.label")
   end
 
   def enter_mfa

--- a/spec/feature/login_spec.rb
+++ b/spec/feature/login_spec.rb
@@ -3,10 +3,8 @@ RSpec.feature "Logging in" do
   include ActiveSupport::Testing::TimeHelpers
 
   before { allow(Rails.configuration).to receive(:feature_flag_mfa).and_return(mfa_enabled) }
-  before { allow(Rails.configuration).to receive(:feature_flag_bypass_mfa).and_return(bypass_mfa_enabled) }
 
   let(:mfa_enabled) { true }
-  let(:bypass_mfa_enabled) { false }
 
   let!(:user) { FactoryBot.create(:user) }
 
@@ -29,70 +27,6 @@ RSpec.feature "Logging in" do
     visit_security_page
 
     expect(page).to have_text(I18n.t("account.security.event.login_success"))
-  end
-
-  it "doesn't give the option to 'remember me'" do
-    enter_email_address_and_password
-
-    expect(page).to_not have_text(Rails::Html::FullSanitizer.new.sanitize(I18n.t("mfa.phone.code.fields.remember_me.label")))
-  end
-
-  context "the user checks 'remember me'" do
-    let!(:user) { FactoryBot.create(:user, :confirmed) }
-    let(:bypass_mfa_enabled) { true }
-
-    before do
-      enter_email_address_and_password
-      expect(page).to have_text(Rails::Html::FullSanitizer.new.sanitize(I18n.t("mfa.phone.code.fields.remember_me.label")))
-      enter_mfa(remember_me: true)
-      expect(page).to have_text(I18n.t("account.your_account.heading"))
-    end
-
-    it "shows the event on the security page" do
-      visit_security_page
-
-      expect(page).to have_text(I18n.t("account.security.security_codes.code_description.present"))
-    end
-
-    context "the user returns 29 days later" do
-      before { travel(MultiFactorAuth::BYPASS_TOKEN_EXPIRATION_AGE - 1.day) }
-
-      it "skips MFA" do
-        enter_email_address_and_password
-        expect(page).to have_text(I18n.t("account.your_account.heading"))
-      end
-    end
-
-    context "the user returns 31 days later" do
-      before { travel(MultiFactorAuth::BYPASS_TOKEN_EXPIRATION_AGE + 1.day) }
-
-      it "does not skip MFA" do
-        enter_email_address_and_password
-        expect(page).to have_text(I18n.t("mfa.phone.code.sign_in_heading"))
-      end
-    end
-
-    context "with multiple users on the same machine" do
-      let(:user2) { FactoryBot.create(:user, email: "other-user@example.com") }
-
-      before do
-        travel(Devise.timeout_in + 1.second)
-        enter_email_address_and_password(email: user2.email, password: user2.password)
-        enter_mfa(the_user: user2, remember_me: true)
-        expect(page).to have_text(I18n.t("account.your_account.heading"))
-        travel(Devise.timeout_in + 1.second)
-      end
-
-      it "remembers the first user" do
-        enter_email_address_and_password(email: user.email, password: user.password)
-        expect(page).to have_text(I18n.t("account.your_account.heading"))
-      end
-
-      it "remembers the second user" do
-        enter_email_address_and_password(email: user2.email, password: user2.password)
-        expect(page).to have_text(I18n.t("account.your_account.heading"))
-      end
-    end
   end
 
   context "when the email is missing" do
@@ -269,10 +203,9 @@ RSpec.feature "Logging in" do
     click_on I18n.t("devise.sessions.new.fields.submit.label")
   end
 
-  def enter_mfa(the_user: user, remember_me: false)
+  def enter_mfa(the_user: user)
     phone_code = the_user.reload.phone_code
     fill_in "phone_code", with: phone_code
-    check "remember_me" if remember_me
     click_on I18n.t("mfa.phone.code.fields.submit.label")
   end
 

--- a/spec/feature/remember_me_spec.rb
+++ b/spec/feature/remember_me_spec.rb
@@ -1,0 +1,99 @@
+RSpec.feature "Remember Me" do
+  include ActiveJob::TestHelper
+  include ActiveSupport::Testing::TimeHelpers
+
+  before { allow(Rails.configuration).to receive(:feature_flag_mfa).and_return(true) }
+  before { allow(Rails.configuration).to receive(:feature_flag_bypass_mfa).and_return(bypass_mfa_enabled) }
+
+  let(:bypass_mfa_enabled) { true }
+
+  let!(:user) { FactoryBot.create(:user, :confirmed) }
+
+  context "'remember me' is disabled" do
+    let(:bypass_mfa_enabled) { false }
+
+    it "doesn't give the option to 'remember me'" do
+      enter_email_address_and_password
+
+      expect(page).to_not have_text(Rails::Html::FullSanitizer.new.sanitize(I18n.t("mfa.phone.code.fields.remember_me.label")))
+    end
+  end
+
+  context "the user checks 'remember me'" do
+    before { log_in_and_remember_me }
+
+    it "shows the event on the security page" do
+      visit_security_page
+
+      expect(page).to have_text(I18n.t("account.security.security_codes.code_description.present"))
+    end
+
+    context "the user returns 29 days later" do
+      before do
+        travel(MultiFactorAuth::BYPASS_TOKEN_EXPIRATION_AGE - 1.day)
+        enter_email_address_and_password
+      end
+
+      it "skips MFA" do
+        expect(page).to have_text(I18n.t("account.your_account.heading"))
+      end
+    end
+
+    context "the user returns 31 days later" do
+      before do
+        travel(MultiFactorAuth::BYPASS_TOKEN_EXPIRATION_AGE + 1.day)
+        enter_email_address_and_password
+      end
+
+      it "does not skip MFA" do
+        expect(page).to have_text(I18n.t("mfa.phone.code.sign_in_heading"))
+      end
+    end
+
+    context "with multiple users on the same machine" do
+      let(:user2) { FactoryBot.create(:user, email: "other-user@example.com") }
+
+      before do
+        log_out
+        log_in_and_remember_me(the_user: user2)
+        log_out
+      end
+
+      it "remembers all the users who chose to skip MFA" do
+        enter_email_address_and_password(the_user: user)
+        expect(page).to have_text(I18n.t("account.your_account.heading"))
+
+        log_out
+
+        enter_email_address_and_password(the_user: user2)
+        expect(page).to have_text(I18n.t("account.your_account.heading"))
+      end
+    end
+  end
+
+  def enter_email_address_and_password(the_user: user)
+    visit new_user_session_path
+    fill_in "email", with: the_user.email
+    fill_in "password", with: the_user.password
+    click_on I18n.t("devise.sessions.new.fields.submit.label")
+  end
+
+  def log_in_and_remember_me(the_user: user)
+    enter_email_address_and_password(the_user: the_user)
+    expect(page).to have_text(Rails::Html::FullSanitizer.new.sanitize(I18n.t("mfa.phone.code.fields.remember_me.label")))
+
+    fill_in "phone_code", with: the_user.reload.phone_code
+    check "remember_me"
+    click_on I18n.t("mfa.phone.code.fields.submit.label")
+
+    expect(page).to have_text(I18n.t("account.your_account.heading"))
+  end
+
+  def log_out
+    travel(Devise.timeout_in + 1.second)
+  end
+
+  def visit_security_page
+    click_on I18n.t("navigation.menu_bar.security.link_text")
+  end
+end

--- a/spec/feature/remember_me_spec.rb
+++ b/spec/feature/remember_me_spec.rb
@@ -52,6 +52,20 @@ RSpec.feature "Remember Me" do
         visit_change_number_page
         expect(page).to have_text(I18n.t("mfa.phone.code.redo_description_preamble"))
       end
+
+      context "the user has already re-done MFA" do
+        before do
+          visit_change_email_page
+          redo_mfa
+          expect(page).to have_text(I18n.t("devise.registrations.edit.heading_email"))
+          visit user_root_path
+        end
+
+        it "doesn't re-do MFA again" do
+          visit_change_email_page
+          expect(page).to have_text(I18n.t("devise.registrations.edit.heading_email"))
+        end
+      end
     end
 
     context "the user returns 31 days later" do
@@ -106,6 +120,11 @@ RSpec.feature "Remember Me" do
 
   def log_out
     travel(Devise.timeout_in + 1.second)
+  end
+
+  def redo_mfa(the_user: user)
+    fill_in "phone_code", with: the_user.reload.phone_code
+    click_on I18n.t("mfa.phone.code.fields.submit.label")
   end
 
   def visit_security_page

--- a/spec/feature/remember_me_spec.rb
+++ b/spec/feature/remember_me_spec.rb
@@ -38,6 +38,11 @@ RSpec.feature "Remember Me" do
         expect(page).to have_text(I18n.t("account.your_account.heading"))
       end
 
+      it "re-does MFA when changing email address" do
+        visit_change_email_page
+        expect(page).to have_text(I18n.t("mfa.phone.code.redo_description_preamble"))
+      end
+
       it "re-does MFA when changing phone number" do
         visit_change_number_page
         expect(page).to have_text(I18n.t("mfa.phone.code.redo_description_preamble"))
@@ -100,6 +105,15 @@ RSpec.feature "Remember Me" do
 
   def visit_security_page
     click_on I18n.t("navigation.menu_bar.security.link_text")
+  end
+
+  def visit_change_email_page
+    within ".accounts-menu" do
+      click_on "Manage your account"
+    end
+    within "#main-content" do
+      click_on "Change Email"
+    end
   end
 
   def visit_change_number_page

--- a/spec/feature/remember_me_spec.rb
+++ b/spec/feature/remember_me_spec.rb
@@ -1,4 +1,5 @@
 RSpec.feature "Remember Me" do
+  include ApplicationHelper
   include ActiveJob::TestHelper
   include ActiveSupport::Testing::TimeHelpers
 
@@ -41,16 +42,19 @@ RSpec.feature "Remember Me" do
       it "re-does MFA when changing email address" do
         visit_change_email_page
         expect(page).to have_text(I18n.t("mfa.phone.code.redo_description_preamble"))
+        expect(page).to have_text(redacted_phone_number(user.phone))
       end
 
       it "re-does MFA when changing password" do
         visit_change_password_page
         expect(page).to have_text(I18n.t("mfa.phone.code.redo_description_preamble"))
+        expect(page).to have_text(redacted_phone_number(user.phone))
       end
 
       it "re-does MFA when changing phone number" do
         visit_change_number_page
         expect(page).to have_text(I18n.t("mfa.phone.code.redo_description_preamble"))
+        expect(page).to have_text(redacted_phone_number(user.phone))
       end
 
       context "the user has already re-done MFA" do

--- a/spec/feature/remember_me_spec.rb
+++ b/spec/feature/remember_me_spec.rb
@@ -43,6 +43,11 @@ RSpec.feature "Remember Me" do
         expect(page).to have_text(I18n.t("mfa.phone.code.redo_description_preamble"))
       end
 
+      it "re-does MFA when changing password" do
+        visit_change_password_page
+        expect(page).to have_text(I18n.t("mfa.phone.code.redo_description_preamble"))
+      end
+
       it "re-does MFA when changing phone number" do
         visit_change_number_page
         expect(page).to have_text(I18n.t("mfa.phone.code.redo_description_preamble"))
@@ -113,6 +118,15 @@ RSpec.feature "Remember Me" do
     end
     within "#main-content" do
       click_on "Change Email"
+    end
+  end
+
+  def visit_change_password_page
+    within ".accounts-menu" do
+      click_on "Manage your account"
+    end
+    within "#main-content" do
+      click_on "Change Password"
     end
   end
 

--- a/spec/feature/remember_me_spec.rb
+++ b/spec/feature/remember_me_spec.rb
@@ -37,6 +37,11 @@ RSpec.feature "Remember Me" do
       it "skips MFA" do
         expect(page).to have_text(I18n.t("account.your_account.heading"))
       end
+
+      it "re-does MFA when changing phone number" do
+        visit_change_number_page
+        expect(page).to have_text(I18n.t("mfa.phone.code.redo_description_preamble"))
+      end
     end
 
     context "the user returns 31 days later" do
@@ -95,5 +100,14 @@ RSpec.feature "Remember Me" do
 
   def visit_security_page
     click_on I18n.t("navigation.menu_bar.security.link_text")
+  end
+
+  def visit_change_number_page
+    within ".accounts-menu" do
+      click_on "Manage your account"
+    end
+    within "#main-content" do
+      click_on "Change Mobile number"
+    end
   end
 end

--- a/spec/feature/remember_me_spec.rb
+++ b/spec/feature/remember_me_spec.rb
@@ -66,6 +66,20 @@ RSpec.feature "Remember Me" do
           expect(page).to have_text(I18n.t("devise.registrations.edit.heading_email"))
         end
       end
+
+      context "the user aborted an MFA re-do" do
+        before do
+          visit_change_email_page
+          abort_redo_mfa
+          expect(page).to have_text(I18n.t("account.manage.heading"))
+          visit user_root_path
+        end
+
+        it "re-does MFA again" do
+          visit_change_email_page
+          expect(page).to have_text(I18n.t("mfa.phone.code.redo_description_preamble"))
+        end
+      end
     end
 
     context "the user returns 31 days later" do
@@ -125,6 +139,10 @@ RSpec.feature "Remember Me" do
   def redo_mfa(the_user: user)
     fill_in "phone_code", with: the_user.reload.phone_code
     click_on I18n.t("mfa.phone.code.fields.submit.label")
+  end
+
+  def abort_redo_mfa
+    click_on "Back"
   end
 
   def visit_security_page

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -51,6 +51,12 @@ RSpec.describe ApplicationHelper do
     end
   end
 
+  describe "#redacted_phone_number" do
+    it "redacts all but the final 3 digits" do
+      expect(redacted_phone_number("+447958123456")).to eq("xxxxx xxx456")
+    end
+  end
+
   describe "#service_for" do
     let(:user) { FactoryBot.create(:user) }
 

--- a/spec/requests/security_activity_spec.rb
+++ b/spec/requests/security_activity_spec.rb
@@ -187,11 +187,12 @@ RSpec.describe "security activities" do
       it "records PHONE_CHANGED events" do
         old_phone = user.phone
 
-        post edit_user_registration_phone_code_path, params: {
+        post edit_user_registration_phone_confirm_path, params: {
           "phone" => "07581123456",
           "current_password" => user.password,
         }
-        post edit_user_registration_phone_verify_path, params: { "phone_code" => user.phone_code }
+        post edit_user_registration_phone_code_path
+        post edit_user_registration_phone_verify_path, params: { "phone_code" => user.reload.phone_code }
 
         expect_event SecurityActivity::PHONE_CHANGED, { notes: "from #{old_phone} to #{user.reload.phone}" }
         expect_event_on_security_page SecurityActivity::PHONE_CHANGED

--- a/spec/requests/security_activity_spec.rb
+++ b/spec/requests/security_activity_spec.rb
@@ -179,7 +179,10 @@ RSpec.describe "security activities" do
     end
 
     context "with MFA enabled" do
-      before { allow(Rails.configuration).to receive(:feature_flag_mfa).and_return(true) }
+      before do
+        allow(Rails.configuration).to receive(:feature_flag_mfa).and_return(true)
+        allow(Rails.configuration).to receive(:allow_insecure_change_credential).and_return(true)
+      end
 
       it "records PHONE_CHANGED events" do
         old_phone = user.phone


### PR DESCRIPTION
When logging in, I choose to remember this device:

<img width="783" alt="Screenshot 2021-02-08 at 13 53 28" src="https://user-images.githubusercontent.com/75235/107229241-74b7eb80-6a15-11eb-865f-af69696f6903.png">

Then I log out, and log in again, and don't need to go through MFA.  So far nothing new.

Then I try to change a core credential, and I see this:

<img width="767" alt="Screenshot 2021-02-08 at 13 54 39" src="https://user-images.githubusercontent.com/75235/107229248-784b7280-6a15-11eb-9781-20f63a603c42.png">

After going through MFA, I get sent on to the change page:

<img width="835" alt="Screenshot 2021-02-08 at 13 55 12" src="https://user-images.githubusercontent.com/75235/107229251-797c9f80-6a15-11eb-8312-6a011858b03e.png">

---

[Trello card](https://trello.com/c/OMnMt7Nv/607-build-new-2fa-flow-for-users-who-are-remembered-on-this-device-but-are-trying-to-change-a-core-cred)
