### PR TITLE
Update heading levels on Your Information page

### DIFF
--- a/app/views/registrations/your_information.html.erb
+++ b/app/views/registrations/your_information.html.erb
@@ -41,6 +41,7 @@
     id: "cookie_consent",
     heading: t("devise.registrations.your_information.fields.cookie_consent.heading"),
     heading_size: "s",
+    heading_level: 3,
     error_message: error_items("cookie_consent", @error_items),
     hint: t("devise.registrations.your_information.fields.cookie_consent.hint"),
     items: [
@@ -79,6 +80,7 @@
     id: "feedback_consent",
     heading: t("devise.registrations.your_information.fields.feedback_consent.heading"),
     heading_size: "s",
+    heading_level: 3,
     error_message: error_items("feedback_consent", @error_items),
     hint: t("devise.registrations.your_information.fields.feedback_consent.hint"),
     items: [


### PR DESCRIPTION
Update the radio groups' headings to `h3` (previously `h2`) on the "Your information" page.


This fixes an accessibility issue highlighted in the DAC report, wherein the heading structure on the "Your information" consent page is flat, despite hierarchical relationships being present.

<img width="1254" alt="Screenshot 2021-03-01 at 16 20 45" src="https://user-images.githubusercontent.com/7116819/109527790-f4ccf080-7aab-11eb-894e-a42d0dd20e41.png">


------

~Depends on this PR which adds the option to pass a custom heading level to the radio group https://github.com/alphagov/govuk_publishing_components/pull/1951~ MERGED

------

https://trello.com/c/lNkwruEi/647-fix-accessibility-issues-raised-by-dac (this corresponds to **Headings (A) page 21** on the checklist)