### PR TITLE
Move backlink before main

### DIFF
--- a/app/views/delete/show.html.erb
+++ b/app/views/delete/show.html.erb
@@ -4,9 +4,9 @@
   <%= render "account-navigation", page_is: yield(:location) %>
 <% end %>
 
-<%= render "govuk_publishing_components/components/back_link", {
-  href: account_manage_path
-} %>
+<% content_for :before_main do %>
+  <%= render "govuk_publishing_components/components/back_link", { href: account_manage_path } %>
+<% end %>
 
 <%= render "govuk_publishing_components/components/heading", {
   text: yield(:title),

--- a/app/views/edit_consent/cookie.html.erb
+++ b/app/views/edit_consent/cookie.html.erb
@@ -4,7 +4,10 @@
   <%= render "account-navigation", page_is: yield(:location) %>
 <% end %>
 
-<%= render "govuk_publishing_components/components/back_link", { href: account_manage_path } %>
+<% content_for :before_main do %>
+  <%= render "govuk_publishing_components/components/back_link", { href: account_manage_path } %>
+<% end %>
+
 <%= form_with(
   url: edit_user_consent_cookie_url,
   method: :post,

--- a/app/views/edit_consent/feedback.html.erb
+++ b/app/views/edit_consent/feedback.html.erb
@@ -4,7 +4,10 @@
   <%= render "account-navigation", page_is: yield(:location) %>
 <% end %>
 
-<%= render "govuk_publishing_components/components/back_link", { href: account_manage_path } %>
+<% content_for :before_main do %>
+  <%= render "govuk_publishing_components/components/back_link", { href: account_manage_path } %>
+<% end %>
+
 <%= form_with(
   url: edit_user_consent_feedback_url,
   method: :post,

--- a/app/views/edit_phone/confirm.html.erb
+++ b/app/views/edit_phone/confirm.html.erb
@@ -4,7 +4,10 @@
   <%= render "account-navigation", page_is: yield(:location) %>
 <% end %>
 
-<%= render "govuk_publishing_components/components/back_link", { href: edit_user_registration_phone_path } %>
+<% content_for :before_main do %>
+  <%= render "govuk_publishing_components/components/back_link", { href: edit_user_registration_phone_path } %>
+<% end %>
+
 <%= render "govuk_publishing_components/components/heading", {
   text: yield(:title),
   heading_level: 1,

--- a/app/views/edit_phone/resend.html.erb
+++ b/app/views/edit_phone/resend.html.erb
@@ -1,6 +1,8 @@
 <% content_for :title, t("mfa.phone.resend.heading") %>
 
-<%= render "govuk_publishing_components/components/back_link", { href: edit_user_registration_phone_code_path } %>
+<% content_for :before_main do %>
+  <%= render "govuk_publishing_components/components/back_link", { href: edit_user_registration_phone_code_path } %>
+<% end %>
 
 <%= render "govuk_publishing_components/components/heading", {
   text: yield(:title),

--- a/app/views/edit_phone/show.html.erb
+++ b/app/views/edit_phone/show.html.erb
@@ -4,7 +4,10 @@
   <%= render "account-navigation", page_is: yield(:location) %>
 <% end %>
 
-<%= render "govuk_publishing_components/components/back_link", { href: account_manage_path } %>
+<% content_for :before_main do %>
+  <%= render "govuk_publishing_components/components/back_link", { href: account_manage_path } %>
+<% end %>
+
 <%= render "govuk_publishing_components/components/heading", {
   text: yield(:title),
   heading_level: 1,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -78,6 +78,7 @@
         </div>
       <% end %>
       <div class="govuk-grid-column-two-thirds">
+        <%= yield :before_main %>
         <main class="app-main-class" id="main-content" role="main">
           <%= yield %>
         </main>

--- a/app/views/redo_mfa_phone/code.html.erb
+++ b/app/views/redo_mfa_phone/code.html.erb
@@ -1,8 +1,8 @@
 <% content_for :title, t("mfa.phone.code.redo_heading") %>
 
-<%= render "govuk_publishing_components/components/back_link", {
-  href: redo_mfa_stop_path
-} %>
+<% content_for :before_main do %>
+  <%= render "govuk_publishing_components/components/back_link", { href: redo_mfa_stop_path } %>
+<% end %>
 
 <%= render "govuk_publishing_components/components/heading", {
   text: yield(:title),

--- a/app/views/redo_mfa_phone/resend.html.erb
+++ b/app/views/redo_mfa_phone/resend.html.erb
@@ -1,8 +1,7 @@
 <% content_for :title, t("mfa.phone.resend.heading") %>
-
-<%= render "govuk_publishing_components/components/back_link", {
-  href: redo_mfa_phone_code_path
-} %>
+<% content_for :before_main do %>
+  <%= render "govuk_publishing_components/components/back_link", { href: redo_mfa_phone_code_path } %>
+<% end %>
 
 <%= render "govuk_publishing_components/components/heading", {
   text: yield(:title),

--- a/app/views/registrations/edit_email.html.erb
+++ b/app/views/registrations/edit_email.html.erb
@@ -3,8 +3,10 @@
 <% content_for :account_navigation do %>
   <%= render "account-navigation", page_is: yield(:location) %>
 <% end %>
+<% content_for :before_main do %>
+  <%= render "govuk_publishing_components/components/back_link", { href: account_manage_path } %>
+<% end %>
 
-<%= render "govuk_publishing_components/components/back_link", { href: account_manage_path } %>
 <%= render "govuk_publishing_components/components/heading", {
   text: yield(:title),
   heading_level: 1,

--- a/app/views/registrations/edit_password.html.erb
+++ b/app/views/registrations/edit_password.html.erb
@@ -3,8 +3,10 @@
 <% content_for :account_navigation do %>
   <%= render "account-navigation", page_is: yield(:location) %>
 <% end %>
+<% content_for :before_main do %>
+  <%= render "govuk_publishing_components/components/back_link", { href: account_manage_path } %>
+<% end %>
 
-<%= render "govuk_publishing_components/components/back_link", { href: account_manage_path } %>
 <%= render "govuk_publishing_components/components/heading", {
   text: yield(:title),
   heading_level: 1,

--- a/app/views/registrations/phone_resend.html.erb
+++ b/app/views/registrations/phone_resend.html.erb
@@ -1,8 +1,7 @@
 <% content_for :title, t("mfa.phone.resend.heading") %>
-
-<%= render "govuk_publishing_components/components/back_link", {
-  href: new_user_registration_phone_code_path
-} %>
+<% content_for :before_main do %>
+  <%= render "govuk_publishing_components/components/back_link", { href: new_user_registration_phone_code_path } %>
+<% end %>
 
 <%= render "govuk_publishing_components/components/heading", {
   text: t("mfa.phone.resend.heading"),

--- a/app/views/security/report.html.erb
+++ b/app/views/security/report.html.erb
@@ -3,9 +3,9 @@
 <% content_for :account_navigation do %>
   <%= render "account-navigation", page_is: yield(:location) %>
 <% end %>
-<%= render "govuk_publishing_components/components/back_link", {
-  href: account_security_path
-} %>
+<% content_for :before_main do %>
+  <%= render "govuk_publishing_components/components/back_link", { href: account_security_path } %>
+<% end %>
 
 <%= render "govuk_publishing_components/components/heading", {
   text: yield(:title),

--- a/app/views/sessions/phone_resend.html.erb
+++ b/app/views/sessions/phone_resend.html.erb
@@ -1,8 +1,7 @@
 <% content_for :title, t("mfa.phone.resend.heading") %>
-
-<%= render "govuk_publishing_components/components/back_link", {
-  href: user_session_phone_code_path
-} %>
+<% content_for :before_main do %>
+  <%= render "govuk_publishing_components/components/back_link", { href: user_session_phone_code_path } %>
+<% end %>
 
 <%= render "govuk_publishing_components/components/heading", {
   text: yield(:title),


### PR DESCRIPTION
One of the issues highlighted in the DAC report for Accounts was that screen reader users reported confusion in encountering the back link in the `main` content landmark.
The `main` landmark should not contain navigation elements such as the back link. 

This moves the back link to just before the `main`. 
The reason I named the content block `before_main` instead of something more obviously connected to the back link, is in case there's a need to have other things before the main element in the future (breadcrumbs? other navigation-y stuff?). 

No visual change should occur as a result of this adjustment.

----
[Relevant Trello card](https://trello.com/c/lNkwruEi/647-fix-accessibility-issues-raised-by-dac) – these changes would resolve the **GOV.UK Back Link in Main Landmark (Usability)** issue from the checklist