### PR TITLE
Change structure of sign in attempts list

### DIFF
--- a/app/assets/stylesheets/accounts.scss
+++ b/app/assets/stylesheets/accounts.scss
@@ -149,3 +149,42 @@ $_current-indicator-width: 4px;
   margin-bottom: govuk-spacing(7);
   background: govuk-colour("light-grey");
 }
+
+.summary-list {
+  @include govuk-font(19);
+  @include govuk-clearfix;
+  padding-bottom: govuk-spacing(3);
+  margin-bottom: govuk-spacing(3);
+  border-bottom: solid 1px $govuk-border-colour;
+
+  @include govuk-media-query($from: "tablet") {
+    padding-bottom: govuk-spacing(2);
+    margin-bottom: govuk-spacing(2);
+  }
+}
+
+.summary-list__key,
+.summary-list__value {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0 0 govuk-spacing(1) 0;
+
+  @include govuk-media-query($from: "tablet") {
+    padding: govuk-spacing(0) govuk-spacing(4) govuk-spacing(0) 0;
+  }
+}
+
+.summary-list__key {
+  @include govuk-font(19, $weight: "bold");
+
+  @include govuk-media-query($from: "tablet") {
+    float: left;
+    width: 30%;
+  }
+}
+
+.summary-list__value {
+  @include govuk-media-query($from: "tablet") {
+    padding-left: 30%;
+  }
+}

--- a/app/views/security/_activity.html.erb
+++ b/app/views/security/_activity.html.erb
@@ -1,20 +1,21 @@
-<div class="govuk-summary-list__row">
-  <dt class="govuk-summary-list__key">
+<div class="summary-list">
+  <dt class="summary-list__key">
     <%= t("account.security.event.#{activity.name}") %>
   </dt>
-  <dd class="govuk-summary-list__value">
+  <dd class="summary-list__value">
     <span class="date-text">
       <%= date_with_time_ago(activity.created_at) %>
     </span>
-    <br>
-      <%= activity.client %>
-    <br>
+  </dd>
+  <dd class="summary-list__value">
+    <%= activity.client %>
+  </dd>
+  <dd class="summary-list__value">
     <%= "#{activity.ip_address_country} (#{activity.ip_address})" %>
-    <br>
-     <p class="govuk-body">
-      <a class="govuk-link" href="<%= account_security_report_path %>" data-module="gem-track-click" data-track-category="account-manage" data-track-action="security" data-track-label="not-me">
-        <%= t("account.security.report_suspicious_activity") %>
-      </a>
-    </p>
+  </dd>
+  <dd class="summary-list__value">
+    <a class="govuk-link" href="<%= account_security_report_path %>" data-module="gem-track-click" data-track-category="account-manage" data-track-action="security" data-track-label="not-me">
+      <%= t("account.security.report_suspicious_activity") %>
+    </a>
   </dd>
 </div>

--- a/app/views/security/show.html.erb
+++ b/app/views/security/show.html.erb
@@ -65,7 +65,7 @@
       margin_bottom: 4,
     } %>
 
-    <dl class="govuk-summary-list">
+    <dl>
       <% @activity.each do |activity| %>
         <%= render "activity", activity: activity %>
       <% end %>


### PR DESCRIPTION
## What

Modify the definition list on the security page so that the information formerly contained in a single DD is now split into multiple DDs. Had to write some custom styles to make this happen as the existing DS styles weren't up to being modified in this way.

## Why

An accessibility audit revealed that this information should be broken up in this way.

## Visual changes

No visual changes on desktop, but I've taken the opportunity to add a bit more spacing on mobile to make it more readable.

Before | After
------ | ------
![Screenshot 2021-03-01 at 16 18 44](https://user-images.githubusercontent.com/861310/109527458-94d64a00-7aab-11eb-9f4c-c7979a300f0c.png) | ![Screenshot 2021-03-01 at 16 18 39](https://user-images.githubusercontent.com/861310/109527550-b0d9eb80-7aab-11eb-9cd9-edbdbf44cf26.png)

Update: have addressed the long text issue on desktop highlighted by @danacotoran 

With long text | Without
------ | ------
![Screenshot 2021-03-03 at 13 18 43](https://user-images.githubusercontent.com/861310/109811967-611e3000-7c23-11eb-868c-af2b10fbbcf0.png) | ![Screenshot 2021-03-03 at 13 20 05](https://user-images.githubusercontent.com/861310/109812034-76935a00-7c23-11eb-9ef8-ca153fb00f44.png)





Trello card: https://trello.com/c/lNkwruEi/647-fix-accessibility-issues-raised-by-dac


