### PR TITLE
DAC fixes – Information conveyed by styling

### DIFF
--- a/app/views/application/_account-navigation.html.erb
+++ b/app/views/application/_account-navigation.html.erb
@@ -3,15 +3,30 @@
 <nav aria-label="Account management">
   <ul class="accounts-menu">
     <li class="accounts-menu__item <%= "accounts-menu__item--current" if page_is == "your-account" %>">
-      <a class="accounts-menu__link govuk-link govuk-link--no-visited-state" href="<%= user_root_path %>"><%= t("navigation.menu_bar.account.link_text") %></a>
+      <%= link_to(
+        t("navigation.menu_bar.account.link_text"),
+        user_root_path,
+        class: 'accounts-menu__link govuk-link govuk-link--no-visited-state',
+        'aria-current': page_is == "your-account" ? "page" : nil,
+      ) %>
       <span class="accounts-menu__link-description"><%= t("navigation.menu_bar.account.description") %></span>
     </li>
     <li class="accounts-menu__item <%= "accounts-menu__item--current" if page_is == "manage" %>">
-      <a class="accounts-menu__link govuk-link govuk-link--no-visited-state" href="<%= account_manage_path %>"><%= t("navigation.menu_bar.manage.link_text") %></a>
+      <%= link_to(
+        t("navigation.menu_bar.manage.link_text"),
+        account_manage_path,
+        class: 'accounts-menu__link govuk-link govuk-link--no-visited-state',
+        'aria-current': page_is == "manage" ? "page" : nil,
+      ) %>
       <span class="accounts-menu__link-description"><%= t("navigation.menu_bar.manage.description") %></span>
     </li>
     <li class="accounts-menu__item <%= "accounts-menu__item--current" if page_is == "security" %>">
-      <a class="accounts-menu__link govuk-link govuk-link--no-visited-state" href="<%= account_security_path %>"><%= t("navigation.menu_bar.security.link_text") %></a>
+      <%= link_to(
+        t("navigation.menu_bar.security.link_text"),
+        account_security_path,
+        class: 'accounts-menu__link govuk-link govuk-link--no-visited-state',
+        'aria-current': page_is == "security" ? "page" : nil,
+      ) %>
       <span class="accounts-menu__link-description"><%= t("navigation.menu_bar.security.description") %></span>
     </li>
   </ul>

--- a/config/locales/mfa.en.yml
+++ b/config/locales/mfa.en.yml
@@ -23,7 +23,7 @@ en:
         - We’ve sent you a text message with a security code.
         - It may take a few minutes to arrive.
         description_with_phone_number:
-        - We’ve sent a text message with a security code to <span class="govuk-!-font-weight-bold">%{phone_number}</span>.
+        - We’ve sent a text message with a security code to <strong>%{phone_number}</strong>.
         - It may take a few minutes to arrive.
         fields:
           phone_code:


### PR DESCRIPTION
Implement suggested solutions from the DAC Accessibility report:
- on the MFA page, use `strong` to emphasise the phone number, instead
  of using a `span` with bold styling
- on the Account manager navigation, use `aria-current` to indicate the
  location within the service.
I re-wrote the account nav links to use `link_to` syntax which is more readable. 

This would address the **Information conveyed by styling (A)** criterion – pages 13 and 14 on the report PDF.

https://trello.com/c/lNkwruEi/647-fix-accessibility-issues-raised-by-dac