### PR TITLE
Revert "Use GovukError.notify instead of Raven"

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,7 +23,7 @@ class ApplicationController < ActionController::Base
 protected
 
   def top_level_error_handler(exception = nil)
-    GovukError.notify(exception) if exception
+    Raven.capture_exception(exception) if exception
 
     respond_to do |format|
       format.html do

--- a/app/controllers/standard_errors_controller.rb
+++ b/app/controllers/standard_errors_controller.rb
@@ -31,6 +31,6 @@ private
 
   def report_error
     error = request.env["action_dispatch.exception"]
-    GovukError.notify(error) if error
+    Raven::Rack.capture_exception(error, request.env) if error
   end
 end


### PR DESCRIPTION
Reverts alphagov/govuk-account-manager-prototype#770

---

We're not actually using govuk_app_config in this app.  We probably should be, so switching to that can be another PR.