### PR TITLE
Fix incorrect variable name

### DIFF
--- a/app/jobs/bigquery_report_export_job.rb
+++ b/app/jobs/bigquery_report_export_job.rb
@@ -45,7 +45,7 @@ protected
   def delete_job(dataset, table_name)
     delete_job = dataset.query_job "DELETE FROM #{table_name} WHERE 1 = 1"
     delete_job.wait_until_done!
-    raise DeleteError, delete_error.error.dig("message") if delete_job.failed?
+    raise DeleteError, delete_job.error.dig("message") if delete_job.failed?
   end
 
   def insert_job(dataset, table_name, rows)


### PR DESCRIPTION
This only causes a problem if the job fails, but it obscures the real
error.

---

[Sentry error](https://sentry.io/organizations/govuk/issues/2262547832/?project=5370953&query=is%3Aunresolved&statsPeriod=14d)