### PR TITLE
Implement fixes needed for a non-POSTy JWT flow

### DIFF
--- a/app/controllers/concerns/accepts_jwt.rb
+++ b/app/controllers/concerns/accepts_jwt.rb
@@ -24,6 +24,6 @@ module AcceptsJwt
     return unless bits.length > 1
 
     querystring = CGI.parse(bits[1])
-    querystring["state"]&.first
+    querystring["state"]&.first&.split(":")&.first
   end
 end

--- a/app/views/registrations/start.html.erb
+++ b/app/views/registrations/start.html.erb
@@ -65,7 +65,7 @@
   } %>
 <% end %>
 
-<p class="govuk-body"><%= sanitize(t("devise.registrations.start.sign_in", link: link_to(t("devise.registrations.start.sign_in_link"), new_user_session_path, class: "govuk-link"))) %></p>
+<p class="govuk-body"><%= sanitize(t("devise.registrations.start.sign_in", link: link_to(t("devise.registrations.start.sign_in_link"), new_user_session_path(previous_url: params[:previous_url]), class: "govuk-link"))) %></p>
 
 <% if @criteria_keys %>
   <%= render "govuk_publishing_components/components/inset_text", {

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,46 +1,22 @@
 {
   "ignored_warnings": [
     {
-      "warning_type": "Redirect",
-      "warning_code": 18,
-      "fingerprint": "062a4003b05105991b88193f8e0b1d580bfbf942e384cc6748ff2d321222cf04",
-      "check_name": "Redirect",
-      "message": "Possible unprotected redirect",
-      "file": "app/controllers/welcome_controller.rb",
-      "line": 8,
-      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
-      "code": "redirect_to((if ApplicationKey.validate_jwt!(params[:jwt]) then\n  ApplicationKey.validate_jwt!(params[:jwt])[:post_login_oauth]\nelse\n  user_root_path\nend))",
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "be7bc4f7735a57aa69cb603326b613e1361f46d6e301a456f7d3699b661a804d",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "config/initializers/doorkeeper.rb",
+      "line": 14,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "Jwt.exists?(request.params[:state].split(\":\").first)",
       "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "WelcomeController",
-        "method": "show"
-      },
-      "user_input": "ApplicationKey.validate_jwt!(params[:jwt])[:post_login_oauth]",
+      "location": null,
+      "user_input": "request.params[:state].split(\":\").first",
       "confidence": "High",
-      "note": "This is validated to have a safe prefix in the ApplicationKey validation"
-    },
-    {
-      "warning_type": "Redirect",
-      "warning_code": 18,
-      "fingerprint": "1d696a73d181f2a98407c6788d71a2c95ceb6c84145cddc13543bf150a944548",
-      "check_name": "Redirect",
-      "message": "Possible unprotected redirect",
-      "file": "app/controllers/devise_sessions_controller.rb",
-      "line": 12,
-      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
-      "code": "redirect_to(ApplicationKey.validate_jwt!(params[:jwt])[:post_login_oauth])",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "DeviseSessionsController",
-        "method": "create"
-      },
-      "user_input": "ApplicationKey.validate_jwt!(params[:jwt])[:post_login_oauth]",
-      "confidence": "High",
-      "note": "This is validated to have a safe prefix in the ApplicationKey validation"
+      "note": "After the split / first this is guaranteed to be a string."
     }
   ],
-  "updated": "2020-10-09 16:35:24 +0100",
+  "updated": "2021-02-17 16:54:55 +0000",
   "brakeman_version": "4.10.0"
 }

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -11,7 +11,7 @@ Doorkeeper.configure do
       current_user
     else
       destination_url =
-        if request.params[:state] && Jwt.exists?(request.params[:state].to_s)
+        if request.params[:state] && Jwt.exists?(request.params[:state].split(":").first)
           new_user_registration_start_url
         else
           new_user_session_url

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -10,8 +10,15 @@ Doorkeeper.configure do
     if current_user
       current_user
     else
+      destination_url =
+        if request.params[:state] && Jwt.exists?(request.params[:state].to_s)
+          new_user_registration_start_url
+        else
+          new_user_session_url
+        end
+
       params = { previous_url: request.fullpath, _ga: request.params[:_ga] }.compact
-      redirect_to(new_user_session_url + "?" + Rack::Utils.build_nested_query(params))
+      redirect_to(destination_url + "?" + Rack::Utils.build_nested_query(params))
       nil
     end
   end


### PR DESCRIPTION
**Depends on:** #689

---

The POST flow sends the user to `/`.  The non-POST flow will do a normal OAuth login: a GET request to `/oauth/authorize/...`

So some changes are needed:

1. We need to do the routing to either login or registration in Doorkeeper, not in the welcome controller.
2. We need to make sure the `previous_url` query param gets passed from the registration to the login page, if the user moves.
3. We unfortunately need a bit of a work-around for getting the JWT ID from the URL, until we have the account-api app set up on the GOV.UK side.

---

[Trello card](https://trello.com/c/nfoKVqOK/629-use-the-new-non-posty-jwt-mechanism-in-the-transition-checker)