### PR TITLE
Assign error state to variable in redo MFA controller

### DIFF
--- a/app/controllers/redo_mfa_phone_controller.rb
+++ b/app/controllers/redo_mfa_phone_controller.rb
@@ -7,8 +7,8 @@ class RedoMfaPhoneController < ApplicationController
   def code; end
 
   def verify
-    case MultiFactorAuth.verify_code(current_user, params[:phone_code])
-    when :ok
+    state = MultiFactorAuth.verify_code(current_user, params[:phone_code])
+    if state == :ok
       record_security_event(SecurityActivity::ADDITIONAL_FACTOR_VERIFICATION_SUCCESS, user: current_user, factor: :sms)
 
       session[:has_done_mfa] = true


### PR DESCRIPTION
The state is used in the error path to show an appropriate message.

---

[Sentry error](https://sentry.io/organizations/govuk/issues/2233295427/?project=5370953&referrer=slack)