### PR TITLE
Make cookies/feedback section more accessible

### DIFF
--- a/app/assets/stylesheets/accounts.scss
+++ b/app/assets/stylesheets/accounts.scss
@@ -43,16 +43,6 @@ $_current-indicator-width: 4px;
   }
 }
 
-.accounts-menu__link-description {
-  @include govuk-font(16);
-  display: block;
-  margin-top: govuk-spacing(1);
-
-  @include govuk-media-query($until: tablet) {
-    @include govuk-visually-hidden;
-  }
-}
-
 .accounts-panel {
   padding: govuk-spacing(6);
   border: solid 1px govuk-colour("mid-grey");

--- a/app/assets/stylesheets/accounts.scss
+++ b/app/assets/stylesheets/accounts.scss
@@ -100,32 +100,6 @@ $_current-indicator-width: 4px;
     }
   }
 
-  .accounts-summary-list__key-heading {
-    @include govuk-font(19, $weight: "bold");
-    margin-bottom: govuk-spacing(1);
-  }
-
-  .accounts-summary-list__key-description {
-    @include govuk-font(16);
-    margin: 0;
-  }
-
-  &.accounts-summary-list--wide {
-    @include govuk-media-query($from: "tablet") {
-      .govuk-summary-list__key {
-        width: 70%;
-      }
-
-      .govuk-summary-list__value {
-        width: 15%;
-      }
-
-      .govuk-summary-list__actions {
-        width: 15%;
-      }
-    }
-  }
-
   &.accounts-summary-list--paginated {
     margin-bottom: 0;
 

--- a/app/views/application/_account-navigation.html.erb
+++ b/app/views/application/_account-navigation.html.erb
@@ -9,7 +9,6 @@
         class: 'accounts-menu__link govuk-link govuk-link--no-visited-state',
         'aria-current': page_is == "your-account" ? "page" : nil,
       ) %>
-      <span class="accounts-menu__link-description"><%= t("navigation.menu_bar.account.description") %></span>
     </li>
     <li class="accounts-menu__item <%= "accounts-menu__item--current" if page_is == "manage" %>">
       <%= link_to(
@@ -18,7 +17,6 @@
         class: 'accounts-menu__link govuk-link govuk-link--no-visited-state',
         'aria-current': page_is == "manage" ? "page" : nil,
       ) %>
-      <span class="accounts-menu__link-description"><%= t("navigation.menu_bar.manage.description") %></span>
     </li>
     <li class="accounts-menu__item <%= "accounts-menu__item--current" if page_is == "security" %>">
       <%= link_to(
@@ -27,7 +25,6 @@
         class: 'accounts-menu__link govuk-link govuk-link--no-visited-state',
         'aria-current': page_is == "security" ? "page" : nil,
       ) %>
-      <span class="accounts-menu__link-description"><%= t("navigation.menu_bar.security.description") %></span>
     </li>
   </ul>
 </nav>

--- a/app/views/edit_consent/cookie.html.erb
+++ b/app/views/edit_consent/cookie.html.erb
@@ -19,7 +19,7 @@
 
   <%= render "govuk_publishing_components/components/radio", {
     name: "cookie_consent",
-    heading: t('account.manage.privacy.cookies_question'),
+    heading: t('account.manage.cookies.cookies_question'),
     heading_size: "l",
     is_page_heading: true,
     items: [

--- a/app/views/edit_consent/cookie.html.erb
+++ b/app/views/edit_consent/cookie.html.erb
@@ -17,11 +17,17 @@
   }
 ) do %>
 
+  <% description = capture do %>
+    <p class="govuk-body"><%= t('account.manage.change_cookies.description') %></p>
+    <p class="govuk-body"><%= t('account.manage.change_cookies.question') %></p>
+  <% end %>
+
   <%= render "govuk_publishing_components/components/radio", {
     name: "cookie_consent",
-    heading: t('account.manage.cookies.cookies_question'),
+    heading: t('account.manage.change_cookies.title'),
     heading_size: "l",
     is_page_heading: true,
+    description: description,
     items: [
       {
         value: "yes",

--- a/app/views/edit_consent/feedback.html.erb
+++ b/app/views/edit_consent/feedback.html.erb
@@ -17,11 +17,17 @@
   }
 ) do %>
 
+  <% description = capture do %>
+    <p class="govuk-body"><%= t('account.manage.change_feedback.description') %></p>
+    <p class="govuk-body"><%= t('account.manage.change_feedback.question') %></p>
+  <% end %>
+
   <%= render "govuk_publishing_components/components/radio", {
     name: "feedback_consent",
-    heading: t("devise.registrations.your_information.fields.feedback_consent.heading"),
+    heading: t("account.manage.change_feedback.title"),
     heading_size: "l",
     is_page_heading: true,
+    description: description,
     items: [
       {
         value: "yes",

--- a/app/views/manage/show.html.erb
+++ b/app/views/manage/show.html.erb
@@ -30,58 +30,75 @@
 </div>
 
 <%= render "govuk_publishing_components/components/heading", {
-  text: t("account.manage.privacy.heading"),
+  text: t("account.manage.cookies.title"),
   heading_level: 2,
   font_size: "m",
   margin_bottom: 4,
 } %>
 
-<div class="accounts-summary-list accounts-summary-list--wide">
-  <dl class="govuk-summary-list">
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        <p class="govuk-body accounts-summary-list__key-heading"><%= t("account.manage.privacy.cookies_question") %></p>
-        <p class="govuk-body accounts-summary-list__key-description"><%= t("account.manage.privacy.cookies_description") %></p>
-      </dt>
-      <dd class="govuk-summary-list__value">
-        <%= current_user.cookie_consent == true ? t("general.yes") : t("general.no") %>
-      </dd>
-      <dd class="govuk-summary-list__actions">
-        <a href="<%= edit_user_consent_cookie_path %>"
-          class="govuk-link"
-          title="<%= t("general.change") %> <%= t("account.manage.privacy.cookies_link_extra") %>"
-          data-module = "gem-track-click"
-          data-track-category = "account-manage"
-          data-track-action = "manage-account"
-          data-track-label = "personal-information-cookies">
-          <%= t("general.change") %>
-          <span class="govuk-visually-hidden"><%= t("account.manage.privacy.cookies_link_extra") %></span>
-        </a>
-      </dd>
-    </div>
+<p class="govuk-body"><%= t("account.manage.cookies.description") %></p>
 
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        <p class="govuk-body accounts-summary-list__key-heading"><%= t("account.manage.privacy.email_question") %></p>
-        <p class="govuk-body accounts-summary-list__key-description"><%= t("account.manage.privacy.email_description") %></p>
-      </dt>
-      <dd class="govuk-summary-list__value">
-        <%= current_user.feedback_consent == true ? t("general.yes") : t("general.no") %>
-      </dd>
-      <dd class="govuk-summary-list__actions">
-        <a href="<%= edit_user_consent_feedback_path %>"
-          class="govuk-link"
-          title="<%= t("general.change") %> <%= t("account.manage.privacy.email_link_extra") %>"
-          data-module = "gem-track-click"
-          data-track-category = "account-manage"
-          data-track-action = "manage-account"
-          data-track-label = "personal-information-feedback">
-          <%= t("general.change") %>
-          <span class="govuk-visually-hidden"><%= t("account.manage.privacy.email_link_extra") %></span>
-        </a>
-      </dd>
-    </div>
-  </dl>
+<% cookie_link_text = capture do %>
+  <%= t("general.change") %> <span class="govuk-visually-hidden"><%= t("account.manage.cookies.link_extra") %></span>
+<% end %>
+
+<div class="accounts-summary-list">
+  <%= render "govuk_publishing_components/components/summary_list", {
+    wide_title: true,
+    items: [
+      {
+        field: t("account.manage.cookies.label"),
+        value: current_user.cookie_consent == true ? t("general.yes") : t("general.no"),
+        edit: {
+          href: edit_user_consent_cookie_path,
+          link_text: cookie_link_text,
+          link_text_no_enhance: true,
+          data_attributes: {
+            module: "gem-track-click",
+            track_category: "account-manage",
+            track_action: "manage-account",
+            track_label: "personal-information-cookies",
+          }
+        }
+      },
+    ]
+  } %>
+</div>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("account.manage.feedback.title"),
+  heading_level: 2,
+  font_size: "m",
+  margin_bottom: 4,
+} %>
+
+<p class="govuk-body"><%= t("account.manage.feedback.description") %></p>
+
+<% feedback_link_text = capture do %>
+  <%= t("general.change") %> <span class="govuk-visually-hidden"><%= t("account.manage.feedback.link_extra") %></span>
+<% end %>
+
+<div class="accounts-summary-list">
+  <%= render "govuk_publishing_components/components/summary_list", {
+    wide_title: true,
+    items: [
+      {
+        field: t("account.manage.feedback.label"),
+        value: current_user.feedback_consent == true ? t("general.yes") : t("general.no"),
+        edit: {
+          href: edit_user_consent_feedback_path,
+          link_text: feedback_link_text,
+          link_text_no_enhance: true,
+          data_attributes: {
+            module: "gem-track-click",
+            track_category: "account-manage",
+            track_action: "manage-account",
+            track_label: "personal-information-feedback",
+          }
+        }
+      },
+    ]
+  } %>
 </div>
 
 <%= render "govuk_publishing_components/components/heading", {

--- a/config/locales/account/account_menu.en.yml
+++ b/config/locales/account/account_menu.en.yml
@@ -4,12 +4,9 @@ en:
     destroy_user_session: Sign out
     menu_bar:
       account:
-        description: See services you’ve used
         link_text: Your account
       manage:
-        description: Make changes to your account details and privacy settings
         link_text: Manage your account
       security:
-        description: See sign-in attempts and how information about you is used.
-        link_text: Security
+        link_text: Security and privacy
     user_root_path: Account

--- a/config/locales/account/manage.en.yml
+++ b/config/locales/account/manage.en.yml
@@ -2,8 +2,15 @@
 en:
   account:
     manage:
+      change_cookies:
+        description: We’d like to use cookies to collect anonymised analytics about how you use GOV.UK while you’re signed in to your GOV.UK account, for example what pages you visit and what you click on.
+        question: Can we use cookies to learn about how you use GOV.UK while you’re signed in to your account?
+        title: Change your cookie settings
+      change_feedback:
+        description: As we add more features to your GOV.UK account, we would like to email you to find out any thoughts or suggestions you might have.
+        question: Can we email you to ask for feedback about your account?
+        title: Change your feedback settings
       cookies:
-        cookies_question: Can your account use cookies to learn about how you use GOV.UK?
         description: We use cookies to learn about how you use GOV.UK while you’re signed in to your account, for example what pages you visit and what you click on.
         label: GOV.UK can use cookies while you’re signed in
         link_extra: your cookie settings

--- a/config/locales/account/manage.en.yml
+++ b/config/locales/account/manage.en.yml
@@ -2,6 +2,12 @@
 en:
   account:
     manage:
+      cookies:
+        cookies_question: Can your account use cookies to learn about how you use GOV.UK?
+        description: We use cookies to learn about how you use GOV.UK while you’re signed in to your account, for example what pages you visit and what you click on.
+        label: GOV.UK can use cookies while you’re signed in
+        link_extra: your cookie settings
+        title: Cookie settings
       delete:
         description: You can permanently delete this account and all the information stored in it.
         heading: Delete your account
@@ -9,18 +15,16 @@ en:
       details:
         heading: Account details
         unconfirmed: unconfirmed
+      feedback:
+        description: We’d like to email you to ask for your thoughts as we add more features to your account.
+        label: GOV.UK can send you feedback emails
+        link_extra: your feedback settings
+        title: Feedback settings
       heading: Manage your account
       page_title: Manage your GOV.UK account
       privacy:
-        cookies_description: For example what pages you visit and what you click on
-        cookies_link_extra: your cookie settings
-        cookies_question: Can your account use cookies to learn about how you use GOV.UK?
         cookies_success: Your cookie settings have been changed
-        email_description: For example when new features are added to your account
-        email_link_extra: your feedback settings
-        email_question: Can GOV.UK email you to ask for feedback about your account?
         email_success: Your feedback settings have been changed
-        heading: Privacy settings
   devise:
     registrations:
       edit:


### PR DESCRIPTION
## What

Accessibility fixes.

- Restructure the manage account page sections for cookies and feedback
- Reword the actual screens for changing cookies and feedback preferences
- Update the accounts menu to remove the descriptive text.

## Why

The DAC audit raised an issue with the layout of the information in the DL element (DAC_Content_Structure_02), which couldn't easily be resolved using the existing layout. It also raised DAC_Reflow_01 relating to text appearing on desktop but not mobile.

## Visual changes

Privacy settings

Before | After
------ | ------
![Screenshot 2021-03-10 at 13 32 18](https://user-images.githubusercontent.com/861310/110637239-15c8cc00-81a5-11eb-9d85-3d437e86bb07.png) | ![Screenshot 2021-03-16 at 15 16 55](https://user-images.githubusercontent.com/861310/111333607-c1bd5c00-866a-11eb-97ad-3cdff0cfc1d0.png)

Change screens

Before | After
------ | ------
![Screenshot 2021-03-16 at 15 43 46](https://user-images.githubusercontent.com/861310/111338779-1cf14d80-866f-11eb-8376-0e378e92804e.png) | ![Screenshot 2021-03-16 at 15 42 47](https://user-images.githubusercontent.com/861310/111338805-24185b80-866f-11eb-8153-ebb93a284d32.png)
![Screenshot 2021-03-16 at 15 43 54](https://user-images.githubusercontent.com/861310/111338834-2bd80000-866f-11eb-8338-f63b5ebb263d.png) | ![Screenshot 2021-03-16 at 15 47 37](https://user-images.githubusercontent.com/861310/111338865-31cde100-866f-11eb-9cc2-0d954cabe7e1.png)

Accounts navigation menu

Before | After
------ | ------
![Screenshot 2021-03-16 at 15 12 04](https://user-images.githubusercontent.com/861310/111333723-d863b300-866a-11eb-91e6-f6c1cd9578aa.png) | ![Screenshot 2021-03-16 at 15 12 30](https://user-images.githubusercontent.com/861310/111333785-e4e80b80-866a-11eb-8031-9d0d3f67e2ae.png)



Trello card: https://trello.com/c/lNkwruEi/647-fix-accessibility-issues-raised-by-dac