### PR TITLE
Add a migration to update callback paths

### DIFF
--- a/db/migrate/20210331091146_change_redirect_urls_for_frontend.rb
+++ b/db/migrate/20210331091146_change_redirect_urls_for_frontend.rb
@@ -1,0 +1,47 @@
+class ChangeRedirectUrlsForFrontend < ActiveRecord::Migration[6.0]
+  def up
+    Doorkeeper::Application.where(
+      redirect_uri: "http://finder-frontend.dev.gov.uk/transition-check/login/callback",
+    ).each do |dev_app|
+      dev_app.update!(
+        redirect_uri: [
+          "http://frontend.dev.gov.uk/sign-in/callback",
+          "http://finder-frontend.dev.gov.uk/transition-check/login/callback",
+        ],
+      )
+    end
+
+    Doorkeeper::Application.where(
+      redirect_uri: "https://www.integration.publishing.service.gov.uk/transition-check/login/callback",
+    ).each do |integration_app|
+      integration_app.update!(
+        redirect_uri: [
+          "https://www.integration.publishing.service.gov.uk/sign-in/callback",
+          "https://www.integration.publishing.service.gov.uk/transition-check/login/callback"
+        ],
+      )
+    end
+
+    Doorkeeper::Application.where(
+      redirect_uri: "https://www.staging.publishing.service.gov.uk/transition-check/login/callback",
+    ).each do |staging_app|
+      staging_app.update!(
+        redirect_uri: [
+          "https://www.staging.publishing.service.gov.uk/sign-in/callback",
+          "https://www.staging.publishing.service.gov.uk/transition-check/login/callback"
+        ],
+      )
+    end
+
+    Doorkeeper::Application.where(
+      redirect_uri: "https://www.gov.uk/transition-check/login/callback",
+    ).each do |production_app|
+      production_app.update!(
+        redirect_uri: [
+          "https://www.gov.uk/sign-in/callback",
+          "https://www.gov.uk/transition-check/login/callback"
+        ],
+      )
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_26_105828) do
+ActiveRecord::Schema.define(version: 2021_03_31_091146) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -21,7 +21,10 @@ if Rails.env.development?
 
   Doorkeeper::Application.create!(
     name: "GOV.UK Personalisation",
-    redirect_uri: "http://finder-frontend.dev.gov.uk/transition-check/login/callback",
+    redirect_uri: [
+      "http://finder-frontend.dev.gov.uk/transition-check/login/callback",
+      "http://frontend.dev.gov.uk/sign-in/callback",
+    ],
     scopes: %i[email openid transition_checker],
     uid: "client-id",
     secret: "client-secret",


### PR DESCRIPTION
We need both paths while we have both callbacks in use, which is
temporarily the case.  When the session code is removed from
finder-frontend, we can switch to the /sign-in/callback paths.