### PR TITLE
Add page title to the Resend email instructions page

### DIFF
--- a/app/views/confirmations/new.html.erb
+++ b/app/views/confirmations/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, t("devise.confirmations.resend.page_title") %>
 <%= render "govuk_publishing_components/components/heading", {
   text: t("devise.confirmations.resend.heading"),
   heading_level: 1,

--- a/config/locales/account/confirmations.en.yml
+++ b/config/locales/account/confirmations.en.yml
@@ -34,6 +34,7 @@ en:
         heading: Resend instructions to confirm your email address
         instructions: We’ll send you an email with instructions for confirming the email address for your GOV.UK account.
         label: Email
+        page_title: Resend email confirmation instructions
       send_instructions: You will receive an email with instructions for how to confirm your email address in a few minutes.
       send_paranoid_instructions: If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes.
   errors:


### PR DESCRIPTION
This page does not have a page title and is defaulting to **GOV.UK Account**: https://www.account.publishing.service.gov.uk/account/confirmation/new 

This is a [WCAG SC 2.4.2](https://www.w3.org/WAI/WCAG21/Understanding/page-titled) fail.

We must have missed it when we reviewed all the page titles [some time ago](https://github.com/alphagov/govuk-account-manager-prototype/commit/fba5bb17fc7612b673676c85550ac1f79ab89b17).

This sets the page title for that page to "Resend email confirmation instructions", as advised by our content designer.

### Before 
<img width="871" alt="Screenshot 2021-02-16 at 18 19 42" src="https://user-images.githubusercontent.com/7116819/108104790-a23f0d80-7083-11eb-9e99-fcf208dd4e68.png">

### After
<img width="889" alt="Screenshot 2021-02-16 at 18 19 23" src="https://user-images.githubusercontent.com/7116819/108104782-9fdcb380-7083-11eb-9e06-ebbbe65dbb24.png">
