### PR TITLE
Add hidden text to "See your results" link

### DIFF
--- a/app/views/account/show.html.erb
+++ b/app/views/account/show.html.erb
@@ -40,7 +40,7 @@
 
     <p class="govuk-body govuk-!-margin-0">
       <a href="<%= transition_checker_path %>/saved-results" class="govuk-link" data-module="gem-track-click" data-track-category="account-manage" data-track-action="your-account" data-track-label="see-results">
-        <%= t("account.your_account.transition.link1") %>
+        <%= sanitize(t("account.your_account.transition.link1")) %>
       </a>
     </p>
     <p class="govuk-body"><%= t("account.your_account.transition.link1_description") %></p>

--- a/config/locales/account/your_account.en.yml
+++ b/config/locales/account/your_account.en.yml
@@ -11,7 +11,7 @@ en:
       transition:
         description: A personalised list of Brexit actions for you, your family and your business.
         heading: 'Brexit checker results: what you need to do'
-        link1: See your results
+        link1: See your <span class="govuk-visually-hidden">Brexit checker</span> results
         link1_description: Go back to the Brexit checker results you’ve saved.
         link2: Update your results and email alerts
         link2_description: Answer the Brexit checker questions again to update your results.


### PR DESCRIPTION
The DAC report has highlighted that screen reader users have trouble understanding what the "See your results" link on the account manager homepage refers to.

The purpose of the link must be determinable without any additional context – this is because screen reader users use navigating "out of context", filtering the page by element type.

This adds hidden text to the link, which ensures that it will read the same for sighted users, while at the same time providing some much needed context for assistive tech users who are jumping from link to link.

-----

[Relevant Trello card](https://trello.com/c/lNkwruEi/647-fix-accessibility-issues-raised-by-dac) – this change should resolve the **Link only purpose** issue from the checklist