### PR TITLE
Fix feedback form showing an email error for the name field

### DIFF
--- a/app/helpers/error_items_helper.rb
+++ b/app/helpers/error_items_helper.rb
@@ -1,11 +1,9 @@
 module ErrorItemsHelper
   def error_items(field, error_items)
-    if error_items && error_items.select { |item| item[:field] == field }.any?
-      sanitize(error_items
-        .select { |key| key.to_s.match(field) }
-        .map { |error| error[:text] }.uniq
-        .join("<br>"))
-    end
+    errors_for_field = (error_items || []).filter_map { |item| item[:text] if item[:field] == field }.uniq
+    return unless errors_for_field.any?
+
+    sanitize(errors_for_field.join("<br>"))
   end
 
   def devise_error_items(field, resource_error_messages = nil)

--- a/spec/helpers/error_items_helper_spec.rb
+++ b/spec/helpers/error_items_helper_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe ErrorItemsHelper do
+  describe "#error_items" do
+    it "extracts only the errors relevant to the field" do
+      errors = [
+        {
+          field: "name",
+          text: "Enter your name.",
+        },
+        {
+          field: "email",
+          text: "This does not look like a valid email address.",
+        },
+      ]
+      expect(error_items("name", errors)).to eq("Enter your name.")
+      expect(error_items("email", errors)).to eq("This does not look like a valid email address.")
+    end
+
+    it "merges multiple errors for the desired field" do
+      errors = [
+        {
+          field: "email",
+          text: "This does not look like a valid email address.",
+        },
+        {
+          field: "email",
+          text: "Enter an email address in this format: name@example.com.",
+        },
+      ]
+      expect(error_items("email", errors)).to eq("This does not look like a valid email address.<br>Enter an email address in this format: name@example.com.")
+    end
+  end
+end


### PR DESCRIPTION
<img width="739" alt="Screenshot 2021-03-08 at 11 01 48" src="https://user-images.githubusercontent.com/75235/110312978-b7adb480-7ffd-11eb-96c0-e97258a4aac0.png">

---

The error_items helper takes input of the form

    [{ field: "name", text: "message" }, { field: "name", ...

So to extract the errors for a specific field we have to filter on the
`field` value.  And the conditional does that.

But we weren't doing that when constructing the error string, we were
filtering on the whole hash converted to a string, and since the error
message contained the word "name", it was being returned for the
"name" field.

---

[Trello card](https://trello.com/c/lNkwruEi/647-fix-accessibility-issues-raised-by-dac)