### PR TITLE
Add type="tel" to telephone input fields

### DIFF
--- a/app/views/registrations/phone_resend.html.erb
+++ b/app/views/registrations/phone_resend.html.erb
@@ -24,6 +24,7 @@
       error_message: @phone_error_message,
       width: 10,
       autocomplete: "tel",
+      type: "tel",
     } %>
   <% end %>
 

--- a/app/views/registrations/start.html.erb
+++ b/app/views/registrations/start.html.erb
@@ -51,6 +51,7 @@
     width: 10,
     error_message: devise_error_items(:phone),
     autocomplete: "tel",
+    type: "tel",
   } %>
 
   <%= render "govuk_publishing_components/components/button", {


### PR DESCRIPTION
It was highlighted on our accessibility audit that the virtual keyboard which appeared for number fields on mobile did not correspond with the required input characters.

The virtual keyboard used for numerical/phone input should be the numerical one. It would seem that our phone input fields did not have a type attribute set, and would therefore default to using `type="text"`.
This is why the alphabetical keyboard would appear, rather than the correct numerical one.

This adds `type="tel"` to phone input fields, which will ensure that the correct keyboard is displayed on mobile browsers.

Before | After
------------ | -------------
<img width="423" alt="Screenshot 2021-03-10 at 17 23 35" src="https://user-images.githubusercontent.com/7116819/110670938-d8c10180-81c5-11eb-83fa-7232d0e07dc2.png"> | <img width="412" alt="Screenshot 2021-03-10 at 16 53 38" src="https://user-images.githubusercontent.com/7116819/110670932-d5c61100-81c5-11eb-9083-234f09a5ab17.png">





------
https://trello.com/c/lNkwruEi/647-fix-accessibility-issues-raised-by-dac