### PR TITLE
Add summary error messages on views missing them

### DIFF
--- a/app/controllers/edit_phone_controller.rb
+++ b/app/controllers/edit_phone_controller.rb
@@ -8,8 +8,10 @@ class EditPhoneController < ApplicationController
   def show; end
 
   def confirm
+    @error_messages = {}
     unless current_user.valid_password? params[:current_password]
       @password_error_message = I18n.t("activerecord.errors.models.user.attributes.password.#{params[:current_password].blank? ? 'blank' : 'invalid'}")
+      @error_messages[:current_password] = [@password_error_message]
     end
 
     if params[:phone]
@@ -25,6 +27,7 @@ class EditPhoneController < ApplicationController
     else
       @phone_error_message = I18n.t("activerecord.errors.models.user.attributes.phone.blank")
     end
+    @error_messages[:phone] = [@phone_error_message]
 
     if @password_error_message || @phone_error_message
       render :show

--- a/app/views/_shared/_error_messages.html.erb
+++ b/app/views/_shared/_error_messages.html.erb
@@ -1,4 +1,5 @@
 <%
+resource ||= nil
 raw_errors = resource ? resource.errors.messages : resource_error_messages
 resource_errors = raw_errors.map { |field, errors| errors.map { |error| { field: field, error: error } } }.flatten.select { |error| error[:error].present? }
 %>

--- a/app/views/edit_phone/show.html.erb
+++ b/app/views/edit_phone/show.html.erb
@@ -15,6 +15,8 @@
   margin_bottom: 6,
 } %>
 
+<%= render "_shared/error_messages", resource_error_messages: @error_messages if @error_messages %>
+
 <p class="govuk-body">
   <%= sanitize(t("mfa.phone.update.start.current", phone_number: MultiFactorAuth.formatted_phone_number(current_user.phone))) %>
 </p>
@@ -22,6 +24,7 @@
 <%= form_with(url: edit_user_registration_phone_confirm_path, method: :post) do %>
   <%= render "govuk_publishing_components/components/input", {
     label: { text: t("mfa.phone.update.start.fields.phone.label") },
+    id: "phone",
     name: "phone",
     type: "tel",
     error_message: @phone_error_message,
@@ -38,6 +41,7 @@
     heading_size: "m",
     hint: t("devise.registrations.edit.fields.current_password.hint"),
     name: "current_password",
+    id: "current_password",
     error_message: @password_error_message,
     autocomplete: "current-password",
   } %>

--- a/app/views/redo_mfa_phone/code.html.erb
+++ b/app/views/redo_mfa_phone/code.html.erb
@@ -4,6 +4,8 @@
   <%= render "govuk_publishing_components/components/back_link", { href: redo_mfa_stop_path } %>
 <% end %>
 
+<%= render "_shared/error_messages", resource_error_messages: { phone_code: [ sanitize(@phone_code_error_message) ]} if @phone_code_error_message %>
+
 <%= render "govuk_publishing_components/components/heading", {
   text: yield(:title),
   heading_level: 1,
@@ -20,6 +22,7 @@
 <%= form_with url: redo_mfa_phone_verify_path, method: :post, html: { autocomplete: "off" } do %>
   <%= render "govuk_publishing_components/components/input", {
     label: { text: t("mfa.phone.code.fields.phone_code.label") },
+    id: "phone_code",
     name: "phone_code",
     maxlength: 5,
     type: "number",

--- a/app/views/registrations/phone_code.html.erb
+++ b/app/views/registrations/phone_code.html.erb
@@ -7,6 +7,12 @@
   margin_bottom: 3,
 } %>
 
+<%= render "_shared/error_messages",
+  resource_error_messages: {
+    phone_code: [
+    sanitize(@phone_code_error_message),
+  ]} if @phone_code_error_message %>
+
 <% t("mfa.phone.code.description_with_phone_number", phone_number: MultiFactorAuth.formatted_phone_number(@registration_state.phone)).each do |msg| %>
   <p class="govuk-body"><%= sanitize(msg) %></p>
 <% end %>
@@ -14,6 +20,7 @@
 <%= form_with(url: new_user_registration_phone_verify_path, method: :post, html: { autocomplete: "off" }) do %>
   <%= render "govuk_publishing_components/components/input", {
     label: { text: t("mfa.phone.code.fields.phone_code.label") },
+    id: "phone_code",
     name: "phone_code",
     maxlength: 5,
     type: "number",

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -13,6 +13,8 @@
 <%= form_with url: new_user_session_path, html: { "data-module" => "explicit-cross-domain-links" } do %>
   <% if resource %>
     <%= render "_shared/error_messages", resource: resource %>
+  <% elsif @resource_error_messages %>
+    <%= render "_shared/error_messages", resource_error_messages: @resource_error_messages %>
   <% end %>
 
   <% if flash[:notice] %>

--- a/app/views/sessions/phone_code.html.erb
+++ b/app/views/sessions/phone_code.html.erb
@@ -7,6 +7,8 @@
   margin_bottom: 3,
 } %>
 
+<%= render "_shared/error_messages", resource_error_messages: { phone_code: [ sanitize(@phone_code_error_message) ]} if @phone_code_error_message %>
+
 <% t("mfa.phone.code.description").each do |msg| %>
   <p class="govuk-body"><%= msg %></p>
 <% end %>
@@ -17,6 +19,7 @@
   <%= render "govuk_publishing_components/components/input", {
     label: { text: t("mfa.phone.code.fields.phone_code.label") },
     name: "phone_code",
+    id: "phone_code",
     maxlength: 5,
     type: "number",
     error_message: sanitize(@phone_code_error_message),


### PR DESCRIPTION
It was flagged as part of our DAC report that some pages on Accounts are
not using the validation error pattern suggested in the Design System:
https://design-system.service.gov.uk/patterns/validation/

Based on the DS recommendation, if the user's answers fail validation we
should show the error summary at the top of the page, and move keyboard
focus to it. Some of the pages that seemed to be missing this validation
pattern were the Sign in page, MFA code page, Edit phone page.

The purpose of this change is for accessibility and usability purposes –
all users should immediately be aware that a validation error has occurred,
and should be able to navigate to the error fairly easily.

Before: no error summary when an error happens | After: has error summary when there's been an error
------------ | -------------
<img width="699" alt="Screenshot 2021-03-17 at 17 08 47" src="https://user-images.githubusercontent.com/7116819/111649021-e1d05500-87fb-11eb-9e46-f4290bcda7e2.png"> | <img width="641" alt="Screenshot 2021-03-17 at 16 55 55" src="https://user-images.githubusercontent.com/7116819/111649009-df6dfb00-87fb-11eb-858e-049a776739d7.png">


https://trello.com/c/lNkwruEi/647-fix-accessibility-issues-raised-by-dac