### PR TITLE
Reorder the change password screen

### DIFF
--- a/app/views/registrations/edit_password.html.erb
+++ b/app/views/registrations/edit_password.html.erb
@@ -18,6 +18,18 @@
 
   <%= render "govuk_publishing_components/components/show_password", {
     label: {
+      text: t("devise.registrations.edit.fields.current_password.label"),
+    },
+    heading_size: "m",
+    hint: t("devise.registrations.edit.fields.current_password.hint_current"),
+    name: "user[current_password]",
+    id: "current__confirmation",
+    error_message: devise_error_items(:current_password),
+    autocomplete: "current-password",
+  } %>
+
+  <%= render "govuk_publishing_components/components/show_password", {
+    label: {
       text: t("devise.registrations.edit.fields.password.label"),
     },
     hint: t("devise.registrations.edit.fields.password.hint"),
@@ -28,18 +40,6 @@
   } %>
 
   <%= render "_shared/password_tip" %>
-
-  <%= render "govuk_publishing_components/components/show_password", {
-    label: {
-      text: t("devise.registrations.edit.fields.current_password.label"),
-    },
-    heading_size: "m",
-    hint: t("devise.registrations.edit.fields.current_password.hint_current"),
-    name: "user[current_password]",
-    id: "current__confirmation",
-    error_message: devise_error_items(:current_password),
-    autocomplete: "current-password",
-  } %>
 
   <%= render "govuk_publishing_components/components/button", {
     text: t("devise.registrations.edit.fields.submit.label"),


### PR DESCRIPTION
This reorders the two fields on the Change password screen so that the
current password field is first and the new password field is second.

We've seen evidence that the current layout confuses both password
managers and some users. This should make it more friendly for both.

Trello card: https://trello.com/c/fcFsQuuD/611-reorder-the-change-password-screen