### PR TITLE
Request auth level

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -22,6 +22,7 @@ class SessionsController < Devise::SessionsController
 
     @email = params.dig(:user, :email)
     catch(:warden) do
+      request.env["warden.mfa.authenticate_to_level"] = params.dig(:authenticate_to_level)
       request.env["warden.mfa.bypass_token"] = (cookies.encrypted[MFA_BYPASS_COOKIE_NAME] || {})[@email]
       self.resource = warden.authenticate(auth_options)
     end

--- a/app/helpers/registration_helper.rb
+++ b/app/helpers/registration_helper.rb
@@ -1,0 +1,7 @@
+module RegistrationHelper
+  def show_phone_field?
+    return true unless Rails.application.config.feature_flag_enforce_levels_of_authentication
+
+    params.dig(:authenticate_to_level) != "level0"
+  end
+end

--- a/app/views/registrations/start.html.erb
+++ b/app/views/registrations/start.html.erb
@@ -45,19 +45,23 @@
 
   <%= render "_shared/password_tip" %>
 
-  <%= render "govuk_publishing_components/components/input", {
-    label: {
-      text: t("devise.registrations.start.fields.phone.label"),
-    },
-    hint: t("devise.registrations.start.fields.phone.hint"),
-    name: "user[phone]",
-    id: "phone",
-    value: MultiFactorAuth.formatted_phone_number(params.dig(:user, :phone)),
-    width: 10,
-    error_message: devise_error_items(:phone),
-    autocomplete: "tel",
-    type: "tel",
-  } %>
+  <% if show_phone_field? %>
+    <%= render "govuk_publishing_components/components/input", {
+      label: {
+        text: t("devise.registrations.start.fields.phone.label"),
+      },
+      hint: t("devise.registrations.start.fields.phone.hint"),
+      name: "user[phone]",
+      id: "phone",
+      value: MultiFactorAuth.formatted_phone_number(params.dig(:user, :phone)),
+      width: 10,
+      error_message: devise_error_items(:phone),
+      autocomplete: "tel",
+      type: "tel",
+    } %>
+  <% end %>
+
+  <%= hidden_field_tag :authenticate_to_level, params.dig(:authenticate_to_level) %>
 
   <%= render "govuk_publishing_components/components/button", {
     text: t("devise.registrations.start.fields.submit.label"),

--- a/app/views/registrations/start.html.erb
+++ b/app/views/registrations/start.html.erb
@@ -61,7 +61,8 @@
     } %>
   <% end %>
 
-  <%= hidden_field_tag :authenticate_to_level, params.dig(:authenticate_to_level) %>
+  <%= hidden_field_tag :previous_url, params[:previous_url] %>
+  <%= hidden_field_tag :authenticate_to_level, params[:authenticate_to_level] %>
 
   <%= render "govuk_publishing_components/components/button", {
     text: t("devise.registrations.start.fields.submit.label"),
@@ -75,7 +76,17 @@
   } %>
 <% end %>
 
-<p class="govuk-body"><%= sanitize(t("devise.registrations.start.sign_in", link: link_to(t("devise.registrations.start.sign_in_link"), new_user_session_path(previous_url: params[:previous_url]), class: "govuk-link"))) %></p>
+<p class="govuk-body">
+  <%= sanitize(
+      t("devise.registrations.start.sign_in",
+      link: link_to(t("devise.registrations.start.sign_in_link"),
+      new_user_session_path(
+        previous_url: params[:previous_url],
+        authenticate_to_level: params[:authenticate_to_level]
+      ), class: "govuk-link"
+      )))
+  %>
+</p>
 
 <% if @criteria_keys %>
   <%= render "govuk_publishing_components/components/inset_text", {

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -55,6 +55,8 @@
       }
     } %>
 
+    <%= hidden_field_tag :authenticate_to_level, params.dig(:authenticate_to_level) %>
+
     <%= render "govuk_publishing_components/components/button", {
       text: t("devise.sessions.new.fields.submit.label"),
       margin_bottom: 3,

--- a/config/application.rb
+++ b/config/application.rb
@@ -55,5 +55,7 @@ module GovukAccountManagerPrototype
     config.i18n.load_path += Dir[Rails.root.join("config/locales/**/*.yml").to_s]
 
     config.i18n.default_locale = :en
+
+    config.feature_flag_enforce_levels_of_authentication = ENV["FEATURE_FLAG_ENFORCE_LEVELS_OF_AUTHENTICATION"] == "enabled"
   end
 end

--- a/config/locales/doorkeeper_openid_connect.en.yml
+++ b/config/locales/doorkeeper_openid_connect.en.yml
@@ -17,6 +17,8 @@ en:
           subject_not_configured: ID Token generation failed due to Doorkeeper::OpenidConnect.configure.subject missing configuration.
     scopes:
       email: View your email address
+      level0: Authenticate your account
+      level1: Authenticate your account with multiple factors
       openid: Authenticate your account
       test_scope_read: View your local development testing data
       test_scope_write: View and update your local development testing data

--- a/config/scopes.yml
+++ b/config/scopes.yml
@@ -7,9 +7,13 @@ optional_scopes:
   - email
   - reporting_access
   - transition_checker
+  - level0
+  - level1
 hidden_scopes:
   - openid
   - transition_checker
+  - level0
+  - level1
 jwt_attributes_and_scopes: {
   "transition_checker_state": ["transition_checker"]
 }

--- a/lib/devise/strategies/multi_factor_authenticatable.rb
+++ b/lib/devise/strategies/multi_factor_authenticatable.rb
@@ -15,7 +15,12 @@ module Devise
         if validate(resource) { hashed = true; resource.valid_password?(password) } # rubocop:disable Style/Semicolon
           if resource.needs_mfa?
             env["warden.mfa.bypass"] = MultiFactorAuth.verify_bypass_token(resource, env["warden.mfa.bypass_token"])
-            env["warden.mfa.required"] = !env["warden.mfa.bypass"]
+            env["warden.mfa.required"] =
+              if env["warden.mfa.authenticate_to_level"] == "level0"
+                false
+              else
+                !env["warden.mfa.bypass"]
+              end
           else
             env["warden.mfa.required"] = false
           end

--- a/lib/level_of_authentication.rb
+++ b/lib/level_of_authentication.rb
@@ -11,7 +11,7 @@ module LevelOfAuthentication
     end
 
     def select_highest_level(array_of_levels)
-      return nil if array_of_levels.empty?
+      return current_maximum_level if array_of_levels.empty?
 
       sort_levels_of_authentication(array_of_levels).last
     end
@@ -20,6 +20,15 @@ module LevelOfAuthentication
       return false if current_auth.nil? || required_auth.nil?
 
       current_auth.delete_prefix("level").to_i >= required_auth.delete_prefix("level").to_i
+    end
+
+    def known_auth_levels_from_hidden_scopes(scopes_path = "./config/scopes.yml")
+      scopes = YAML.load_file(scopes_path)
+      scopes["hidden_scopes"].select { |scope| scope.starts_with?("level") }
+    end
+
+    def current_maximum_level(scopes_path = "./config/scopes.yml")
+      select_highest_level(known_auth_levels_from_hidden_scopes(scopes_path))
     end
   end
 end

--- a/lib/level_of_authentication.rb
+++ b/lib/level_of_authentication.rb
@@ -14,5 +14,9 @@ module LevelOfAuthentication
       sort_levels_of_authentication(array_of_levels).last
     end
 
+    def current_auth_greater_or_equal_to_required(current_auth, required_auth)
+      return false if current_auth.nil? || required_auth.nil?
+      current_auth.delete_prefix("level").to_i >= required_auth.delete_prefix("level").to_i
+    end
   end
 end

--- a/lib/level_of_authentication.rb
+++ b/lib/level_of_authentication.rb
@@ -1,0 +1,18 @@
+module LevelOfAuthentication
+  class << self
+    def sort_levels_of_authentication(array_of_levels)
+      return nil if array_of_levels.empty?
+
+      array_of_levels.sort do |a, b|
+        a.delete_prefix("level").to_i <=> b.delete_prefix("level").to_i
+      end
+    end
+
+    def select_highest_level(array_of_levels)
+      return nil if array_of_levels.empty?
+
+      sort_levels_of_authentication(array_of_levels).last
+    end
+
+  end
+end

--- a/lib/level_of_authentication.rb
+++ b/lib/level_of_authentication.rb
@@ -1,3 +1,5 @@
+class LevelOfAuthenticationTooLowError < StandardError; end
+
 module LevelOfAuthentication
   class << self
     def sort_levels_of_authentication(array_of_levels)
@@ -16,6 +18,7 @@ module LevelOfAuthentication
 
     def current_auth_greater_or_equal_to_required(current_auth, required_auth)
       return false if current_auth.nil? || required_auth.nil?
+
       current_auth.delete_prefix("level").to_i >= required_auth.delete_prefix("level").to_i
     end
   end

--- a/spec/feature/login_spec.rb
+++ b/spec/feature/login_spec.rb
@@ -242,7 +242,7 @@ RSpec.feature "Logging in" do
         it "sucessfully returns the current user if the level of authentication meets the requirement" do
           visit authorization_endpoint_url(client: application, scope: "openid level1")
 
-          expect(page).to have_text(I18n.t("doorkeeper.authorizations.new.heading"))
+          expect(page.current_url).to start_with("https://www.gov.uk/")
         end
       end
     end

--- a/spec/fixtures/scopes.yml
+++ b/spec/fixtures/scopes.yml
@@ -1,0 +1,8 @@
+---
+default_scopes: []
+optional_scopes: []
+hidden_scopes:
+  - openid
+  - level0
+  - level1
+jwt_attributes_and_scopes: {}

--- a/spec/lib/level_of_authentication_spec.rb
+++ b/spec/lib/level_of_authentication_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe LevelOfAuthentication do
+  describe "#sort_levels_of_authentication" do
+    it "returns a sorted array of auth levels" do
+      array = %w[level4 level0 level2]
+
+      expect(
+        LevelOfAuthentication.sort_levels_of_authentication(array),
+      ).to eq(%w[level0 level2 level4])
+    end
+
+    it "sorts correctly for double and triple digit numbers" do
+      array = %w[level0 level100 level10 level1]
+
+      expect(
+        LevelOfAuthentication.sort_levels_of_authentication(array),
+      ).to eq(%w[level0 level1 level10 level100])
+    end
+    it "returns nil if provided an empty array" do
+      expect(LevelOfAuthentication.sort_levels_of_authentication([])).to be_nil
+    end
+  end
+
+  describe "#select_highest_level" do
+    it "returns the highest level as a string" do
+      array = %w[level0 level100 level10 level1]
+
+      expect(
+        LevelOfAuthentication.select_highest_level(array),
+      ).to eq("level100")
+    end
+
+    it "returns nil if provided an empty array" do
+      expect(LevelOfAuthentication.select_highest_level([])).to be_nil
+    end
+  end
+end

--- a/spec/lib/level_of_authentication_spec.rb
+++ b/spec/lib/level_of_authentication_spec.rb
@@ -15,9 +15,6 @@ RSpec.describe LevelOfAuthentication do
         LevelOfAuthentication.sort_levels_of_authentication(array),
       ).to eq(%w[level0 level1 level10 level100])
     end
-    it "returns nil if provided an empty array" do
-      expect(LevelOfAuthentication.sort_levels_of_authentication([])).to be_nil
-    end
   end
 
   describe "#select_highest_level" do
@@ -29,8 +26,10 @@ RSpec.describe LevelOfAuthentication do
       ).to eq("level100")
     end
 
-    it "returns nil if provided an empty array" do
-      expect(LevelOfAuthentication.select_highest_level([])).to be_nil
+    it "returns the current_maximum_level if provided an empty array" do
+      expect(
+        LevelOfAuthentication.select_highest_level([]),
+      ).to eq(LevelOfAuthentication.current_maximum_level)
     end
   end
 
@@ -49,6 +48,22 @@ RSpec.describe LevelOfAuthentication do
 
     it "returns false that level1 is higher than level1000" do
       expect(LevelOfAuthentication.current_auth_greater_or_equal_to_required("level1", "level1000")).to be false
+    end
+  end
+
+  describe "#known_auth_levels_from_hidden_scopes" do
+    it "returns an array of hidden scopes, filtered to known level of auth scopes" do
+      expect(
+        LevelOfAuthentication.known_auth_levels_from_hidden_scopes("./spec/fixtures/scopes.yml"),
+      ).to eq(%w[level0 level1])
+    end
+  end
+
+  describe "current_maximum_level" do
+    it "returns the highest known level of auth scope" do
+      expect(
+        LevelOfAuthentication.current_maximum_level("./spec/fixtures/scopes.yml"),
+      ).to eq("level1")
     end
   end
 end

--- a/spec/lib/level_of_authentication_spec.rb
+++ b/spec/lib/level_of_authentication_spec.rb
@@ -33,4 +33,22 @@ RSpec.describe LevelOfAuthentication do
       expect(LevelOfAuthentication.select_highest_level([])).to be_nil
     end
   end
+
+  describe "#current_auth_greater_or_equal_to_required" do
+    it "returns true that level1 is higher than level0" do
+      expect(LevelOfAuthentication.current_auth_greater_or_equal_to_required("level1", "level0")).to be true
+    end
+
+    it "returns true that level10 is higher than level1" do
+      expect(LevelOfAuthentication.current_auth_greater_or_equal_to_required("level10", "level1")).to be true
+    end
+
+    it "returns true that level1 is equal to level1" do
+      expect(LevelOfAuthentication.current_auth_greater_or_equal_to_required("level1", "level1")).to be true
+    end
+
+    it "returns false that level1 is higher than level1000" do
+      expect(LevelOfAuthentication.current_auth_greater_or_equal_to_required("level1", "level1000")).to be false
+    end
+  end
 end


### PR DESCRIPTION
## What

Currently MFA is required for sign up and login journeys, as they were inherited from the Transition Checker where they were required.

However now we have a range of authentication scenarios, some of which can allow for a lighter touch entry and less friction for the user.

This PR adds the ability for login and sign up journeys to pass a requested leve of auth parameter that can be used to alter the signup / login journey to the appropraite level.

If a current user is signed in but authenticated to the wrong level we will just throw an error for now as that will be handled in [another ticket](https://trello.com/c/Lza4p0uc/719-implement-a-level0-to-level1-upgrade-journey-in-the-account-manager).

## Feature flag

We are also not quite ready to see this in prod, so this includes a feature flag, which when not "enabled" leaves all existing paths and outcomes unchanged.