### PR TITLE
Invalidate the GitHub Actions cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,9 @@ jobs:
         uses: actions/cache@v1
         with:
           path: tmp/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-gems-2-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: |
-            ${{ runner.os }}-gems-
+            ${{ runner.os }}-gems-2-
 
       - name: Install Ruby gems
         run: |


### PR DESCRIPTION
We seem to have got some invalid state in our cache, and there is no
way to manually clear the cache.  We can only wait for it to
expire (takes 7 days), or change the key.

The current cache is giving this error:

    LoadError: libffi.so.6: cannot open shared object file: No such file or directory - /home/runner/work/govuk-account-manager-prototype/govuk-account-manager-prototype/tmp/bundle/ruby/2.7.0/gems/ffi-1.14.2/lib/ffi_c.so