### PR TITLE
Remove rubocop renamed variable _args

### DIFF
--- a/lib/tasks/emails.rake
+++ b/lib/tasks/emails.rake
@@ -6,7 +6,7 @@ namespace :emails do
   end
 
   desc "send test email"
-  task :test_email, %i[email] => [:environment] do |_, _args|
+  task :test_email, %i[email] => [:environment] do |_, args|
     abort("Please provide an email") if args.email.nil?
 
     UserMailer.with(


### PR DESCRIPTION
Looks like an earlier rubocop pass had updated these `args` to `_args`
before I was using them properly.

These are a test and reporting rake task, so it's good to fix them but
they are non critical.

Follow on from this PR:
https://github.com/alphagov/govuk-account-manager-prototype/pull/763