### PR TITLE
Add a final safeguard to ensure we don't double send email

### DIFF
--- a/lib/tasks/emails.rake
+++ b/lib/tasks/emails.rake
@@ -82,7 +82,7 @@ def default_email_body
   The GOV.UK Account team would like to know what you think about your account.
 
   Please fill in this short feedback survey:
-  https://surveys.publishing.service.gov.uk/s/account-feedback1/
+  https://surveys.publishing.service.gov.uk/s/account-feedback2/
 
   It’s 5 questions long and should only take around 5 minutes to complete.
 

--- a/spec/lib/tasks/emails_spec.rb
+++ b/spec/lib/tasks/emails_spec.rb
@@ -35,7 +35,10 @@ RSpec.describe "Email tasks" do
           "10 minute group: 0\n" \
           "1 minute group: 0\n" \
           "Remaining group: 0\n" \
-          "Total: 0 users will be sent the 2021_03_survey\n",
+          "Total: 0 users will be sent the 2021_03_survey\n" \
+          "User emails have been enqueued\n" \
+          "Previous Total has_received_2021_03_survey: 0\n" \
+          "New Total has_received_2021_03_survey: 0\n", \
         ).to_stdout
       end
     end
@@ -54,7 +57,10 @@ RSpec.describe "Email tasks" do
           "10 minute group: 0\n" \
           "1 minute group: 0\n" \
           "Remaining group: 0\n" \
-          "Total: 0 users will be sent the 2021_03_survey\n",
+          "Total: 0 users will be sent the 2021_03_survey\n" \
+          "User emails have been enqueued\n" \
+          "Previous Total has_received_2021_03_survey: 0\n" \
+          "New Total has_received_2021_03_survey: 0\n", \
         ).to_stdout
       end
     end
@@ -75,7 +81,10 @@ RSpec.describe "Email tasks" do
           "10 minute group: 0\n" \
           "1 minute group: 0\n" \
           "Remaining group: 2\n" \
-          "Total: 2 users will be sent the 2021_03_survey\n",
+          "Total: 2 users will be sent the 2021_03_survey\n" \
+          "User emails have been enqueued\n" \
+          "Previous Total has_received_2021_03_survey: 0\n" \
+          "New Total has_received_2021_03_survey: 2\n", \
         ).to_stdout
       end
     end
@@ -99,7 +108,10 @@ RSpec.describe "Email tasks" do
           "10 minute group: 0\n" \
           "1 minute group: 0\n" \
           "Remaining group: 4\n" \
-          "Total: 4 users will be sent the 2021_03_survey\n",
+          "Total: 4 users will be sent the 2021_03_survey\n" \
+          "User emails have been enqueued\n" \
+          "Previous Total has_received_2021_03_survey: 3\n" \
+          "New Total has_received_2021_03_survey: 7\n", \
         ).to_stdout
       end
     end
@@ -137,7 +149,10 @@ RSpec.describe "Email tasks" do
           "10 minute group: 0\n" \
           "1 minute group: 3\n" \
           "Remaining group: 4\n" \
-          "Total: 7 users will be sent the 2021_03_survey\n",
+          "Total: 7 users will be sent the 2021_03_survey\n" \
+          "User emails have been enqueued\n" \
+          "Previous Total has_received_2021_03_survey: 0\n" \
+          "New Total has_received_2021_03_survey: 7\n", \
         ).to_stdout
       end
     end
@@ -187,7 +202,10 @@ RSpec.describe "Email tasks" do
           "10 minute group: 20\n" \
           "1 minute group: 20\n" \
           "Remaining group: 20\n" \
-          "Total: 60 users will be sent the 2021_03_survey\n",
+          "Total: 60 users will be sent the 2021_03_survey\n" \
+          "User emails have been enqueued\n" \
+          "Previous Total has_received_2021_03_survey: 0\n" \
+          "New Total has_received_2021_03_survey: 60\n", \
         ).to_stdout
       end
 
@@ -198,7 +216,10 @@ RSpec.describe "Email tasks" do
           "10 minute group: 1\n" \
           "1 minute group: 2\n" \
           "Remaining group: 3\n" \
-          "Total: 6 users will be sent the 2021_03_survey\n",
+          "Total: 6 users will be sent the 2021_03_survey\n" \
+          "User emails have been enqueued\n" \
+          "Previous Total has_received_2021_03_survey: 0\n" \
+          "New Total has_received_2021_03_survey: 6\n", \
         ).to_stdout
       end
     end


### PR DESCRIPTION
The Not clauses above this should exclude any duplicates between
groups... however when looking at the past cohort it seemed that instead
of the intented 500 emails sent we sent 398 because two users appeared
in two of the groups.

My concern is, if these are not being filtered out we might send a small
number of users two emails which would be annoying. So let's do a final
safeguard for Uniq here.

See here for more details[1]

[1]: https://docs.google.com/document/d/1Ojg57BOtFxXa_3glvjApHxISnwgRMvosplXC4KNrFhk/edit?disco=AAAAL3PadlM