### PR TITLE
Pass along previous_url in login form

### DIFF
--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -23,6 +23,8 @@
     <% end %>
   <% end %>
 
+  <%= hidden_field_tag "previous_url", params[:previous_url] %>
+
   <%= hidden_field_tag "from_confirmation_email", params[:from_confirmation_email] %>
 
   <%= render "govuk_publishing_components/components/input", {


### PR DESCRIPTION
We use this field in the POST method of the controller, but don't
actually submit it.