### PR TITLE
Fix Change email page bug and add tests

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -212,7 +212,7 @@ class RegistrationsController < Devise::RegistrationsController
     self.resource = resource_class.to_adapter.get!(send(:"current_#{resource_name}").to_key)
     prev_unconfirmed_email = resource.unconfirmed_email if resource.respond_to?(:unconfirmed_email)
 
-    old_email = resource.email
+    @old_email = resource.email
 
     new_email = params.dig(:user, :email)
     new_password = params.dig(:user, :password)
@@ -235,7 +235,7 @@ class RegistrationsController < Devise::RegistrationsController
     end
 
     if resource_updated
-      record_security_event(SecurityActivity::EMAIL_CHANGE_REQUESTED, user: resource, notes: "from #{old_email} to #{new_email}") if new_email
+      record_security_event(SecurityActivity::EMAIL_CHANGE_REQUESTED, user: resource, notes: "from #{@old_email} to #{new_email}") if new_email
       record_security_event(SecurityActivity::PASSWORD_CHANGED, user: resource) if new_password
 
       resource.update!(banned_password_match: false) if new_password

--- a/app/views/registrations/edit_email.html.erb
+++ b/app/views/registrations/edit_email.html.erb
@@ -18,7 +18,7 @@
   <%= render "_shared/error_messages", resource: resource %>
 
   <%= render "govuk_publishing_components/components/inset_text", {
-    text: t("devise.registrations.edit.fields.email.inset_text", email: resource.email),
+    text: t("devise.registrations.edit.fields.email.inset_text", email: @old_email || resource.email),
   } %>
 
   <%= render "govuk_publishing_components/components/input", {

--- a/spec/feature/change_email_spec.rb
+++ b/spec/feature/change_email_spec.rb
@@ -1,0 +1,144 @@
+RSpec.feature "Change Email" do
+  include ActiveJob::TestHelper
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:user) { FactoryBot.create(:user) }
+
+  let(:new_email) { "test@testing.com" }
+
+  context "when the change email form is submitted with correct details" do
+    it "displays the confirmation instructions page" do
+      log_in
+      go_to_change_email_page
+      enter_new_email
+      enter_password
+
+      expect(page).to have_text(I18n.t("confirmation_sent.heading"))
+      expect(page).to have_text("#{I18n.t('confirmation_sent.instruction_one')} #{new_email}")
+    end
+
+    it "notifies the user about the update" do
+      log_in
+      go_to_change_email_page
+      enter_new_email
+      enter_password
+
+      assert_enqueued_jobs 2, only: NotifyDeliveryJob
+    end
+  end
+
+  context "when the user enters the same email" do
+    it "returns an error" do
+      log_in
+      go_to_change_email_page
+      enter_same_email
+      enter_password
+
+      expect(page).to have_text(I18n.t("devise.failure.same_email"))
+    end
+
+    it "displays the current email" do
+      log_in
+      go_to_change_email_page
+      enter_same_email
+      enter_password
+
+      expect(page).to have_text(I18n.t("devise.registrations.edit.fields.email.inset_text", email: user.email))
+    end
+  end
+
+  context "when the email is invalid" do
+    it "returns an error" do
+      log_in
+      go_to_change_email_page
+      enter_invalid_email
+      enter_password
+
+      expect(page).to have_text(I18n.t("activerecord.errors.models.user.attributes.email.invalid"))
+    end
+
+    it "displays the current email" do
+      log_in
+      go_to_change_email_page
+      enter_same_email
+      enter_password
+
+      expect(page).to have_text(I18n.t("devise.registrations.edit.fields.email.inset_text", email: user.email))
+    end
+  end
+
+  context "when the email field is empty" do
+    it "returns an error" do
+      log_in
+      go_to_change_email_page
+      enter_empty_email
+      enter_password
+
+      expect(page).to have_text(I18n.t("activerecord.errors.models.user.attributes.email.blank"))
+    end
+
+    it "displays the current email" do
+      log_in
+      go_to_change_email_page
+      enter_same_email
+      enter_password
+
+      expect(page).to have_text(I18n.t("devise.registrations.edit.fields.email.inset_text", email: user.email))
+    end
+  end
+
+  context "when the password is incorrect" do
+    it "returns an error" do
+      log_in
+      go_to_change_email_page
+      enter_new_email
+      enter_incorrect_password
+
+      expect(page).to have_text(I18n.t("activerecord.errors.models.user.attributes.current_password.invalid"))
+    end
+
+    it "displays the current email" do
+      log_in
+      go_to_change_email_page
+      enter_new_email
+      enter_incorrect_password
+
+      expect(page).to have_text(I18n.t("devise.registrations.edit.fields.email.inset_text", email: user.email))
+    end
+  end
+
+  def go_to_change_email_page
+    within ".accounts-menu" do
+      click_on "Manage your account"
+    end
+    within "#main-content" do
+      click_on "Change Email"
+    end
+  end
+
+  def enter_new_email
+    fill_in "email", with: new_email
+  end
+
+  def enter_same_email
+    fill_in "email", with: user.email
+  end
+
+  def enter_invalid_email
+    fill_in "email", with: "BLAH"
+  end
+
+  def enter_empty_email
+    fill_in "email", with: ""
+  end
+
+  def enter_password
+    fill_in "current__confirmation", with: user.password
+    click_on I18n.t("devise.registrations.edit.fields.submit.label")
+  end
+
+  def enter_incorrect_password
+    fill_in "current__confirmation", with: "asdf#{user.password}"
+    click_on I18n.t("devise.registrations.edit.fields.submit.label")
+  end
+end


### PR DESCRIPTION
On the **Change your email address** page, there is a bit of content that notifies the user what their account's email address currently is.
The content reads something like: 
> The email address currently stored in your GOV.UK
account is: currentemail@currentemail.com

What is happening is that if the user submits the form with the wrong information, so that an error appears, the content changes to reflect (incorrectly) what the user had typed into the email input prior to the error. This could be misleading because people might think that their email has been changed, when it fact it has stayed the same.

**Example:** I tried to change my account email address to my shiny new address gorenroeinreio-fnekfnerifnei@nfewnfiewn.de. 
However, I accidentally submitted the form without typing up my password! 
Now I see an error, but the page is telling me that my current email address is gorenroeinreio-fnekfnerifnei@nfewnfiewn.de even though in actuality my details have not been updated yet.
<img width="788" alt="Screenshot 2021-05-05 at 17 03 52" src="https://user-images.githubusercontent.com/7116819/117172661-ebba1180-adc3-11eb-8050-5fff00699bec.png">


This PR aims to fix that problem, and also adds tests to verify that if there's been an error, the user's old/current email is displayed.