### PR TITLE
Preferentially take the JWT ID from the OAuth state param

### DIFF
--- a/app/controllers/concerns/accepts_jwt.rb
+++ b/app/controllers/concerns/accepts_jwt.rb
@@ -3,12 +3,27 @@ module AcceptsJwt
 
   def find_or_create_jwt(payload = nil)
     @find_or_create_jwt ||=
-      if payload
-        Jwt.create!(jwt_payload: payload).tap { |j| session[:jwt_id] = j.id }
-      elsif session[:jwt_id]
-        Jwt.find_by(id: session[:jwt_id]) || session.delete(:jwt_id) && Jwt::Nil.new
-      else
-        Jwt::Nil.new
+      begin
+        jwt_from_state = Jwt.find_by(id: oauth_state_param) if oauth_state_param
+        if jwt_from_state
+          jwt_from_state.tap { |j| session[:jwt_id] = j.id }
+        elsif payload
+          Jwt.create!(jwt_payload: payload).tap { |j| session[:jwt_id] = j.id }
+        elsif session[:jwt_id]
+          Jwt.find_by(id: session[:jwt_id]) || session.delete(:jwt_id) && Jwt::Nil.new
+        else
+          Jwt::Nil.new
+        end
       end
+  end
+
+  def oauth_state_param
+    return unless params[:previous_url]&.start_with? oauth_authorization_path
+
+    bits = params[:previous_url].split("?")
+    return unless bits.length > 1
+
+    querystring = CGI.parse(bits[1])
+    querystring["state"]&.first
   end
 end


### PR DESCRIPTION
We're retiring the POST method of submitting attributes to create when
a user signs up.  This is so we can send users on a normal OAuth login
journey.

This change is the first step towards that goal.  Next we'll be adding
an endpoint for an app to submit a JWT and get the ID to pass in the
state param.

Ultimately we'll be retiring the ability to set attributes on
registration too when the Transition Checker goes away, at which point
this whole JWT thing can go away.

---

[Trello card](https://trello.com/c/pqEmxKJ5/627-allow-retrieving-the-jwt-id-from-the-oauth-state-param)