### PR TITLE
Add tracking to the show password button

### DIFF
--- a/app/views/delete/show.html.erb
+++ b/app/views/delete/show.html.erb
@@ -22,7 +22,7 @@
   <% end %>
 </ul>
 
-<%= form_with(url: account_delete_path, method: :delete) do %>
+<%= form_with(url: account_delete_path, method: :delete, data: { module: "gem-track-click" }) do %>
   <%= render "govuk_publishing_components/components/show_password", {
     label: {
       text: t("devise.registrations.edit.fields.current_password.label"),
@@ -32,6 +32,11 @@
     name: "current_password",
     error_message: @password_error_message,
     autocomplete: "current-password",
+    data: {
+      button_track_action: "passwordShowHide",
+      button_track_category: "pageElementInteraction",
+      button_track_label: "deleteAccount"
+    }
   } %>
 
   <%= render "govuk_publishing_components/components/inset_text", {

--- a/app/views/edit_phone/show.html.erb
+++ b/app/views/edit_phone/show.html.erb
@@ -19,7 +19,7 @@
   <%= sanitize(t("mfa.phone.update.start.current", phone_number: MultiFactorAuth.formatted_phone_number(current_user.phone))) %>
 </p>
 
-<%= form_with(url: edit_user_registration_phone_confirm_path, method: :post) do %>
+<%= form_with(url: edit_user_registration_phone_confirm_path, method: :post, data: { module: "gem-track-click" }) do %>
   <%= render "govuk_publishing_components/components/input", {
     label: { text: t("mfa.phone.update.start.fields.phone.label") },
     name: "phone",
@@ -40,6 +40,11 @@
     name: "current_password",
     error_message: @password_error_message,
     autocomplete: "current-password",
+    data: {
+      button_track_action: "passwordShowHide",
+      button_track_category: "pageElementInteraction",
+      button_track_label: "changePhoneNumber"
+    }
   } %>
 
   <%= render "govuk_publishing_components/components/button", {

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -12,7 +12,7 @@
   margin_bottom: 3,
 } %>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do %>
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }, data: { module: "gem-track-click" }) do %>
   <%= render "_shared/error_messages", resource: resource %>
   <%= hidden_field_tag "user[reset_password_token]", params[:reset_password_token] %>
   <%= email_field_tag 'email', @reset_email, class: "govuk-!-display-none", autocomplete: "off", "aria-hidden": true if @reset_email %>
@@ -25,6 +25,11 @@
     id: "password",
     error_message: devise_error_items(:password),
     autocomplete: @reset_email ? "new-password" : "off",
+    data: {
+      button_track_action: "passwordShowHide",
+      button_track_category: "pageElementInteraction",
+      button_track_label: "resetAccountPassword"
+    }
   } %>
 
   <%= render "_shared/password_tip" %>

--- a/app/views/registrations/edit_email.html.erb
+++ b/app/views/registrations/edit_email.html.erb
@@ -14,7 +14,7 @@
   margin_bottom: 6,
 } %>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do %>
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }, data: { module: "gem-track-click" }) do %>
   <%= render "_shared/error_messages", resource: resource %>
 
   <%= render "govuk_publishing_components/components/inset_text", {
@@ -43,6 +43,11 @@
     id: "current__confirmation",
     error_message: devise_error_items(:current_password),
     autocomplete: "current-password",
+    data: {
+      button_track_action: "passwordShowHide",
+      button_track_category: "pageElementInteraction",
+      button_track_label: "changeEmailAddress"
+    }
   } %>
 
   <%= render "govuk_publishing_components/components/button", {

--- a/app/views/registrations/edit_password.html.erb
+++ b/app/views/registrations/edit_password.html.erb
@@ -14,7 +14,7 @@
   margin_bottom: 6,
 } %>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do %>
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }, data: { module: "gem-track-click" }) do %>
   <%= email_field_tag 'email', resource.email, class: "govuk-!-display-none", autocomplete: "off", "aria-hidden": true %>
   <%= render "_shared/error_messages", resource: resource %>
 
@@ -28,6 +28,11 @@
     id: "current__confirmation",
     error_message: devise_error_items(:current_password),
     autocomplete: "current-password",
+    data: {
+      button_track_action: "passwordShowHide",
+      button_track_category: "pageElementInteraction",
+      button_track_label: "changePassword"
+    }
   } %>
 
   <%= render "govuk_publishing_components/components/show_password", {
@@ -39,6 +44,11 @@
     id: "password",
     error_message: devise_error_items(:password),
     autocomplete: "new-password",
+    data: {
+      button_track_action: "passwordShowHide",
+      button_track_category: "pageElementInteraction",
+      button_track_label: "changePasswordConfirm"
+    }
   } %>
 
   <%= render "_shared/password_tip" %>

--- a/app/views/registrations/start.html.erb
+++ b/app/views/registrations/start.html.erb
@@ -3,7 +3,7 @@
   <meta name="description" content='<%= t("devise.registrations.start.meta_description") %>'>
 <% end %>
 
-<%= form_with(url: new_user_registration_start_path, method: :post) do %>
+<%= form_with(url: new_user_registration_start_path, method: :post, data: { module: "gem-track-click" }) do %>
   <% if resource || @resource_error_messages %>
     <%= render "_shared/error_messages", resource: resource, resource_error_messages: @resource_error_messages %>
   <% end %>
@@ -36,6 +36,11 @@
     id: "password",
     error_message: devise_error_items(:password),
     autocomplete: "new-password",
+    data: {
+      button_track_action: "passwordShowHide",
+      button_track_category: "pageElementInteraction",
+      button_track_label: "createNewAccount"
+    }
   } %>
 
   <%= render "_shared/password_tip" %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -10,55 +10,62 @@
   margin_bottom: 3,
 } %>
 
-<%= form_with url: new_user_session_path, html: { "data-module" => "explicit-cross-domain-links" } do %>
-  <% if resource %>
-    <%= render "_shared/error_messages", resource: resource %>
-  <% end %>
-
-  <% if flash[:notice] %>
-    <% if flash_as_notice(flash[:notice]) %>
-      <%= render "govuk_publishing_components/components/notice", { description_text: flash[:notice] } %>
-    <% else %>
-      <%= render "govuk_publishing_components/components/success_alert", { message: flash[:notice] } %>
+<div data-module="gem-track-click">
+  <%= form_with url: new_user_session_path, html: { "data-module" => "explicit-cross-domain-links" } do %>
+    <% if resource %>
+      <%= render "_shared/error_messages", resource: resource %>
     <% end %>
+
+    <% if flash[:notice] %>
+      <% if flash_as_notice(flash[:notice]) %>
+        <%= render "govuk_publishing_components/components/notice", { description_text: flash[:notice] } %>
+      <% else %>
+        <%= render "govuk_publishing_components/components/success_alert", { message: flash[:notice] } %>
+      <% end %>
+    <% end %>
+
+    <%= hidden_field_tag "previous_url", params[:previous_url] %>
+
+    <%= hidden_field_tag "from_confirmation_email", params[:from_confirmation_email] %>
+
+    <%= render "govuk_publishing_components/components/input", {
+      label: {
+        text: t("devise.sessions.new.fields.email.label"),
+      },
+      name: "user[email]",
+      type: "email",
+      id: "email",
+      value: @email,
+      error_message: devise_error_items(:email, @resource_error_messages),
+      autocomplete: "username",
+    } %>
+
+    <%= render "govuk_publishing_components/components/show_password", {
+      label: {
+        text: t("devise.sessions.new.fields.password.label"),
+      },
+      name: "user[password]",
+      id: "password",
+      error_message: devise_error_items(:password, @resource_error_messages),
+      autocomplete: "current-password",
+      data: {
+        button_track_action: "passwordShowHide",
+        button_track_category: "pageElementInteraction",
+        button_track_label: "signIn"
+      }
+    } %>
+
+    <%= render "govuk_publishing_components/components/button", {
+      text: t("devise.sessions.new.fields.submit.label"),
+      margin_bottom: 3,
+      data_attributes: {
+        module: "gem-track-click",
+        "track-category": "account-signin",
+        "track-action": "signin",
+        "track-label": "password"
+      }
+    } %>
   <% end %>
-
-  <%= hidden_field_tag "previous_url", params[:previous_url] %>
-
-  <%= hidden_field_tag "from_confirmation_email", params[:from_confirmation_email] %>
-
-  <%= render "govuk_publishing_components/components/input", {
-    label: {
-      text: t("devise.sessions.new.fields.email.label"),
-    },
-    name: "user[email]",
-    type: "email",
-    id: "email",
-    value: @email,
-    error_message: devise_error_items(:email, @resource_error_messages),
-    autocomplete: "username",
-  } %>
-
-  <%= render "govuk_publishing_components/components/show_password", {
-    label: {
-      text: t("devise.sessions.new.fields.password.label"),
-    },
-    name: "user[password]",
-    id: "password",
-    error_message: devise_error_items(:password, @resource_error_messages),
-    autocomplete: "current-password",
-  } %>
-
-  <%= render "govuk_publishing_components/components/button", {
-    text: t("devise.sessions.new.fields.submit.label"),
-    margin_bottom: 3,
-    data_attributes: {
-      module: "gem-track-click",
-      "track-category": "account-signin",
-      "track-action": "signin",
-      "track-label": "password"
-    }
-  } %>
-<% end %>
+</div>
 
 <%= sanitize(t("devise.sessions.new.reset_password", reset_password: reset_password_path)) %>


### PR DESCRIPTION
## What

Adds tracking to the show password buttons in various places in the accounts manager (see the trello card for a specific list of locations).

This requires that the wrapping element (or a suitable wrapping element) have the `gem-track-click` module. It would be neater to put this on the thing being tracked, except the thing being tracked in this case is a button created after page load, and the tracking can't cope with that, so it has to go on a parent element. In one case the parent form already had a `data-module` attribute, so I've had to add a wrapping div as well, unfortunately.

## Why

We want to know if people are using this button.

## Visual changes

None.

Trello card: https://trello.com/c/HRCea3NT/721-add-tracking-to-the-show-password-component
