### PR TITLE
Fix Google Chrome file name

### DIFF
--- a/concourse/Dockerfile
+++ b/concourse/Dockerfile
@@ -10,8 +10,8 @@ RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources
     && apt install -y yarn
 
 RUN wget https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_88.0.4324.182-1_amd64.deb \
-    && apt-get install -y --no-install-recommends ./google-chrome-stable/google-chrome-stable_88.0.4324.182-1_amd64.deb \
-    && rm ./google-chrome-stable/google-chrome-stable_88.0.4324.182-1_amd64.deb
+    && apt-get install -y --no-install-recommends ./google-chrome-stable_88.0.4324.182-1_amd64.deb \
+    && rm ./google-chrome-stable_88.0.4324.182-1_amd64.deb
 
 # Enable no-sandbox for chrome so that it can run as a root user
 ENV GOVUK_TEST_CHROME_NO_SANDBOX 1


### PR DESCRIPTION
The filename is `google-chrome-stable_88.0.4324.182-1_amd64.deb` and not
`google-chrome-stable/google-chrome-stable_88.0.4324.182-1_amd64.deb`.
This is a rebase copy-paste leftover of the previous PR to fix our
Concourse pipeline: https://github.com/alphagov/govuk-account-manager-prototype/pull/728