### PR TITLE
Page title improvement based on DAC guidance

### DIFF
--- a/app/helpers/error_items_helper.rb
+++ b/app/helpers/error_items_helper.rb
@@ -10,6 +10,7 @@ module ErrorItemsHelper
     raw_errors = resource ? resource.errors.messages : resource_error_messages
     return nil unless raw_errors
 
+    content_for :title_prefix, t("errors.error") unless content_for?(:title_prefix)
     all_errors = raw_errors.compact.map do |id, errors|
       errors.map do |error|
         { field: id, error: error }

--- a/app/helpers/error_items_helper.rb
+++ b/app/helpers/error_items_helper.rb
@@ -3,6 +3,7 @@ module ErrorItemsHelper
     errors_for_field = (error_items || []).filter_map { |item| item[:text] if item[:field] == field }.uniq
     return unless errors_for_field.any?
 
+    content_for :title_prefix, t("errors.error") unless content_for?(:title_prefix)
     sanitize(errors_for_field.join("<br>"))
   end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,3 +1,9 @@
+<%
+  title = ""
+  title << "#{yield(:title_prefix)}: " if content_for?(:title_prefix)
+  title << "#{yield(:title)} - " if content_for?(:title)
+  title << "GOV.UK Account"
+-%>
 <!DOCTYPE html>
 <html lang="en" class="govuk-template">
 
@@ -5,7 +11,7 @@
   <meta charset="utf-8">
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>
-  <title><%= content_for?(:title) ? "#{yield(:title)} - GOV.UK Account" : "GOV.UK Account" %></title>
+  <title><%= title %></title>
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="theme-color" content="blue">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/config/locales/account/login.en.yml
+++ b/config/locales/account/login.en.yml
@@ -38,6 +38,7 @@ en:
       send_paranoid_instructions: If your account exists, you will receive an email with instructions for how to unlock it in a few minutes.
       unlocked: Your account has been unlocked successfully. Please sign in to continue.
   errors:
+    error: Error
     messages:
       headline: There is a problem
       not_found: This email address does not have a GOV.UK account. Try entering the email address for your account again.

--- a/spec/helpers/error_items_helper_spec.rb
+++ b/spec/helpers/error_items_helper_spec.rb
@@ -28,5 +28,22 @@ RSpec.describe ErrorItemsHelper do
       ]
       expect(error_items("email", errors)).to eq("This does not look like a valid email address.<br>Enter an email address in this format: name@example.com.")
     end
+
+    it "adds 'Error' to the page title when there has been an error" do
+      errors = [
+        {
+          field: "email",
+          text: "This does not look like a valid email address.",
+        },
+      ]
+      error_items("email", errors)
+      expect(content_for(:title_prefix)).to eq("Error")
+    end
+
+    it "Does not change the page title if there has not been an error" do
+      errors = nil
+      error_items("email", errors)
+      expect(content_for?(:title_prefix)).to eq(false)
+    end
   end
 end


### PR DESCRIPTION
Prefix page title with "Error:" when an error has occurred as per recommendations from DAC (page 39 of the report – **Issue ID: DAC_Validation_Pattern_01**).

It was highlighted that the word "error" not being included in the page title could make it more challenging for screen reader users to efficiently identify and correct errors.
The Design System also recommends adding "Error" to the beginning of the page title so that screen readers read it out asap:
https://design-system.service.gov.uk/patterns/validation/#how-to-tell-the-user-about-validation-errors

Before: page title does not indicate there has been an error | After: page title is prefixed with "error" which makes it clear an issue has occurred
------------ | -------------
<img width="1167" alt="Screenshot 2021-03-10 at 15 40 29" src="https://user-images.githubusercontent.com/7116819/110662027-081f4080-81bd-11eb-8c08-a88cbf3e62d9.png">  | <img width="1169" alt="Screenshot 2021-03-10 at 15 39 28" src="https://user-images.githubusercontent.com/7116819/110662013-05245000-81bd-11eb-906e-5f90b41a8469.png">



-----
https://trello.com/c/lNkwruEi/647-fix-accessibility-issues-raised-by-dac