### PR TITLE
Suppress "foo is suspended" Zendesk errors

### DIFF
--- a/app/jobs/zendesk_ticket_job.rb
+++ b/app/jobs/zendesk_ticket_job.rb
@@ -6,5 +6,7 @@ class ZendeskTicketJob < ApplicationJob
   def perform(ticket_attributes)
     ticket = Zendesk::Ticket.new(ticket_attributes).attributes
     GDS_ZENDESK_CLIENT.ticket.create!(ticket)
+  rescue ZendeskAPI::Error::RecordInvalid => e
+    raise e unless e.to_s.include? "is suspended."
   end
 end

--- a/spec/jobs/zendesk_ticket_job_spec.rb
+++ b/spec/jobs/zendesk_ticket_job_spec.rb
@@ -17,4 +17,13 @@ RSpec.describe ZendeskTicketJob do
 
     described_class.new.perform(ticket_attributes)
   end
+
+  it "suppresses 'foo is suspended' errors" do
+    error_hash = { details: [{ description: "Requester: #{ticket_attributes[:email]} is suspended." }] }.with_indifferent_access
+
+    expect(Zendesk::Ticket).to receive(:new)
+      .and_raise(ZendeskAPI::Error::RecordInvalid.new(nil, { body: error_hash }))
+
+    described_class.new.perform(ticket_attributes)
+  end
 end


### PR DESCRIPTION
Some email addresses are suspended.  Maybe spammers?  Trying to submit
a ticket with a suspended email address raises an exception, which we
send to Sentry.  We can't do anything about it, and we don't get many
of them, so just ignore them.

---

[Sentry error](https://sentry.io/organizations/govuk/issues/1983880871/events/latest/?project=5370953&query=is%3Aunresolved&statsPeriod=14d)