### PR TITLE
Amend "change cookie settings" page heading

### DIFF
--- a/app/views/edit_consent/cookie.html.erb
+++ b/app/views/edit_consent/cookie.html.erb
@@ -16,7 +16,7 @@
 
   <%= render "govuk_publishing_components/components/radio", {
     name: "cookie_consent",
-    heading: yield(:title),
+    heading: t('account.manage.privacy.cookies_question'),
     heading_size: "l",
     is_page_heading: true,
     items: [


### PR DESCRIPTION
Seems like the page heading on the "Change your cookie settings" page was mistakenly set to be the same as the title. 
We probably introduced this by accident [when we reviewed all the page titles some weeks ago](https://github.com/alphagov/govuk-account-manager-prototype/commit/fba5bb17fc7612b673676c85550ac1f79ab89b17#diff-5279bff11e336d06c96953479968491993e02121cb7f38b2a52deaf119d46b26).

This does not read well as the title is immediately followed by the yes/no radio options:

![image](https://user-images.githubusercontent.com/7116819/108091399-951a2280-7073-11eb-82d5-836b156237b8.png)


The title of the page should remain "Change your cookie settings".
Whereas the heading should be "Can your account use cookies to learn about how you use GOV.UK?".