### PR TITLE
Fix missing validation when signing up without a phone

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -38,7 +38,6 @@ class RegistrationsController < Devise::RegistrationsController
       phone: params.dig(:user, :phone),
     )
     resource.errors.add :phone, :blank if resource.phone.blank?
-    resource.errors.add :email, :taken if User.exists?(email: resource.email)
 
     if resource.valid?
       RegistrationState.transaction do

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -36,8 +36,8 @@ class RegistrationsController < Devise::RegistrationsController
       password: params.dig(:user, :password),
       password_confirmation: params.dig(:user, :password),
       phone: params.dig(:user, :phone),
+      enforce_has_mfa: true,
     )
-    resource.errors.add :phone, :blank if resource.phone.blank?
 
     if resource.valid?
       RegistrationState.transaction do

--- a/spec/feature/registration_spec.rb
+++ b/spec/feature/registration_spec.rb
@@ -203,6 +203,17 @@ RSpec.feature "Registration" do
     end
   end
 
+  context "when the phone number is missing" do
+    it "returns an error" do
+      visit_registration_form
+      enter_email_address
+      enter_password
+      submit_registration_form
+
+      expect(page).to have_text(I18n.t("activerecord.errors.models.user.attributes.phone.blank"))
+    end
+  end
+
   context "when the phone number is not a mobile" do
     it "returns an error" do
       visit_registration_form


### PR DESCRIPTION
`resource.valid?`, `resource.validate`, and similar methods clear the
errors when they start.  So the `resource.errors.add :phone, :blank`
wasn't actually validating anything.

---

[Sentry error](https://sentry.io/organizations/govuk/issues/2343848269/?project=5370953&referrer=slack)