### PR TITLE
Use typeset apostrophe in 'remember me'

### DIFF
--- a/config/locales/mfa.en.yml
+++ b/config/locales/mfa.en.yml
@@ -29,7 +29,7 @@ en:
           phone_code:
             label: Enter security code
           remember_me:
-            label: Skip this step any time you sign in on this device in the next 30 days.<br>Do not do this if you're using a shared or public device.
+            label: Skip this step any time you sign in on this device in the next 30 days.<br>Do not do this if you’re using a shared or public device.
           submit:
             label: Continue
         not_received:


### PR DESCRIPTION
Something I noticed whilst logging into my account.