### PR TITLE
Skip CSRF protection for bigquery endpoint  & add error reporting

### DIFF
--- a/app/controllers/api/v1/report/bigquery_controller.rb
+++ b/app/controllers/api/v1/report/bigquery_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::Report::BigqueryController < Doorkeeper::ApplicationController
+  skip_before_action :verify_authenticity_token
+
   before_action -> { doorkeeper_authorize! :reporting_access }
 
   respond_to :json

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -313,6 +313,17 @@ jobs:
         params:
           CDN_DOMAIN: account.publishing.service.gov.uk
           BEARER_TOKEN: ((report-bearer-token))
+        on_failure:
+          put: govuk-slack
+          params:
+            channel: '#govuk-accounts-tech'
+            username: 'Concourse (GOV.UK Accounts)'
+            icon_emoji: ':concourse:'
+            silent: true
+            text: |
+              :kaboom:
+              Production BigQuery export has failed
+              Failed build: http://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
 
   - name: suspend-staging
     plan:

--- a/concourse/tasks/trigger-bigquery-export.yml
+++ b/concourse/tasks/trigger-bigquery-export.yml
@@ -14,7 +14,7 @@ run:
     - "-c"
     - |
       echo "triggering account-manager export"
-      curl -XPOST -H "Authorization: Bearer ${BEARER_TOKEN}" -H 'Accept: application/json' "https://www.${CDN_DOMAIN}/api/v1/report/bigquery"
+      curl --fail -XPOST -H "Authorization: Bearer ${BEARER_TOKEN}" -H 'Accept: application/json' "https://www.${CDN_DOMAIN}/api/v1/report/bigquery"
 
       echo "triggering attribute-service export"
-      curl -XPOST -H "Authorization: Bearer ${BEARER_TOKEN}" -H 'Accept: application/json' "https://attributes.${CDN_DOMAIN}/v1/report/bigquery"
+      curl --fail -XPOST -H "Authorization: Bearer ${BEARER_TOKEN}" -H 'Accept: application/json' "https://attributes.${CDN_DOMAIN}/v1/report/bigquery"


### PR DESCRIPTION
After this is merged I'll trigger an export for all the data which has been missed.