### PR TITLE
Implement upgrading level0 sessions to level1, including setting up MFA for the first time (with placeholder content)

### DIFF
--- a/app/views/edit_phone/confirm.html.erb
+++ b/app/views/edit_phone/confirm.html.erb
@@ -1,11 +1,13 @@
 <% content_for :title, t("mfa.phone.update.confirm.heading") %>
-<% content_for :location, "manage" %>
-<% content_for :account_navigation do %>
-  <%= render "account-navigation", page_is: yield(:location) %>
+<% unless setting_up_first_phone? %>
+  <% content_for :location, "manage" %>
+  <% content_for :account_navigation do %>
+    <%= render "account-navigation", page_is: yield(:location) %>
+  <% end %>
 <% end %>
 
 <% content_for :before_main do %>
-  <%= render "govuk_publishing_components/components/back_link", { href: edit_user_registration_phone_path } %>
+  <%= render "govuk_publishing_components/components/back_link", { href: start_path } %>
 <% end %>
 
 <%= render "govuk_publishing_components/components/heading", {
@@ -27,5 +29,5 @@
 <% end %>
 
 <p class="govuk-body">
-  <%= sanitize(t("mfa.phone.code.not_received.change_number_message", link: edit_user_registration_phone_path)) %>
+  <%= sanitize(t("mfa.phone.code.not_received.change_number_message", link: edit_user_registration_phone_resend_path)) %>
 </p>

--- a/app/views/edit_phone/new.html.erb
+++ b/app/views/edit_phone/new.html.erb
@@ -1,12 +1,4 @@
-<% content_for :title, t("mfa.phone.update.start.show.heading") %>
-<% content_for :location, "manage" %>
-<% content_for :account_navigation do %>
-  <%= render "account-navigation", page_is: yield(:location) %>
-<% end %>
-
-<% content_for :before_main do %>
-  <%= render "govuk_publishing_components/components/back_link", { href: account_manage_path } %>
-<% end %>
+<% content_for :title, t("mfa.phone.update.start.new.heading") %>
 
 <%= render "govuk_publishing_components/components/heading", {
   text: yield(:title),
@@ -15,9 +7,9 @@
   margin_bottom: 6,
 } %>
 
-<p class="govuk-body">
-  <%= sanitize(t("mfa.phone.update.start.show.current", phone_number: MultiFactorAuth.formatted_phone_number(current_user.phone))) %>
-</p>
+<% t("mfa.phone.update.start.new.description").each do |msg| %>
+  <p class="govuk-body"><%= sanitize(msg) %></p>
+<% end %>
 
 <%= form_with(url: edit_user_registration_phone_confirm_path, method: :post, data: { module: "gem-track-click" }) do %>
   <% if @resource_error_messages.any? %>
@@ -25,14 +17,14 @@
   <% end %>
 
   <%= render "govuk_publishing_components/components/input", {
-    label: { text: t("mfa.phone.update.start.show.fields.phone.label") },
+    label: { text: t("mfa.phone.update.start.new.fields.phone.label") },
     name: "phone",
     type: "tel",
     error_message: devise_error_items(:phone, @resource_error_messages),
   } %>
 
   <p class="govuk-body">
-    <%= t("mfa.phone.update.start.show.message") %>
+    <%= t("mfa.phone.update.start.new.message") %>
   </p>
 
   <%= render "govuk_publishing_components/components/show_password", {
@@ -52,12 +44,6 @@
   } %>
 
   <%= render "govuk_publishing_components/components/button", {
-    text: t("mfa.phone.update.start.show.fields.submit.label"),
-    inline_layout: true,
+    text: t("mfa.phone.update.start.new.fields.submit.label"),
   } %>
-  <span class="govuk-body"><%= t("general.or") %></span>
-  <%= link_to t("general.cancel"),
-    account_manage_path,
-    class: "govuk-body govuk-link"
-  %>
 <% end %>

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -27,7 +27,8 @@ Doorkeeper.configure do
       else
         destination_url =
           if MultiFactorAuth.choose_mfa_method(current_user).nil?
-            raise NotImplementedError
+            session[:after_change_phone_path] = request.fullpath
+            edit_user_registration_phone_new_url
           else
             login_state = LoginState.create!(created_at: Time.zone.now, user: current_user, redirect_path: request.fullpath)
             session[:login_state_id] = login_state.id

--- a/config/locales/mfa.en.yml
+++ b/config/locales/mfa.en.yml
@@ -65,14 +65,26 @@ en:
               label: Send security code
           heading: Confirm your new number
         start:
-          current: 'The phone number currently stored in your GOV.UK account is: <span class="govuk-!-font-weight-bold">%{phone_number}</span>'
-          fields:
-            phone:
-              label: Enter new mobile phone number
-            submit:
-              label: Continue
-          heading: Change your phone number
-          message: We’ll send a security code to your new number by text message. You’ll need this code to finish changing the phone number for your account.
+          new:
+            description:
+            - PLACEHOLDER You need to provide a phone number to do this.
+            - PLACEHOLDER Because of reasons.
+            fields:
+              phone:
+                label: PLACEHOLDER Enter new mobile phone number
+              submit:
+                label: PLACEHOLDER Continue
+            heading: PLACEHOLDER Set your phone number
+            message: PLACEHOLDER We’ll send a security code to your new number by text message. You’ll need this code to finish setting up the phone number for your account.
+          show:
+            current: 'The phone number currently stored in your GOV.UK account is: <span class="govuk-!-font-weight-bold">%{phone_number}</span>'
+            fields:
+              phone:
+                label: Enter new mobile phone number
+              submit:
+                label: Continue
+            heading: Change your phone number
+            message: We’ll send a security code to your new number by text message. You’ll need this code to finish changing the phone number for your account.
     text_message:
       security_code:
         body: "%{phone_code} is your security code."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,7 @@ Rails.application.routes.draw do
 
         scope "/phone" do
           get  "/", to: "edit_phone#show", as: :edit_user_registration_phone
+          get "/new", to: "edit_phone#new", as: :edit_user_registration_phone_new
           post "/confirm", to: "edit_phone#confirm", as: :edit_user_registration_phone_confirm
           get  "/code", to: "edit_phone#code", as: :edit_user_registration_phone_code
           post "/code", to: "edit_phone#code_send"

--- a/lib/level_of_authentication.rb
+++ b/lib/level_of_authentication.rb
@@ -1,5 +1,3 @@
-class LevelOfAuthenticationTooLowError < StandardError; end
-
 module LevelOfAuthentication
   class << self
     def sort_levels_of_authentication(array_of_levels)

--- a/spec/feature/change_phone_spec.rb
+++ b/spec/feature/change_phone_spec.rb
@@ -144,12 +144,12 @@ RSpec.feature "Change Phone" do
 
   def enter_password
     fill_in "current_password", with: user.password
-    click_on I18n.t("mfa.phone.update.start.fields.submit.label")
+    click_on I18n.t("mfa.phone.update.start.show.fields.submit.label")
   end
 
   def enter_incorrect_password
     fill_in "current_password", with: "1#{user.password}"
-    click_on I18n.t("mfa.phone.update.start.fields.submit.label")
+    click_on I18n.t("mfa.phone.update.start.show.fields.submit.label")
   end
 
   def send_code

--- a/spec/feature/login_spec.rb
+++ b/spec/feature/login_spec.rb
@@ -218,21 +218,33 @@ RSpec.feature "Logging in" do
 
         before { log_in(%w[level0]) }
 
-        it "does not redirect to do MFA if level0 is requested" do
+        it "does not redirect to set up MFA if level0 is requested" do
           visit authorization_endpoint_url(client: application, scope: "openid level0")
+          expect(page).to_not have_content(I18n.t("mfa.phone.update.start.new.heading"))
           expect(page.current_url).to start_with("https://www.gov.uk/")
         end
 
-        it "raises NotImplementedError if a higher scope is requested" do
-          expect {
-            visit authorization_endpoint_url(client: application, scope: "openid level10")
-          }.to raise_error(NotImplementedError)
+        it "redirects to set up MFA if a higher scope is requested" do
+          visit authorization_endpoint_url(client: application, scope: "openid level1")
+          expect(page).to have_content(I18n.t("mfa.phone.update.start.new.heading"))
+          set_up_mfa
+          expect(page.current_url).to start_with("https://www.gov.uk/")
         end
 
-        it "raises NotImplementedError if no scope is requested" do
-          expect {
-            visit authorization_endpoint_url(client: application, scope: "openid")
-          }.to raise_error(NotImplementedError)
+        it "redirects to set up MFA if no scope is requested" do
+          visit authorization_endpoint_url(client: application, scope: "openid")
+          expect(page).to have_content(I18n.t("mfa.phone.update.start.new.heading"))
+          set_up_mfa
+          expect(page.current_url).to start_with("https://www.gov.uk/")
+        end
+
+        def set_up_mfa
+          fill_in "phone", with: "07958123456"
+          fill_in "current_password", with: user.password
+          click_on I18n.t("mfa.phone.update.start.new.fields.submit.label")
+          click_on I18n.t("mfa.phone.update.confirm.fields.submit.label")
+          fill_in "phone_code", with: user.reload.phone_code
+          click_on I18n.t("mfa.phone.code.fields.submit.label")
         end
       end
 

--- a/spec/lib/report/account_events_spec.rb
+++ b/spec/lib/report/account_events_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Report::AccountEvents do
-  let(:report) { described_class.new(start_date: start_date, end_date: end_date, user_id_pepper: "pepper").all }
+  let(:report) { described_class.new(start_date: start_date, end_date: end_date, user_id_pepper: "pepper").all.sort_by { |e| e[:login_timestamp] } }
 
   let(:start_date) { Time.zone.local(2020, 1, 22, 10, 0, 0) }
   let(:end_date) { start_date + 1.day }


### PR DESCRIPTION
We've now got a proliferation of MFA-related controllers, views, and locale entries.  I think we could consolidate these with a bit of refactoring, but it could be pretty hairy and since we're not really doing much to the account manager it's probably not worth prioritising.

---

[Trello card](https://trello.com/c/Lza4p0uc/719-implement-a-level0-to-level1-upgrade-journey-in-the-account-manager)