### PR TITLE
Temporarily remove jasmine:ci from rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,4 +7,4 @@ require_relative "config/application"
 
 Rails.application.load_tasks
 
-task default: %i[spec lint jasmine:ci]
+task default: %i[spec lint]


### PR DESCRIPTION
Our jasmine suite is falling over on concourse due to a Google Chrome
update causing selenium to time out.

Since the jasmine spec currently only consist of a couple analytics
tests, this was suggested as a a relatively low risk interim
workaround that will help unblock our concourse pipeline before we can
implement a more permanent solution.

https://trello.com/c/icPgTrRp/660-investigate-concourse-pipeline-failure