### PR TITLE
Webauthn - Register, View, Delete and Auth

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem "sidekiq"
 gem "sidekiq-scheduler"
 gem "sprockets-rails"
 gem "telephone_number"
+gem 'webauthn'
 
 group :development, :test do
   gem "bullet"

--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem "sidekiq"
 gem "sidekiq-scheduler"
 gem "sprockets-rails"
 gem "telephone_number"
-gem 'webauthn'
+gem "webauthn"
 
 group :development, :test do
   gem "bullet"

--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ end
 group :test do
   gem "climate_control"
   gem "oauth2"
+  gem "shoulda", "~> 4.0.0"
   gem "simplecov"
   gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -445,6 +445,12 @@ GEM
       rubyzip (>= 1.2.2)
     sentry-raven (3.1.1)
       faraday (>= 1.0)
+    shoulda (4.0.0)
+      shoulda-context (~> 2.0)
+      shoulda-matchers (~> 4.0)
+    shoulda-context (2.0.0)
+    shoulda-matchers (4.5.1)
+      activesupport (>= 4.2.0)
     sidekiq (6.1.3)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
@@ -574,6 +580,7 @@ DEPENDENCIES
   rubocop-govuk
   sassc-rails
   sentry-raven
+  shoulda (~> 4.0.0)
   sidekiq
   sidekiq-scheduler
   simplecov

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,8 +59,10 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     aes_key_wrap (1.1.0)
+    android_key_attestation (0.3.0)
     ast (2.4.1)
     awesome_print (1.8.0)
+    awrence (1.2.0)
     aws-ip (0.0.2)
       ipaddress (~> 0.8.0)
     bcrypt (3.1.16)
@@ -81,11 +83,15 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    cbor (0.5.9.6)
     childprocess (3.0.0)
     climate_control (0.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.8)
     connection_pool (2.2.3)
+    cose (1.2.0)
+      cbor (~> 0.5.9)
+      openssl-signature_algorithm (~> 1.0)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -281,6 +287,8 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
+    openssl (2.2.0)
+    openssl-signature_algorithm (1.0.0)
     orm_adapter (0.5.0)
     os (1.1.1)
     parallel (1.19.2)
@@ -421,6 +429,8 @@ GEM
     rubyzip (2.3.0)
     rufus-scheduler (3.6.0)
       fugit (~> 1.1, >= 1.1.6)
+    safety_net_attestation (0.4.0)
+      jwt (~> 2.0)
     sassc (2.4.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
@@ -429,6 +439,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    securecompare (1.0.0)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -472,6 +483,9 @@ GEM
     thwait (0.2.0)
       e2mmap
     tilt (2.0.10)
+    tpm-key_attestation (0.10.0)
+      bindata (~> 2.4)
+      openssl-signature_algorithm (~> 1.0)
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
     uber (0.1.0)
@@ -485,6 +499,16 @@ GEM
     uniform_notifier (1.13.2)
     warden (1.2.9)
       rack (>= 2.0.9)
+    webauthn (2.4.0)
+      android_key_attestation (~> 0.3.0)
+      awrence (~> 1.1)
+      bindata (~> 2.4)
+      cbor (~> 0.5.9)
+      cose (~> 1.1)
+      openssl (~> 2.0)
+      safety_net_attestation (~> 0.4.0)
+      securecompare (~> 1.0)
+      tpm-key_attestation (~> 0.10.0)
     webdrivers (4.4.1)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
@@ -555,6 +579,7 @@ DEPENDENCIES
   simplecov
   sprockets-rails
   telephone_number
+  webauthn
   webmock
 
 RUBY VERSION

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,3 +13,5 @@
 
 //= require ./analytics-track-form
 //= require ./analytics
+//= require ./webauthn-shared
+//= require ./webauthn-registration

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,3 +15,4 @@
 //= require ./analytics
 //= require ./webauthn-shared
 //= require ./webauthn-registration
+//= require ./webauthn-authentication

--- a/app/assets/javascripts/webauthn-authentication.js
+++ b/app/assets/javascripts/webauthn-authentication.js
@@ -1,0 +1,94 @@
+document.addEventListener("DOMContentLoaded", function() {
+  var form = document.querySelector('.webauthn_key_authentication');
+
+  form.addEventListener('submit', function(event) {
+    event.preventDefault();
+    webauthnAuthentcationCeremony();
+  });
+})
+
+var authenticationOptionsPath = "/account/mfa/webauthn/options";
+var authenticationCallbackPath = "/account/mfa/webauthn/callback"
+var accountRootPath = "/"
+
+// Full authentication ceremony
+// 1. Request the authentication options from the server
+// 2. Encode the challenge and user data as an ArrayBuffer
+// 3. Send it to the browser API
+// 4. Decode the ArrayBuffers returned from the Browser API
+// 5. Send it back to the server
+function webauthnAuthentcationCeremony() {
+  requestAuthenticationFromServer()
+    .then((response) => response.json())
+    .then((getOptions) => encodeGetOptions(getOptions))
+    .then((encodedCreationOptions)  => get(encodedCreationOptions))
+    .then((publicKeyCredential) => decodePublicKeyCredentials(publicKeyCredential))
+    .then((decodedPublicKeyCredential) => sendResponseToServer(decodedPublicKeyCredential))
+    .then((authenticationAttemptResponse) => handleAuthenticationAttemptResponse(authenticationAttemptResponse))
+    .catch((err) => handleErrors(err))
+}
+
+// Error handling
+function handleErrors(err) {
+  console.log(err)
+}
+
+// Javascript to talk to the browser API
+// =====================================
+function get(encodedGetOptions) {
+  return navigator.credentials.get({"publicKey": encodedGetOptions});
+}
+
+// To and from the server
+function requestAuthenticationFromServer() {
+  return fetch(authenticationOptionsPath);
+}
+
+function sendResponseToServer(decodedPublicKeyCredential) {
+  return fetch(authenticationCallbackPath, {
+    "method": "POST",
+    "headers": {
+      "Accept": "application/json",
+      "Content-Type": "application/json",
+      "X-CSRF-Token": getCSRFToken()
+    },
+    "credentials": "same-origin",
+    "body": JSON.stringify({ "publicKeyCredential": decodedPublicKeyCredential })
+  });
+}
+
+function handleAuthenticationAttemptResponse(response) {
+  if (response.ok) {
+    window.location.replace(accountRootPath)
+  } else if (response.status < 500) {
+    console.log(response.text)
+  } else {
+    console.log("Sorry something went wrong")
+  }
+}
+
+// Encode and decode ArrayBuffers
+// ==============================
+function decodePublicKeyCredentials(publicKeyCredential) {
+  return Object.assign({
+    "id": publicKeyCredential.id,
+    "rawId": bufferToBase64url(publicKeyCredential.rawId),
+    "response": {
+      "authenticatorData": bufferToBase64url(publicKeyCredential.response.authenticatorData),
+      "clientDataJSON": bufferToBase64url(publicKeyCredential.response.clientDataJSON),
+      "signature": bufferToBase64url(publicKeyCredential.response.signature),
+      "userHandle": publicKeyCredential.response.userHandle
+    },
+    "type": publicKeyCredential.type
+  })
+}
+
+function encodeGetOptions(getOptions) {
+  getOptions.challenge = base64urlToBuffer(getOptions.challenge)
+  getOptions.allowCredentials = getOptions.allowCredentials.map((c) => base64ArrayToArrayBuffer(c))
+  return getOptions;
+}
+
+function authenticatorAttachmentToUndefined(getOptions) {
+  return (getOptions.authenticatorSelection && getOptions.authenticatorSelection.authenticatorAttachment === null)
+}

--- a/app/assets/javascripts/webauthn-authentication.js
+++ b/app/assets/javascripts/webauthn-authentication.js
@@ -1,10 +1,12 @@
 document.addEventListener("DOMContentLoaded", function() {
   var form = document.querySelector('.webauthn_key_authentication');
 
-  form.addEventListener('submit', function(event) {
-    event.preventDefault();
-    webauthnAuthentcationCeremony();
-  });
+  if (form) {
+    form.addEventListener('submit', function(event) {
+      event.preventDefault();
+      webauthnAuthentcationCeremony();
+    });
+  }
 })
 
 var authenticationOptionsPath = "/account/mfa/webauthn/options";

--- a/app/assets/javascripts/webauthn-registration.js
+++ b/app/assets/javascripts/webauthn-registration.js
@@ -1,0 +1,106 @@
+var form = document.querySelector('.webauthn_key_registration')
+
+form.addEventListener('submit', function(event) {
+  event.preventDefault();
+  webauthnRegistrationCeremony();
+});
+
+var registrationOptionsPath = "/account/security/webauthn/registration/options";
+var registartionCallbackPath = "/account/security/webauthn/registration/callback"
+var securityPathWithKeysID = "/account/security#security-keys"
+
+// Full registration ceremony
+// 1. Request the registration options from the server
+// 2. Encode the challenge and user data as an ArrayBuffer
+// 3. Send it to the browser API
+// 4. Decode the data from ArrayBuffers
+// 5. Send it back to the server
+function webauthnRegistrationCeremony() {
+  requestRegistrationFromServer()
+    .then((response) => response.json())
+    .then((createOptions) => encodeRegistrationCreateOptions(createOptions))
+    .then((encodedCreationOptions)  => create(encodedCreationOptions))
+    .then((publicKeyCredential) => decodeRegistrationPublicKeyCredentials(publicKeyCredential))
+    .then((decodedPublicKeyCredential) => sendRegistrationResponseToServer(decodedPublicKeyCredential))
+    .then((registrationAttemptResponse) => handleRegistrationResponse(registrationAttemptResponse))
+    .catch((err) => handleErrors(err))
+}
+
+// Error handling
+function handleErrors(err) {
+  if( err.message === "An attempt was made to use an object that is not, or is no longer, usable") {
+    // We should handle this with a flash banner
+    console.log("I think you are trying to register a key that is already registered")
+  }
+}
+
+// Javascript to talk to the browser API
+// =====================================
+function create(encodedCreateOptions) {
+  return navigator.credentials.create({"publicKey": encodedCreateOptions});
+}
+
+// To and from the server
+// ======================
+function requestRegistrationFromServer() {
+  return fetch(registrationOptionsPath);
+}
+
+function sendRegistrationResponseToServer(decodedPublicKeyCredential) {
+  var nickname = document.getElementsByName('credential_nickname')[0].value
+  var body = { "publicKeyCredential": decodedPublicKeyCredential }
+  if (nickname !== "" && nickname.length < 15) {
+    body.credential_nickname = nickname
+  }
+  return fetch(registartionCallbackPath, {
+    "method": "POST",
+    "headers": {
+      "Accept": "application/json",
+      "Content-Type": "application/json",
+      "X-CSRF-Token": getCSRFToken()
+    },
+    "credentials": "same-origin",
+    "body": JSON.stringify(body)
+  });
+}
+
+function handleRegistrationResponse(response) {
+  if (response.ok) {
+    window.location.replace(securityPathWithKeysID)
+  } else if (response.status < 500) {
+    console.log(response.text)
+  } else {
+    console.log("Sorry something went wrong")
+  }
+}
+
+// Encode and decode ArrayBuffers
+// ==============================
+function decodeRegistrationPublicKeyCredentials(publicKeyCredential) {
+  return Object.assign({
+    "id": publicKeyCredential.id,
+    "rawId": bufferToBase64url(publicKeyCredential.rawId),
+    "response": {
+      "attestationObject": bufferToBase64url(publicKeyCredential.response.attestationObject),
+      "clientDataJSON": bufferToBase64url(publicKeyCredential.response.clientDataJSON),
+    },
+    "type": publicKeyCredential.type
+  })
+}
+
+function encodeRegistrationCreateOptions(createOptions) {
+  createOptions.challenge = base64urlToBuffer(createOptions.challenge);
+  createOptions.user.id = base64urlToBuffer(createOptions.user.id);
+  createOptions.excludeCredentials = createOptions.excludeCredentials.map((c) => base64ArrayToArrayBuffer(c))
+
+  if (authenticatorAttachmentToUndefined(createOptions) === true) {
+    createOptions.authenticatorSelection.authenticatorAttachment = undefined
+  }
+
+  return createOptions;
+}
+
+function authenticatorAttachmentToUndefined(createOptions) {
+  return (createOptions.authenticatorSelection && createOptions.authenticatorSelection.authenticatorAttachment === null)
+}
+

--- a/app/assets/javascripts/webauthn-registration.js
+++ b/app/assets/javascripts/webauthn-registration.js
@@ -1,9 +1,11 @@
 var form = document.querySelector('.webauthn_key_registration')
 
-form.addEventListener('submit', function(event) {
-  event.preventDefault();
-  webauthnRegistrationCeremony();
-});
+if (form) {
+  form.addEventListener('submit', function(event) {
+    event.preventDefault();
+    webauthnRegistrationCeremony();
+  });
+}
 
 var registrationOptionsPath = "/account/security/webauthn/registration/options";
 var registartionCallbackPath = "/account/security/webauthn/registration/callback"

--- a/app/assets/javascripts/webauthn-shared.js
+++ b/app/assets/javascripts/webauthn-shared.js
@@ -1,0 +1,51 @@
+// Taken from @github/webauthn-json:
+// https://github.com/github/webauthn-json/blob/3a758a247b11a0dcc60b7aa5ef32b3a72f9f1549/src/base64url.ts#L23
+function  bufferToBase64url(buffer) {
+  // Buffer to binary string
+  var byteView = new Uint8Array(buffer);
+  var str = "";
+  for (var charCode of byteView) {
+    str += String.fromCharCode(charCode);
+  }
+
+  // Binary string to base64
+  var base64String = btoa(str);
+
+  // Base64 to base64url
+  // We assume that the base64url string is well-formed.
+  var base64urlString = base64String
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=/g, "");
+  return base64urlString;
+}
+
+// Taken from @github/webauthn-json:
+// https://github.com/github/webauthn-json/blob/3a758a247b11a0dcc60b7aa5ef32b3a72f9f1549/src/base64url.ts#L3
+function base64urlToBuffer(baseurl64String) {
+  // Base64url to Base64
+  var padding = "==".slice(0, (4 - (baseurl64String.length % 4)) % 4);
+  var base64String =
+    baseurl64String.replace(/-/g, "+").replace(/_/g, "/") + padding;
+
+  // Base64 to binary string
+  var str = atob(base64String);
+
+  // Binary string to buffer
+  var buffer = new ArrayBuffer(str.length);
+  var byteView = new Uint8Array(buffer);
+  for (let i = 0; i < str.length; i++) {
+    byteView[i] = str.charCodeAt(i);
+  }
+  return buffer;
+}
+
+function getCSRFToken() {
+  var CSRFSelector = document.querySelector('meta[name="csrf-token"]')
+  return CSRFSelector ? CSRFSelector.getAttribute("content") : null
+}
+
+function base64ArrayToArrayBuffer(credential) {
+  credential.id = base64urlToBuffer(credential.id);
+  return credential
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,6 +20,10 @@ class ApplicationController < ActionController::Base
     )
   end
 
+  def webauthn_registered?(resource)
+    resource.webauthn_id && resource.webauthn_credentials.present?
+  end
+
 protected
 
   def top_level_error_handler(exception = nil)

--- a/app/controllers/security_controller.rb
+++ b/app/controllers/security_controller.rb
@@ -3,6 +3,7 @@ class SecurityController < ApplicationController
 
   SUMMARY_ACTIVITIES_TO_SHOW = 3
   SECURITY_CODES_TO_SHOW = 3
+  SECURITY_KEYS_TO_SHOW = 3
 
   def show
     @activity = current_user
@@ -26,6 +27,11 @@ class SecurityController < ApplicationController
       .mfa_tokens
       .order(created_at: :desc)
       .limit(SECURITY_CODES_TO_SHOW)
+
+    @regisered_security_keys =  current_user
+      .webauthn_credentials
+      .order(created_at: :desc)
+      .limit(SECURITY_KEYS_TO_SHOW)
   end
 
   def report; end

--- a/app/controllers/security_controller.rb
+++ b/app/controllers/security_controller.rb
@@ -28,7 +28,7 @@ class SecurityController < ApplicationController
       .order(created_at: :desc)
       .limit(SECURITY_CODES_TO_SHOW)
 
-    @regisered_security_keys =  current_user
+    @regisered_security_keys = current_user
       .webauthn_credentials
       .order(created_at: :desc)
       .limit(SECURITY_KEYS_TO_SHOW)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -117,7 +117,7 @@ class SessionsController < Devise::SessionsController
       webauthn_credential.verify(
         session[:authentication_challenge],
         public_key: stored_credential.public_key,
-        sign_count: stored_credential.sign_count
+        sign_count: stored_credential.sign_count,
       )
 
       stored_credential.update(sign_count: webauthn_credential.sign_count)
@@ -128,7 +128,6 @@ class SessionsController < Devise::SessionsController
       session.delete(:login_state_id)
 
       render json: { status: "ok", redirect_to: redirect_to }, status: :ok
-
     rescue WebAuthn::SignCountVerificationError => e
       # Cryptographic verification of the authenticator data succeeded, but the signature counter was less then or equal
       # to the stored value. This can have several reasons and depending on your risk tolerance you can choose to fail or

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -101,7 +101,7 @@ class SessionsController < Devise::SessionsController
   def webauthn_authenticate; end
 
   def webauthn_get_options
-    options = WebAuthn::Credential.options_for_get(allow: login_state.user.webauthn_credentials.map { |c| c.external_id })
+    options = WebAuthn::Credential.options_for_get(allow: login_state.user.webauthn_credentials.map(&:external_id))
     session[:authentication_challenge] = options.challenge
 
     respond_to do |format|
@@ -120,7 +120,7 @@ class SessionsController < Devise::SessionsController
         sign_count: stored_credential.sign_count,
       )
 
-      stored_credential.update(sign_count: webauthn_credential.sign_count)
+      stored_credential.update!(sign_count: webauthn_credential.sign_count)
 
       redirect_to = do_sign_in(has_done_mfa: true, prevent_redirect: true)
       login_state.user.update!(last_mfa_success: Time.zone.now)

--- a/app/controllers/webauthn_delete_controller.rb
+++ b/app/controllers/webauthn_delete_controller.rb
@@ -1,0 +1,27 @@
+class WebauthnDeleteController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_security_key
+
+  attr_accessor :security_key
+
+  def show
+    redirect_unless_security_key(account_security_path)
+  end
+
+  def destroy
+    redirect_unless_security_key(account_security_path)
+    security_key.destroy! if security_key
+    redirect_to account_security_path(anchor: 'security-keys')
+  end
+
+private
+
+  def redirect_unless_security_key(redirect_path)
+    flash[:alert] = t("mfa.errors.webauthn.delete.no_key_found")
+    redirect_to redirect_path unless security_key
+  end
+
+  def set_security_key
+    @security_key ||= current_user.webauthn_credentials.find(params[:key_id])
+  end
+end

--- a/app/controllers/webauthn_delete_controller.rb
+++ b/app/controllers/webauthn_delete_controller.rb
@@ -11,7 +11,7 @@ class WebauthnDeleteController < ApplicationController
   def destroy
     redirect_unless_security_key(account_security_path)
     security_key.destroy! if security_key
-    redirect_to account_security_path(anchor: 'security-keys')
+    redirect_to account_security_path(anchor: "security-keys")
   end
 
 private

--- a/app/controllers/webauthn_delete_controller.rb
+++ b/app/controllers/webauthn_delete_controller.rb
@@ -1,8 +1,6 @@
 class WebauthnDeleteController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_security_key
-
-  attr_accessor :security_key
+  before_action :security_key
 
   def show
     redirect_unless_security_key(account_security_path)
@@ -21,7 +19,7 @@ private
     redirect_to redirect_path unless security_key
   end
 
-  def set_security_key
+  def security_key
     @security_key ||= current_user.webauthn_credentials.find(params[:key_id])
   end
 end

--- a/app/controllers/webauthn_registration_controller.rb
+++ b/app/controllers/webauthn_registration_controller.rb
@@ -25,7 +25,7 @@ class WebauthnRegistrationController < ApplicationController
         external_id: Base64.urlsafe_encode64(credential_with_attestation.raw_id, padding: false),
         nickname: params[:credential_nickname] || generate_random_nickname,
         public_key: credential_with_attestation.public_key,
-        sign_count: credential_with_attestation.sign_count
+        sign_count: credential_with_attestation.sign_count,
       )
 
       if credential.save
@@ -56,8 +56,7 @@ private
   end
 
   def generate_random_nickname
-      letters = [('a'..'z'), ('A'..'Z')].map(&:to_a).flatten
-      return (0...10).map { letters[rand(letters.length)] }.join
+    letters = [("a".."z"), ("A".."Z")].map(&:to_a).flatten
+    (0...10).map { letters[rand(letters.length)] }.join
   end
-
 end

--- a/app/controllers/webauthn_registration_controller.rb
+++ b/app/controllers/webauthn_registration_controller.rb
@@ -1,0 +1,63 @@
+class WebauthnRegistrationController < ApplicationController
+  before_action :authenticate_user!
+  before_action :create_webauthn_id, only: :create
+
+  def show
+    @registered_credentials = current_user.webauthn_credentials
+  end
+
+  def create
+    options = generate_options
+
+    session[:creation_challenge] = options.challenge
+
+    respond_to do |format|
+      format.json { render json: options }
+    end
+  end
+
+  def callback
+    credential_with_attestation = WebAuthn::Credential.from_create(params[:publicKeyCredential])
+
+    begin
+      credential_with_attestation.verify(session[:creation_challenge])
+      credential = current_user.webauthn_credentials.build(
+        external_id: Base64.urlsafe_encode64(credential_with_attestation.raw_id, padding: false),
+        nickname: params[:credential_nickname] || generate_random_nickname,
+        public_key: credential_with_attestation.public_key,
+        sign_count: credential_with_attestation.sign_count
+      )
+
+      if credential.save
+        render json: { status: "ok" }, status: :ok
+      else
+        render json: "Couldn't register your Security Key", status: :unprocessable_entity
+      end
+    rescue WebAuthn::Error => e
+      render json: "Verification failed: #{e.message}", status: :unprocessable_entity
+    ensure
+      session.delete("creation_challenge")
+    end
+  end
+
+private
+
+  def generate_options
+    WebAuthn::Credential.options_for_create(
+      user: { id: current_user.webauthn_id, name: current_user.email },
+      exclude: current_user.webauthn_credentials.pluck(:external_id),
+    )
+  end
+
+  def create_webauthn_id
+    unless current_user.webauthn_id
+      current_user.update!(webauthn_id: WebAuthn.generate_user_id)
+    end
+  end
+
+  def generate_random_nickname
+      letters = [('a'..'z'), ('A'..'Z')].map(&:to_a).flatten
+      return (0...10).map { letters[rand(letters.length)] }.join
+  end
+
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,6 +41,9 @@ class User < ApplicationRecord
   has_many :mfa_tokens,
            dependent: :destroy
 
+  has_many :webauthn_credentials,
+           dependent: :destroy
+
   validate :password_cannot_be_on_denylist, if: :password_required?
 
   after_commit :update_remote_user_info, on: %i[create update]

--- a/app/models/webauthn_credential.rb
+++ b/app/models/webauthn_credential.rb
@@ -1,0 +1,3 @@
+class WebauthnCredential < ApplicationRecord
+  belongs_to :user
+end

--- a/app/views/security/_security_key.html.erb
+++ b/app/views/security/_security_key.html.erb
@@ -1,0 +1,23 @@
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+    <%= security_key.nickname %>
+  </dt>
+  <dd class="govuk-summary-list__value">
+    <span class="date-text">
+      <%= t("account.security.webauthn.key.registered_on") %>
+      <br>
+      <%= date_with_time_ago(security_key.created_at) %>
+    </span>
+    <br>
+     <p class="govuk-body">
+      <a class="govuk-link" href="<%= webauthn_delete_key_page_path(key_id: security_key.id) %>"
+         data-module="gem-track-click"
+         data-track-category="account-manage"
+         data-track-action="security"
+         data-track-label="not-me"
+      >
+        <%= t("account.security.webauthn.action.revoke") %>
+      </a>
+    </p>
+  </dd>
+</div>

--- a/app/views/security/show.html.erb
+++ b/app/views/security/show.html.erb
@@ -101,3 +101,33 @@
     <%= link_to t("account.security.show_all"), account_security_paginated_mfa_tokens_path(page_number: 1), class: "govuk-link", 'aria-label': t("account.security.show_all_aria_label_mfa") %>
   </p>
 <% end %>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("account.security.webauthn.title"),
+  heading_level: 2,
+  font_size: "m",
+  margin_bottom: 4,
+  id: "security-keys"
+} %>
+
+<%= sanitize(t("account.security.webauthn.description")) %>
+
+<dl class="govuk-summary-list security-key-list">
+  <% unless @regisered_security_keys.empty? %>
+    <% @regisered_security_keys.each do |key| %>
+        <%= render "security_key", security_key: key %>
+    <% end %>
+  <% else %>
+    <div class="govuk-summary-list__row">
+      <dd class="govuk-summary-list__value">
+        <p class="govuk-body">
+          <%= t("account.security.webauthn.none.text") %>
+        </p>
+      </dd>
+    </div>
+  <% end%>
+</dl>
+
+<p class="govuk-body">
+  <%= link_to t("account.security.webauthn.action.register_new"), webauthn_register_path, class: "govuk-link", 'aria-label': "Register a new key" %>
+</p>

--- a/app/views/sessions/webauthn_authenticate.html.erb
+++ b/app/views/sessions/webauthn_authenticate.html.erb
@@ -1,0 +1,46 @@
+<% content_for :title, t("mfa.webauthn.authenticate.page_title") %>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("mfa.webauthn.authenticate.authenticate_heading"),
+  heading_level: 1,
+  font_size: "xl",
+  margin_bottom: 3,
+} %>
+
+<% t("mfa.webauthn.authenticate.description").each do |msg| %>
+  <p class="govuk-body"><%= msg %></p>
+<% end %>
+
+<%= form_with(
+  url: webauthn_register_callback_path,
+  class: "webauthn_key_authentication",
+  method: :post,
+  data: {
+    module: "gem-track-click",
+    "track-category": "account-signin",
+    "track-action": "signin",
+    "track-label": "webauthn-authenticate"
+  }
+) do %>
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("mfa.webauthn.authenticate.fields.submit.label"),
+    margin_bottom: true,
+    data_attributes: {
+      module: "gem-track-click",
+      "track-category": "account-signin",
+      "track-action": "signin",
+      "track-label": "webauthn-authenticate"
+    }
+  } %>
+<% end %>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("mfa.webauthn.authenticate.fallback.heading"),
+  heading_level: 2,
+  margin_bottom: 4,
+  font_size: "m",
+} %>
+
+<a class="govuk-link" href="<%= fallback_to_sms_path %>">
+  <%= t("mfa.webauthn.authenticate.fallback.message") %>
+</a>

--- a/app/views/webauthn_delete/show.html.erb
+++ b/app/views/webauthn_delete/show.html.erb
@@ -1,0 +1,26 @@
+<% content_for :title, t("mfa.webauthn.delete.page_title") %>
+
+<%= render "govuk_publishing_components/components/back_link", {
+  href: account_security_path
+} %>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("mfa.webauthn.delete.delete_heading", key_name: @security_key.nickname),
+  heading_level: 2,
+  font_size: "l",
+  margin_bottom: 4,
+} %>
+
+<%= form_with(
+  url: webauthn_destroy_key_path(key_id: @security_key.id),
+  method: :delete,
+  data: {
+    module: "track-form",
+    "track-category": "webauthn"
+  }
+) do %>
+  <%= render "govuk_publishing_components/components/button", {
+    destructive: true,
+    text: t("mfa.webauthn.delete.form.fields.submit_button.label")
+  } %>
+<% end %>

--- a/app/views/webauthn_registration/show.html.erb
+++ b/app/views/webauthn_registration/show.html.erb
@@ -1,0 +1,33 @@
+<%= render "govuk_publishing_components/components/back_link", {
+  href: account_security_path
+} %>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("account.webauthn.registration.title"),
+  heading_level: 1,
+  font_size: "l",
+  margin_bottom: 4,
+} %>
+
+<%= form_with(
+  url: webauthn_register_callback_path,
+  class: "webauthn_key_registration",
+  method: :post,
+  data: {
+    module: "track-form",
+    "track-category": "account-create"
+  }
+) do %>
+  <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: t("account.webauthn.registration.form.nickname.text")
+    },
+    hint: t("account.webauthn.registration.form.nickname.hint"),
+    name: "credential_nickname",
+    width: 10
+  } %>
+
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("account.webauthn.registration.form.submit_button.label")
+  } %>
+<% end %>

--- a/config/initializers/webauthn.rb
+++ b/config/initializers/webauthn.rb
@@ -1,0 +1,35 @@
+WebAuthn.configure do |config|
+  # This value needs to match `window.location.origin` evaluated by
+  # the User Agent during registration and authentication ceremonies.
+  config.origin = "http://www.login.service.localhost"
+
+  # Relying Party name for display purposes
+  config.rp_name = "GOV.UK Account"
+
+  # Optionally configure a client timeout hint, in milliseconds.
+  # This hint specifies how long the browser should wait for any
+  # interaction with the user.
+  # This hint may be overridden by the browser.
+  # https://www.w3.org/TR/webauthn/#dom-publickeycredentialcreationoptions-timeout
+  # config.credential_options_timeout = 120_000
+
+  # You can optionally specify a different Relying Party ID
+  # (https://www.w3.org/TR/webauthn/#relying-party-identifier)
+  # if it differs from the default one.
+  #
+  # In this case the default would be "auth.example.com", but you can set it to
+  # the suffix "example.com"
+  #
+  # config.rp_id = "example.com"
+
+  # Configure preferred binary-to-text encoding scheme. This should match the encoding scheme
+  # used in your client-side (user agent) code before sending the credential to the server.
+  # Supported values: `:base64url` (default), `:base64` or `false` to disable all encoding.
+  #
+  # config.encoding = :base64url
+
+  # Possible values: "ES256", "ES384", "ES512", "PS256", "PS384", "PS512", "RS256", "RS384", "RS512", "RS1"
+  # Default: ["ES256", "PS256", "RS256"]
+  #
+  # config.algorithms << "ES384"
+end

--- a/config/initializers/webauthn.rb
+++ b/config/initializers/webauthn.rb
@@ -26,7 +26,7 @@ WebAuthn.configure do |config|
   # used in your client-side (user agent) code before sending the credential to the server.
   # Supported values: `:base64url` (default), `:base64` or `false` to disable all encoding.
   #
-  # config.encoding = :base64url
+  config.encoding = :base64url
 
   # Possible values: "ES256", "ES384", "ES512", "PS256", "PS384", "PS512", "RS256", "RS384", "RS512", "RS1"
   # Default: ["ES256", "PS256", "RS256"]

--- a/config/locales/account/security.en.yml
+++ b/config/locales/account/security.en.yml
@@ -49,6 +49,18 @@ en:
         description: See all the times you asked to skip the security code step.
         hint: You will always be asked to enter a security code if you sign in on a device you have not used to access your GOV.UK account before.
         title: Security codes when you sign in
+      webauthn:
+        title: Security keys registered to your account
+        description: |
+          <p class="govuk-body">Security keys are cool because...</p>
+          <p class="govuk-body">Aut molestiae amet officia nemo in fugit. Saepe ut alias aspernatur quas reiciendis.</p>
+        none:
+          text: "No keys currently registered"
+        key:
+          registered_on: "Registered:"
+        action:
+          revoke: Revoke this key
+          register_new: Register a new key
       show_all: Show all
       show_all_aria_label_mfa: Show all the times you asked to skip the security code step
       show_all_aria_label_signin_attempts: Show all sign-in attempts

--- a/config/locales/account/security.en.yml
+++ b/config/locales/account/security.en.yml
@@ -49,18 +49,18 @@ en:
         description: See all the times you asked to skip the security code step.
         hint: You will always be asked to enter a security code if you sign in on a device you have not used to access your GOV.UK account before.
         title: Security codes when you sign in
-      webauthn:
-        title: Security keys registered to your account
-        description: |
-          <p class="govuk-body">Security keys are cool because...</p>
-          <p class="govuk-body">Aut molestiae amet officia nemo in fugit. Saepe ut alias aspernatur quas reiciendis.</p>
-        none:
-          text: "No keys currently registered"
-        key:
-          registered_on: "Registered:"
-        action:
-          revoke: Revoke this key
-          register_new: Register a new key
       show_all: Show all
       show_all_aria_label_mfa: Show all the times you asked to skip the security code step
       show_all_aria_label_signin_attempts: Show all sign-in attempts
+      webauthn:
+        action:
+          register_new: Register a new key
+          revoke: Revoke this key
+        description: |
+          <p class="govuk-body">Security keys are cool because...</p>
+          <p class="govuk-body">Aut molestiae amet officia nemo in fugit. Saepe ut alias aspernatur quas reiciendis.</p>
+        key:
+          registered_on: 'Registered:'
+        none:
+          text: No keys currently registered
+        title: Security keys registered to your account

--- a/config/locales/account/webauthn.en.yml
+++ b/config/locales/account/webauthn.en.yml
@@ -1,0 +1,12 @@
+---
+en:
+  account:
+    webauthn:
+      registration:
+        title: Register a new security key
+        form:
+          nickname:
+            text: Give your key a name
+            hint: A name will help identify this key when logging in or authenticating. If you choose not to provide one we will give it random letters as a name.
+          submit_button:
+            label: "Register a new key"

--- a/config/locales/account/webauthn.en.yml
+++ b/config/locales/account/webauthn.en.yml
@@ -3,10 +3,10 @@ en:
   account:
     webauthn:
       registration:
-        title: Register a new security key
         form:
           nickname:
-            text: Give your key a name
             hint: A name will help identify this key when logging in or authenticating. If you choose not to provide one we will give it random letters as a name.
+            text: Give your key a name
           submit_button:
-            label: "Register a new key"
+            label: Register a new key
+        title: Register a new security key

--- a/config/locales/mfa.en.yml
+++ b/config/locales/mfa.en.yml
@@ -16,6 +16,9 @@ en:
         expired: The security code you’ve entered has expired. Security codes expire after 30 minutes. We can <a class="govuk-link" href="%{resend_link}">send a new security code</a>.
         invalid: The security code you’ve entered is not correct. Try entering the code again.
         too_many_attempts: You’ve entered the wrong security code too many times. You need to <a class="govuk-link" href="%{resend_link}">get a new security code</a>.
+      webauthn:
+        delete:
+          no_key_found: Something has gone wrong, you do not have a key registered with this ID so it cannot be deleted.
     phone:
       code:
         change_heading: Enter your security code
@@ -74,6 +77,28 @@ en:
               label: Continue
           heading: Change your phone number
           message: We’ll send a security code to your new number by text message. You’ll need this code to finish changing the phone number for your account.
+    webauthn:
+      delete:
+        page_title: Delete a security key
+        delete_heading: "Delete key: %{key_name}"
+        description: |
+          Parting is such sweet sorrow. When you delete a key it is gone, you will not be able to log in with it anymore. If you want it back, you would need to re-regsiter it.
+        form:
+          fields:
+            submit_button:
+              label: Delete key
+      authenticate:
+        page_title: Authenticate with your security key
+        authenticate_heading: Authenticate with your security key
+        description:
+          - You previously registered security keys with your GOV.UK Account
+          - Ensure you have your key / device to hand and then continue
+        fields:
+          submit:
+            label: Authenticate
+        fallback:
+          heading: If you cannot use your device or key
+          message: You can fall back to authenticating by SMS instead
     text_message:
       security_code:
         body: "%{phone_code} is your security code."

--- a/config/locales/mfa.en.yml
+++ b/config/locales/mfa.en.yml
@@ -77,26 +77,26 @@ en:
               label: Continue
           heading: Change your phone number
           message: We’ll send a security code to your new number by text message. You’ll need this code to finish changing the phone number for your account.
+    text_message:
+      security_code:
+        body: "%{phone_code} is your security code."
     webauthn:
+      authenticate:
+        authenticate_heading: Authenticate with your security key
+        description:
+        - You previously registered security keys with your GOV.UK Account
+        - Ensure you have your key / device to hand and then continue
+        fallback:
+          heading: If you cannot use your device or key
+          message: You can fall back to authenticating by SMS instead
+        fields:
+          submit:
+            label: Authenticate
+        page_title: Authenticate with your security key
       delete:
-        page_title: Delete a security key
-        delete_heading: "Delete key: %{key_name}"
+        delete_heading: 'Delete key: %{key_name}'
         form:
           fields:
             submit_button:
               label: Delete key
-      authenticate:
-        page_title: Authenticate with your security key
-        authenticate_heading: Authenticate with your security key
-        description:
-          - You previously registered security keys with your GOV.UK Account
-          - Ensure you have your key / device to hand and then continue
-        fields:
-          submit:
-            label: Authenticate
-        fallback:
-          heading: If you cannot use your device or key
-          message: You can fall back to authenticating by SMS instead
-    text_message:
-      security_code:
-        body: "%{phone_code} is your security code."
+        page_title: Delete a security key

--- a/config/locales/mfa.en.yml
+++ b/config/locales/mfa.en.yml
@@ -81,8 +81,6 @@ en:
       delete:
         page_title: Delete a security key
         delete_heading: "Delete key: %{key_name}"
-        description: |
-          Parting is such sweet sorrow. When you delete a key it is gone, you will not be able to log in with it anymore. If you want it back, you would need to re-regsiter it.
         form:
           fields:
             submit_button:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,10 +26,19 @@ Rails.application.routes.draw do
       get "/insecure-password", to: "insecure_password#show", as: :insecure_password_interstitial
 
       get "/manage", to: "manage#show", as: :account_manage
-      get "/security", to: "security#show", as: :account_security
-      get "/security/activity/:page_number", to: "security#paginated_activity", as: :account_security_paginated_activity
-      get "/security/code/:page_number", to: "security#paginated_mfa_tokens", as: :account_security_paginated_mfa_tokens
-      get "/security/report", to: "security#report", as: :account_security_report
+      scope "/security" do
+        get "/", to: "security#show", as: :account_security
+        get "/activity/:page_number", to: "security#paginated_activity", as: :account_security_paginated_activity
+        get "/code/:page_number", to: "security#paginated_mfa_tokens", as: :account_security_paginated_mfa_tokens
+        get "/report", to: "security#report", as: :account_security_report
+        scope "/webauthn" do
+          scope "/registration" do
+            get "/", to: "webauthn_registration#show", as: :webauthn_register
+            get "/options", to: "webauthn_registration#create", as: :webauthn_register_request_options
+            post "/callback", to: "webauthn_registration#callback", as: :webauthn_register_callback
+          end
+        end
+      end
 
       get    "/delete", to: "delete#show", as: :account_delete
       delete "/delete", to: "delete#destroy"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,13 @@ Rails.application.routes.draw do
       scope "/mfa" do
         get "/abort", to: "redo_mfa#stop", as: :redo_mfa_stop
 
+        scope "/webauthn" do
+          get "/", to: "sessions#webauthn_authenticate", as: :webauthn_authenticate
+          get "/fallback", to: "sessions#generate_and_send_sms", as: :fallback_to_sms
+          get "/options", to: "sessions#webauthn_get_options", as: :webauthn_authenticate_request_options
+          post "/callback", to: "sessions#webauthn_authenticate_callback", as: :webauthn_authenticate_callback
+        end
+
         scope "/phone" do
           get  "/code", to: "redo_mfa_phone#code", as: :redo_mfa_phone_code
           post "/verify", to: "redo_mfa_phone#verify", as: :redo_mfa_phone_verify

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,10 @@ Rails.application.routes.draw do
         get "/code/:page_number", to: "security#paginated_mfa_tokens", as: :account_security_paginated_mfa_tokens
         get "/report", to: "security#report", as: :account_security_report
         scope "/webauthn" do
+          scope "/delete" do
+             get "/", to: "webauthn_delete#show", as: :webauthn_delete_key_page
+             delete "/", to: "webauthn_delete#destroy", as: :webauthn_destroy_key
+          end
           scope "/registration" do
             get "/", to: "webauthn_registration#show", as: :webauthn_register
             get "/options", to: "webauthn_registration#create", as: :webauthn_register_request_options

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,8 +33,8 @@ Rails.application.routes.draw do
         get "/report", to: "security#report", as: :account_security_report
         scope "/webauthn" do
           scope "/delete" do
-             get "/", to: "webauthn_delete#show", as: :webauthn_delete_key_page
-             delete "/", to: "webauthn_delete#destroy", as: :webauthn_destroy_key
+            get "/", to: "webauthn_delete#show", as: :webauthn_delete_key_page
+            delete "/", to: "webauthn_delete#destroy", as: :webauthn_destroy_key
           end
           scope "/registration" do
             get "/", to: "webauthn_registration#show", as: :webauthn_register

--- a/db/migrate/20210203095633_add_webauthn_id_to_user.rb
+++ b/db/migrate/20210203095633_add_webauthn_id_to_user.rb
@@ -1,0 +1,5 @@
+class AddWebauthnIdToUser < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :webauthn_id, :string
+  end
+end

--- a/db/migrate/20210203112448_create_webauthn_credentials.rb
+++ b/db/migrate/20210203112448_create_webauthn_credentials.rb
@@ -1,0 +1,15 @@
+class CreateWebauthnCredentials < ActiveRecord::Migration[6.0]
+  def change
+    create_table :webauthn_credentials do |t|
+      t.string :external_id
+      t.string :public_key
+      t.string :nickname
+      t.bigint :sign_count, null: false, default: 0
+      t.references :user, foreign_key: true
+
+      t.timestamps null: false
+    end
+
+    add_index :webauthn_credentials, :external_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -197,6 +197,7 @@ ActiveRecord::Schema.define(version: 2021_02_18_135210) do
     t.string "session_token"
     t.boolean "has_received_onboarding_email", default: false, null: false
     t.boolean "banned_password_match"
+    t.string "webauthn_id"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -204,6 +204,18 @@ ActiveRecord::Schema.define(version: 2021_02_18_135210) do
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end
 
+  create_table "webauthn_credentials", force: :cascade do |t|
+    t.string "external_id"
+    t.string "public_key"
+    t.string "nickname"
+    t.bigint "sign_count", default: 0, null: false
+    t.bigint "user_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["external_id"], name: "index_webauthn_credentials_on_external_id", unique: true
+    t.index ["user_id"], name: "index_webauthn_credentials_on_user_id"
+  end
+
   add_foreign_key "data_activities", "oauth_applications"
   add_foreign_key "data_activities", "users"
   add_foreign_key "email_subscriptions", "users"
@@ -220,4 +232,5 @@ ActiveRecord::Schema.define(version: 2021_02_18_135210) do
   add_foreign_key "security_activities", "oauth_applications"
   add_foreign_key "security_activities", "user_agents"
   add_foreign_key "security_activities", "users"
+  add_foreign_key "webauthn_credentials", "users"
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -19,7 +19,7 @@ FactoryBot.define do
       end
 
       after(:create) do |user, evaluator|
-        create_list(:webauthn_credentials, evaluator.credentials_count, user: user)
+        create_list(:webauthn_credential, evaluator.credentials_count, user: user)
         user.reload
       end
     end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -12,5 +12,16 @@ FactoryBot.define do
       unconfirmed_email { "new_email@example.com" }
       confirmation_token { "abc123" }
     end
+
+    trait :with_webauthn_credentials do
+      transient do
+        credentials_count { 2 }
+      end
+
+      after(:create) do |user, evaluator|
+        create_list(:webauthn_credentials, evaluator.credentials_count, user: user)
+        user.reload
+      end
+    end
   end
 end

--- a/spec/factories/webauthn_credentials.rb
+++ b/spec/factories/webauthn_credentials.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :webauthn_credential do
+    user
+    external_id { "123" }
+    public_key { "blah" }
+    nickname { "test_webauthn_cred" }
+    sign_count { 0 }
+  end
+end

--- a/spec/factories/webauthn_credentials.rb
+++ b/spec/factories/webauthn_credentials.rb
@@ -1,9 +1,9 @@
 FactoryBot.define do
   factory :webauthn_credential do
     user
-    external_id { "123" }
-    public_key { "blah" }
-    nickname { "test_webauthn_cred" }
+    sequence(:external_id) { |n| "external_id #{n}" }
+    sequence(:public_key) { |n| "public_key #{n}" }
+    sequence(:nickname) { |n| "nickname #{n}" }
     sign_count { 0 }
   end
 end

--- a/spec/feature/webauthn/authenticate_key_spec.rb
+++ b/spec/feature/webauthn/authenticate_key_spec.rb
@@ -1,5 +1,5 @@
 RSpec.feature "Authenticate with a new a webauthn key" do
-  secnario do
+  scenario do
     # We had some difficulty getting these to work. The JS will trigger a web browser API which will present the user with a modal box
     # that they can use to authenticate from this point on. However capybara does not appear to have access to that API, and we would need to
     # find a way of stubbing the input from a yubikey.

--- a/spec/feature/webauthn/authenticate_key_spec.rb
+++ b/spec/feature/webauthn/authenticate_key_spec.rb
@@ -1,0 +1,12 @@
+RSpec.feature "Authenticate with a new a webauthn key" do
+  secnario do
+    # We had some difficulty getting these to work. The JS will trigger a web browser API which will present the user with a modal box
+    # that they can use to authenticate from this point on. However capybara does not appear to have access to that API, and we would need to
+    # find a way of stubbing the input from a yubikey.
+    # There are some testing methods that come with the library here: https://github.com/cedarcode/webauthn-ruby/blob/master/lib/webauthn/fake_client.rb
+    # However our conclusion is, you cannot feature test registration / authententication
+    # Instead we would need to use the webauthn-ruby libray stubs to write feature tests.
+    # This means the majoirty of the JS code needs to be unit tested easily.
+    # Though we note: https://www.selenium.dev/selenium/docs/api/rb/Selenium/WebDriver/DevTools/WebAuthn.html#add_virtual_authenticator-instance_method
+  end
+end

--- a/spec/feature/webauthn/register_key_spec.rb
+++ b/spec/feature/webauthn/register_key_spec.rb
@@ -1,0 +1,47 @@
+RSpec.feature "Register a new a webauthn key" do
+  scenario do
+    given_i_am_signed_in_and_i_have_no_key_registered
+    when_i_navigate_to_the_security_tab
+    then_i_click_register_a_new_key
+    then_i_see_the_register_key_form
+    and_i_give_my_key_a_nickname
+    and_i_submit_the_form
+    # then_i_register_my_key_with_my_browser
+    # then_i_see_my_new_key_registered_on_the_security_tab
+  end
+
+  def then_i_click_register_a_new_key
+    click_on(I18n.t("account.security.webauthn.action.register_new"))
+  end
+
+  def then_i_see_the_register_key_form
+    expect(page).to have_css(
+      'h1',
+      text: I18n.t("account.webauthn.registration.title"),
+      visible: true
+    )
+  end
+
+  def and_i_give_my_key_a_nickname
+    fill_in 'credential_nickname', :with => 'nickname 1'
+  end
+
+  def and_i_submit_the_form
+    click_on I18n.t("account.webauthn.registration.form.submit_button.label")
+  end
+
+  # def then_i_register_my_key_with_my_browser
+    # We had some difficulty getting these to work. The JS will trigger a web browser API which will present the user with a modal box
+    # that they can use to authenticate from this point on. However capybara does not appear to have access to that API, and we would need to
+    # find a way of stubbing the input from a yubikey.
+    # There are some testing methods that come with the library here: https://github.com/cedarcode/webauthn-ruby/blob/master/lib/webauthn/fake_client.rb
+    # However our conclusion is, you cannot feature test registration / authententication
+    # Instead we would need to use the webauthn-ruby libray stubs to write feature tests.
+    # This means the majoirty of the JS code needs to be unit tested easily.
+    # Though we note: https://www.selenium.dev/selenium/docs/api/rb/Selenium/WebDriver/DevTools/WebAuthn.html#add_virtual_authenticator-instance_method
+  # end
+
+  # def then_i_see_my_new_key_registered_on_the_security_tab
+  #   then_i_see_registered_key("nickname 1")
+  # end
+end

--- a/spec/feature/webauthn/register_key_spec.rb
+++ b/spec/feature/webauthn/register_key_spec.rb
@@ -16,14 +16,14 @@ RSpec.feature "Register a new a webauthn key" do
 
   def then_i_see_the_register_key_form
     expect(page).to have_css(
-      'h1',
+      "h1",
       text: I18n.t("account.webauthn.registration.title"),
-      visible: true
+      visible: true,
     )
   end
 
   def and_i_give_my_key_a_nickname
-    fill_in 'credential_nickname', :with => 'nickname 1'
+    fill_in "credential_nickname", with: "nickname 1"
   end
 
   def and_i_submit_the_form
@@ -31,14 +31,14 @@ RSpec.feature "Register a new a webauthn key" do
   end
 
   # def then_i_register_my_key_with_my_browser
-    # We had some difficulty getting these to work. The JS will trigger a web browser API which will present the user with a modal box
-    # that they can use to authenticate from this point on. However capybara does not appear to have access to that API, and we would need to
-    # find a way of stubbing the input from a yubikey.
-    # There are some testing methods that come with the library here: https://github.com/cedarcode/webauthn-ruby/blob/master/lib/webauthn/fake_client.rb
-    # However our conclusion is, you cannot feature test registration / authententication
-    # Instead we would need to use the webauthn-ruby libray stubs to write feature tests.
-    # This means the majoirty of the JS code needs to be unit tested easily.
-    # Though we note: https://www.selenium.dev/selenium/docs/api/rb/Selenium/WebDriver/DevTools/WebAuthn.html#add_virtual_authenticator-instance_method
+  # We had some difficulty getting these to work. The JS will trigger a web browser API which will present the user with a modal box
+  # that they can use to authenticate from this point on. However capybara does not appear to have access to that API, and we would need to
+  # find a way of stubbing the input from a yubikey.
+  # There are some testing methods that come with the library here: https://github.com/cedarcode/webauthn-ruby/blob/master/lib/webauthn/fake_client.rb
+  # However our conclusion is, you cannot feature test registration / authententication
+  # Instead we would need to use the webauthn-ruby libray stubs to write feature tests.
+  # This means the majoirty of the JS code needs to be unit tested easily.
+  # Though we note: https://www.selenium.dev/selenium/docs/api/rb/Selenium/WebDriver/DevTools/WebAuthn.html#add_virtual_authenticator-instance_method
   # end
 
   # def then_i_see_my_new_key_registered_on_the_security_tab

--- a/spec/feature/webauthn/view_key_spec.rb
+++ b/spec/feature/webauthn/view_key_spec.rb
@@ -1,0 +1,22 @@
+RSpec.feature "View WebAuthn security keys" do
+  scenario do
+    given_i_am_signed_in_and_i_have_no_key_registered
+    when_i_navigate_to_the_security_tab
+    then_i_see_no_keys_registered
+  end
+
+  scenario do
+    given_i_am_signed_in_and_i_have_a_key_registered
+    when_i_navigate_to_the_security_tab
+    then_i_see_my_registered_keys
+  end
+
+  def then_i_see_no_keys_registered
+    expect(page).to have_content(I18n.t("account.security.webauthn.none.text"))
+  end
+
+  def then_i_see_my_registered_keys
+    credential_nicknames = user_with_credentials.webauthn_credentials.map(&:nickname)
+    credential_nickname.each { |key_nickname| then_i_see_registered_key(key_nickname) }
+  end
+end

--- a/spec/feature/webauthn/view_key_spec.rb
+++ b/spec/feature/webauthn/view_key_spec.rb
@@ -17,6 +17,6 @@ RSpec.feature "View WebAuthn security keys" do
 
   def then_i_see_my_registered_keys
     credential_nicknames = user_with_credentials.webauthn_credentials.map(&:nickname)
-    credential_nickname.each { |key_nickname| then_i_see_registered_key(key_nickname) }
+    credential_nicknames.each { |key_nickname| then_i_see_registered_key(key_nickname) }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -15,6 +15,10 @@ RSpec.describe User do
     end
   end
 
+  describe "associations" do
+    it { should have_many(:webauthn_credentials).dependent(:destroy) }
+  end
+
   context "#destroy!" do
     it "calls the attribute service to delete the attributes" do
       attribute_service_stub = stub_attribute_service_delete_all

--- a/spec/models/webauthn_credential_spec.rb
+++ b/spec/models/webauthn_credential_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe WebauthnCredential do
+  describe "associations" do
+    it { should belong_to(:user) }
+  end
+
+  describe "factories" do
+    it "has a valid factory" do
+      expect(FactoryBot.build(:user)).to be_valid
+    end
+
+    it "has a valid factory" do
+      user = FactoryBot.build(:user, :with_webauthn_credentials)
+      credentials = user.webauthn_credentials
+
+      expect(user).to be_valid
+      credentials.each { |credential| expect(credential).to be_valid }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -147,3 +147,10 @@ RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::ControllerHelpers, type: :view
 end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end

--- a/spec/support/helpers/feature_steps_helper.rb
+++ b/spec/support/helpers/feature_steps_helper.rb
@@ -1,0 +1,35 @@
+module FeatureStepsHelper
+  def given_i_am_signed_in_and_i_have_no_key_registered
+    sign_in_as(FactoryBot.create(:user))
+  end
+
+  def given_i_am_signed_in_and_i_have_a_key_registered
+    sign_in_as(user_with_credentials)
+  end
+
+  def sign_in_as(user)
+    visit new_user_session_path
+    fill_in "email", with: user.email
+    fill_in "password", with: user.password
+    click_on I18n.t("devise.sessions.new.fields.submit.label")
+
+    fill_in "phone_code", with: user.reload.phone_code
+    click_on I18n.t("mfa.phone.code.fields.submit.label")
+  end
+
+  def user_with_credentials
+    @user_with_credentials ||= FactoryBot.create(:user, :with_webauthn_credentials)
+  end
+
+  def when_i_navigate_to_the_security_tab
+    click_on(I18n.t("navigation.menu_bar.security.link_text"))
+  end
+
+  def then_i_see_registered_key(key_nickname)
+    within ".security-key-list" do
+      expect(page).to have_content(key_nickname)
+    end
+  end
+end
+
+RSpec.configuration.send :include, FeatureStepsHelper


### PR DESCRIPTION
[Trello](https://trello.com/c/924M5Jnv/585-webauthn-prototyping)

## What is this

This is the summation of the GOV.UK Accounts team work to add webauthn features to the acount.

Webauthn is a method of allowing a browser / device to manage a public/private key exchage in a way easy for the user to manage. In pratice it allows a pre-registered device to act as a known factor to strengthen identity assurances during login, or when we might wish to re-authorise for a high risk change (e.g. user is changing their password / email).

It is a flexible API, here we tested and produced a working demo with Yubikeys, but it could easily be extended to cover other webauthn credentails, for instance Apple's biometric IDs, Windows Hello or Android fingerprint IDs.

## What's in this

Features to:
- Register a new Webauthn Key (tested with Yubikey)
- View regsitered Webauthn Keys
- Remove registered Webauthn Keys
- Login with Webatuhn Keys

## What's missing

Development has been paused on this feature in preparation of us handing over to another team. This PR and commit messages are left to reference in the handover document to hopefully save future devs time if they are looking to impliment this in future.

Things we didn't get around to:

- Service design for fallback - Given not all browers support webauthn, and devices vary a more robust set of thinking about fallbacks when a device cannot use Webauthn is needed. The user flow currently may be unexpected. Also it is unclear if we would be satisfied with locking out a user who is using an incompatible browser, or if we always want to fall back to SMS. This impacts if Webauthn is best considered a replacement for SMS 2fa, allowing us to make mobile phone numbers optional on accounts, or if its an optional extension. We also need to think through what the preferred options are if multiple factors are registered.
- Content design - All content is placeholder
- Error messages at Registration / Authentication - Much is handled by client side javascript, meaning we don't get the benefit of our usual Rails error messaging and validation setup. There is space in the `.catch()` section of the promise chains to pick up on errors. These should be extended from a single `console.log()` to something that shows the user an error. Currently if a user attempts to authenticate with a crednetial they have not registered, things just silently fail with no warning to the user.
- A better testing strategy - we tried to impliment Feature tests (documented here) our current belief is that this isn't possible with our current stack. Instead some robust request specs and unit tests will need to fill that gap (sorry didn't get a chance to do those here!)
- JS needs to be wrapped in code that first checks for browser compatibility and sends the user down the correct path based on availble browser APIs.

## What did we learn

This is an interesting API, and becuase of its extensions it has a real opportunity to meet the user at their device and allow a broad range of 2nd factors that come "built in" (fingerprint readers, apple face ID, others).

It may not be the mostly widely used form of 2fa, but it offered excellent security and should have a place in a menu of second factor options letting the user choose what is easiest for them.

**GOV.UK**

- Bringing in client side JS node_modules is difficult at the moment. We are not using webpacker and sprokets means we would need to create our own compiled js packages to make use of high quality typescript modules currently available.
- govuk-docker may want to consider making a secure context the default dev environment if we think we will end up requiring more client side code that makes use of modern browser APIs. It will also help our dev environments look more like our prod ones.

**Anyone implimenting this**

- Base64 <-> ArrayBuffer encoding is a pain. If possible check out the [github package](https://github.com/github/webauthn-json) it would hvae made things a lot easier. Specifically ensure you use Ruby's `Base64.urlsafe_decode` for data passed in the registration callback.
- High level feature tests here are hard. We mayneed to rely on lower level tests to prove everything looks good here.