### PR TITLE
Add an endpoint to accept a JWT and return its ID 

### DIFF
--- a/app/controllers/api/v1/jwt_controller.rb
+++ b/app/controllers/api/v1/jwt_controller.rb
@@ -1,0 +1,18 @@
+class Api::V1::JwtController < Doorkeeper::ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  before_action :doorkeeper_authorize!
+
+  respond_to :json
+
+  def create
+    head :bad_request and return if doorkeeper_token.resource_owner_id.present?
+
+    jwt = Jwt.create!(
+      jwt_payload: params.fetch(:jwt),
+      application_id_from_token: doorkeeper_token.application_id,
+    )
+
+    render json: { id: jwt.id }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -124,6 +124,8 @@ Rails.application.routes.draw do
       get "/deanonymise-token", to: "deanonymise_token#show"
       get "/ephemeral-state", to: "ephemeral_state#show"
 
+      post "/jwt", to: "jwt#create"
+
       scope "transition-checker", module: :transition_checker, as: :transition_checker do
         get "/email-subscription", to: "emails#show"
         post "/email-subscription", to: "emails#update"

--- a/spec/requests/api/v1/jwt_spec.rb
+++ b/spec/requests/api/v1/jwt_spec.rb
@@ -1,0 +1,55 @@
+RSpec.describe "/api/v1/jwt" do
+  let(:application) { FactoryBot.create(:oauth_application) }
+
+  let(:user) { nil }
+
+  let(:token) do
+    FactoryBot.create(
+      :oauth_access_token,
+      application_id: application.id,
+      resource_owner_id: user&.id,
+    )
+  end
+
+  let(:headers) do
+    {
+      Accept: "application/json",
+      Authorization: "Bearer #{token.token}",
+    }
+  end
+
+  let(:jwt_payload) do
+    {
+      scopes: [],
+      attributes: {},
+      post_register_oauth: "/oauth/authorize/foo",
+      post_login_oauth: "/oauth/authorize/bar",
+    }
+  end
+
+  let(:params) do
+    {
+      jwt: JWT.encode(jwt_payload, nil, "none"),
+    }
+  end
+
+  it "accepts an unsigned JWT & drops the post_login_oauth" do
+    post api_v1_jwt_path, params: params, headers: headers
+    expect(response).to be_successful
+
+    body = JSON.parse(response.body)
+    expect(body).to eq({ "id" => Jwt.last.id })
+    expect(Jwt.find(body["id"]).jwt_payload.deep_symbolize_keys).to match(
+      jwt_payload.merge(application: hash_including(id: application.id), signing_key: nil, post_login_oauth: nil),
+    )
+  end
+
+  context "a user access token is used" do
+    let(:user) { FactoryBot.create(:user) }
+
+    it "rejects" do
+      post api_v1_jwt_path, params: params, headers: headers
+      expect(response).to have_http_status(:bad_request)
+    end
+  end
+end


### PR DESCRIPTION
The second part of #684

Since the JWT comes from an authenticated endpoint, we don't need to
validate the crypto.  The only way to get an access token is to know
the client's secrets, and so if an attacker can explot this new way,
they could already exploit the old way.

The new endpoint rejects user access tokens, which ensures that only
someone able to do a client_credentials auth flow can create a JWT.

The Transition Checker JWT flow can be changed to:

1. [frontend] POST to a new endpoint in the Transition Checker
2. [backend] Generate an access token with the client credentials flow
3. [backend] POST the JWT to the account-manager, returning an ID
4. [backend] Generate an OAuth redirect URL with `state={returned id}`
5. [backend] Redirect the user to do a normal OAuth consent journey

This is good because we're dropping the weird POST-to-the-auth-server
flow we currently have, and adopting something more standard.  There
is a follow-up card to make the change to finder-frontend and to
delete the then-redundant POST code from this app.

The post_login_oauth field isn't needed any more because the standard
OAuth auth flow passes along the redirect URL.

---

[Trello card](https://trello.com/c/YobN9DTz/628-add-an-api-endpoint-to-the-account-manager-to-submit-a-jwt)