### PR TITLE
Add partial support for level-of-authentication 0 users, and return level-of-authentication after OAuth-ing

### DIFF
--- a/app/controllers/concerns/change_core_credentials.rb
+++ b/app/controllers/concerns/change_core_credentials.rb
@@ -1,12 +1,13 @@
-module RequiresRecentMfa
+module ChangeCoreCredentials
   class MissingMfaMethod < StandardError; end
 
   extend ActiveSupport::Concern
 
-  def has_done_mfa_recently?
-    return true if Rails.env.test? && Rails.application.config.allow_insecure_change_credential
+  def must_redo_mfa?
+    return false if Rails.env.test? && Rails.application.config.allow_insecure_change_credential
+    return false unless current_user.needs_mfa?
 
-    session[:has_done_mfa]
+    !session[:has_done_mfa]
   end
 
   def redo_mfa(after_redo_mfa_url)

--- a/app/controllers/edit_phone_controller.rb
+++ b/app/controllers/edit_phone_controller.rb
@@ -1,5 +1,5 @@
 class EditPhoneController < ApplicationController
-  include RequiresRecentMfa
+  include ChangeCoreCredentials
 
   before_action :authenticate_user!
   before_action :enforce_has_phone!
@@ -73,6 +73,6 @@ protected
   end
 
   def enforce_recent_mfa!
-    redo_mfa edit_user_registration_phone_path unless has_done_mfa_recently?
+    redo_mfa edit_user_registration_phone_path if must_redo_mfa?
   end
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,7 +1,7 @@
 class RegistrationsController < Devise::RegistrationsController
   include AcceptsJwt
   include CookiesHelper
-  include RequiresRecentMfa
+  include ChangeCoreCredentials
 
   # rubocop:disable Rails/LexicallyScopedActionFilter
   prepend_before_action :authenticate_scope!, only: %i[edit_password edit_email update destroy]
@@ -365,14 +365,14 @@ protected
   end
 
   def enforce_recent_mfa_for_email!
-    redo_mfa edit_user_registration_email_path unless has_done_mfa_recently?
+    redo_mfa edit_user_registration_email_path if must_redo_mfa?
   end
 
   def enforce_recent_mfa_for_password!
-    redo_mfa edit_user_registration_password_path unless has_done_mfa_recently?
+    redo_mfa edit_user_registration_password_path if must_redo_mfa?
   end
 
   def enforce_recent_mfa_for_update!
-    redo_mfa account_manage_path unless has_done_mfa_recently?
+    redo_mfa account_manage_path if must_redo_mfa?
   end
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -192,6 +192,14 @@ class RegistrationsController < Devise::RegistrationsController
         user_is_new: true,
       }
 
+      if resource.needs_mfa?
+        session[:level_of_authentication] = :level1
+        session[:has_done_mfa] = true
+      else
+        session[:level_of_authentication] = :level0
+        session[:has_done_mfa] = false
+      end
+
       resource.update_remote_user_info
 
       record_security_event(SecurityActivity::USER_CREATED, user: resource)

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -37,6 +37,7 @@ class RegistrationsController < Devise::RegistrationsController
       password_confirmation: params.dig(:user, :password),
       phone: params.dig(:user, :phone),
     )
+    resource.errors.add :phone, :blank if resource.phone.blank?
     resource.errors.add :email, :taken if User.exists?(email: resource.email)
 
     if resource.valid?

--- a/app/models/ephemeral_state.rb
+++ b/app/models/ephemeral_state.rb
@@ -8,6 +8,7 @@ class EphemeralState < ApplicationRecord
     {
       _ga: ga_client_id,
       cookie_consent: user.cookie_consent,
+      level_of_authentication: level_of_authentication,
     }.compact
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,6 +42,7 @@ class User < ApplicationRecord
            dependent: :destroy
 
   validate :password_cannot_be_on_denylist, if: :password_required?
+  validate :validate_phone_number, if: -> { phone.present? }
 
   # this has to happen before the record is actually destroyed because
   # there's a foreign key constraint ensuring that an access token
@@ -52,8 +53,6 @@ class User < ApplicationRecord
   # token gets destroyed between the test reading it and this callback
   # happening)
   before_destroy :destroy_remote_user_info_immediately, prepend: true
-
-  validate :validate_phone_number
 
   before_save :format_phone_number
 
@@ -104,11 +103,7 @@ class User < ApplicationRecord
   end
 
   def validate_phone_number
-    if phone.blank?
-      errors.add :phone, :blank
-    elsif !MultiFactorAuth.valid?(phone)
-      errors.add :phone, :invalid
-    end
+    errors.add :phone, :invalid unless MultiFactorAuth.valid?(phone)
   end
 
   def password_cannot_be_on_denylist

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -439,6 +439,7 @@ Doorkeeper.configure do
         user: controller.current_user,
         grant: access_grant.token,
         ga_client_id: controller.params[:_ga],
+        level_of_authentication: controller.session[:level_of_authentication] || :level0,
       )
     elsif controller.params[:grant_type] == "authorization_code"
       access_token = context.auth.body["access_token"]

--- a/db/migrate/20210415084043_add_level_of_authentication_to_ephemeral_state.rb
+++ b/db/migrate/20210415084043_add_level_of_authentication_to_ephemeral_state.rb
@@ -1,0 +1,5 @@
+class AddLevelOfAuthenticationToEphemeralState < ActiveRecord::Migration[6.0]
+  def change
+    add_column :ephemeral_states, :level_of_authentication, :string, default: "level0", null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_31_091146) do
+ActiveRecord::Schema.define(version: 2021_04_15_084043) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -46,6 +46,7 @@ ActiveRecord::Schema.define(version: 2021_03_31_091146) do
     t.string "ga_client_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "level_of_authentication", default: "level0", null: false
     t.index ["user_id"], name: "index_ephemeral_states_on_user_id"
   end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -20,5 +20,9 @@ FactoryBot.define do
     trait :has_not_received_2021_03_survey do
       has_received_2021_03_survey { false }
     end
+
+    trait :without_mfa do
+      phone { nil }
+    end
   end
 end

--- a/spec/feature/login_spec.rb
+++ b/spec/feature/login_spec.rb
@@ -33,6 +33,12 @@ RSpec.feature "Logging in" do
 
       expect(page).to have_text(I18n.t("account.your_account.heading"))
     end
+
+    it "allows the user to change email address" do
+      enter_email_address_and_password
+      visit_change_email_page
+      expect(page).to have_text(I18n.t("devise.registrations.edit.heading_email"))
+    end
   end
 
   context "when the email is missing" do
@@ -208,5 +214,14 @@ RSpec.feature "Logging in" do
 
   def visit_security_page
     click_on I18n.t("navigation.menu_bar.security.link_text")
+  end
+
+  def visit_change_email_page
+    within ".accounts-menu" do
+      click_on "Manage your account"
+    end
+    within "#main-content" do
+      click_on "Change Email"
+    end
   end
 end

--- a/spec/feature/login_spec.rb
+++ b/spec/feature/login_spec.rb
@@ -25,6 +25,16 @@ RSpec.feature "Logging in" do
     expect(page).to have_text(I18n.t("account.security.event.login_success"))
   end
 
+  context "when the user doesn't have MFA set up" do
+    let(:user) { FactoryBot.create(:user, :without_mfa) }
+
+    it "bypasses the MFA page" do
+      enter_email_address_and_password
+
+      expect(page).to have_text(I18n.t("account.your_account.heading"))
+    end
+  end
+
   context "when the email is missing" do
     it "shows an error" do
       enter_email_address_and_password(email: "")

--- a/spec/requests/api/v1/ephemeral_state_spec.rb
+++ b/spec/requests/api/v1/ephemeral_state_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe "/api/v1/ephemeral-state" do
     expect(JSON.parse(response.body).symbolize_keys).to eq({
       _ga: "hello world",
       cookie_consent: user.cookie_consent,
+      level_of_authentication: "level0",
     })
   end
 


### PR DESCRIPTION
We're going to launch an experiment which doesn't require MFA, but we don't want to switch off MFA for the Transition Checker users.

We've decided to implement this using "levels of authentication", where we shall have two levels:

- `level0`: the user has signed in with a username and password
- `level1`: `level0` + the user has signed in with MFA (either by entering a code or by having their device remembered)

The `/api/v1/ephemeral-state` endpoint returns the user's level of authentication.  The account-api will use this to decide which attributes a user can access.

This PR does not implement a way for *existing users* to sign in at `level0`, or for *new users* to register at `level0`: entering a phone number is still mandatory at registration time, and entering a code is still mandatory at login time.  A later PR will allow a service to request a specific level of authentication, which is when those features (+ a `level0` to `level1` upgrade journey) will be implemented.

To test the changes in this PR, some partial support has been added for `level0` users:

- Validation that a user has a phone number has been removed from the `User` model (this is now a check when registering)
- For the purpose of changing core credentials, a user without MFA is always considered to "have done MFA recently"

---

[Trello card](https://trello.com/c/ybaWjoXJ/711-return-a-users-level-of-authentication-from-the-account-manager-to-the-account-api)

