### PR TITLE
Remove deployment to concourse section

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,14 +134,6 @@ Then you can run the tests with:
 bundle exec rake
 ```
 
-## Deployment to GOV.UK via concourse
-
-Every commit to main is deployed to GOV.UK PaaS by [this concourse pipeline](https://cd.gds-reliability.engineering/teams/govuk-tools/pipelines/govuk-account-manager-prototype), which is configured in [concourse/pipeline.yml](/concourse/pipeline.yml).
-
-You will need to be logged into the GDS VPN to access concourse.
-
-The concourse pipeline has credentials for the govuk-accounts-developers user in GOV.UK PaaS. This user has the SpaceDeveloper role, so it can `cf push` the application.
-
 ## Secrets
 
 Secrets are defined via the [gds-cli](https://github.com/alphagov/gds-cli) and Concourse secrets manager.


### PR DESCRIPTION
Remove [Deployment to GOV.UK via concourse](https://github.com/alphagov/govuk-account-manager-prototype#deployment-to-govuk-via-concourse) section from readme file as covered by https://team-manual.account.publishing.service.gov.uk/development-tasks/deploy-a-branch-to-staging/#deploy-a-branch-from-github.

Trello card: https://trello.com/c/cXchhY04/615-ensure-readme-files-do-not-have-any-content-that-should-be-in-the-team-manual-or-the-tech-docs