### PR TITLE
Allow running Chrome as root user in docker

### DIFF
--- a/concourse/Dockerfile
+++ b/concourse/Dockerfile
@@ -12,6 +12,9 @@ RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources
     && apt update -y \
     && apt install -y yarn
 
+# Enable no-sandbox for chrome so that it can run as a root user
+ENV GOVUK_TEST_CHROME_NO_SANDBOX 1
+
 COPY Gemfile* .ruby-version package.json /application/
 
 WORKDIR /application/

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -114,8 +114,6 @@ jobs:
         config:
           inputs:
             - name: git-main
-          outputs:
-            - name: committer-details
           platform: linux
           run:
             dir: git-main


### PR DESCRIPTION
I think this will fix the Concourse build: I've tested building the container and running the tests locally.