### PR TITLE
Remove the transition checker cookie consent hack

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -76,7 +76,7 @@ module ApplicationHelper
     "#{base_url}/transition"
   end
 
-  def service_for(previous_url, current_user)
+  def service_for(previous_url)
     return unless previous_url&.start_with? oauth_authorization_path
 
     bits = previous_url.split("?")
@@ -88,16 +88,9 @@ module ApplicationHelper
     app = Doorkeeper::Application.by_uid(querystring["client_id"].first)
     return unless app
 
-    url =
-      if current_user&.cookie_consent && previous_url.end_with?("%3A%2Ftransition-check%2Fsaved-results")
-        "#{previous_url}%3Acookies-yes"
-      else
-        previous_url
-      end
-
     {
       name: app.name,
-      url: url,
+      url: previous_url,
     }
   end
 

--- a/app/views/confirmations/sent.html.erb
+++ b/app/views/confirmations/sent.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t("confirmation_sent.heading") %>
-<% service = service_for(params[:previous_url], current_user) if @user_is_new %>
+<% service = service_for(params[:previous_url]) if @user_is_new %>
 
 <%= render "govuk_publishing_components/components/heading", {
   text: yield(:title),

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -58,8 +58,6 @@ RSpec.describe ApplicationHelper do
   end
 
   describe "#service_for" do
-    let(:user) { FactoryBot.create(:user) }
-
     let(:application) do
       FactoryBot.create(
         :oauth_application,
@@ -71,18 +69,18 @@ RSpec.describe ApplicationHelper do
 
     it "extracts the service name using the client_id parameter" do
       url = oauth_authorization_path + "?" + Rack::Utils.build_nested_query(client_id: application.uid)
-      expect(service_for(url, user)[:name]).to eq(application.name)
+      expect(service_for(url)[:name]).to eq(application.name)
     end
 
     it "only produces a service name if the link looks like an OAuth content URL" do
       url = "//nefarious-attempt-to-embed-an-arbitrary-link?" + Rack::Utils.build_nested_query(client_id: application.uid)
-      expect(service_for(url, user)).to be_nil
+      expect(service_for(url)).to be_nil
     end
 
     context "the client_id doesn't match an application" do
       it "returns nil" do
         url = oauth_authorization_path + "?" + Rack::Utils.build_nested_query(client_id: "breadbread")
-        expect(service_for(url, user)).to be_nil
+        expect(service_for(url)).to be_nil
       end
     end
   end


### PR DESCRIPTION
This is no longer needed, as the transition checker uses the
slightly-less-of-a-hack ephemeral state workaround we implemented.

https://github.com/alphagov/finder-frontend/blob/master/app/controllers/sessions_controller.rb#L35-L48

---

[Trello card](https://trello.com/c/nfoKVqOK/629-use-the-new-non-posty-jwt-mechanism-in-the-transition-checker)