### PR TITLE
Put cookie banner above skip link

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,8 +26,6 @@
     document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
   <% end -%>
 
-  <%= render "govuk_publishing_components/components/skip_link" %>
-
   <% unless @skip_cookie_banner %>
     <%= render "govuk_publishing_components/components/cookie_banner", {
       title: t("cookie_banner.title"),
@@ -54,6 +52,8 @@
       },
     } %>
   <% end %>
+
+  <%= render "govuk_publishing_components/components/skip_link" %>
 
   <%= render "govuk_publishing_components/components/layout_header", {
     product_name: "Account",


### PR DESCRIPTION
## What

Switch around the skip link and the cookie banner

## Why

This brings it in line with design system guidance for the cookie banner and makes it easier for assistive tech to encounter and interact with the cookies information.