### PR TITLE
Use `heading_level` param instead of `is_page_heading`

### DIFF
--- a/app/views/edit_consent/cookie.html.erb
+++ b/app/views/edit_consent/cookie.html.erb
@@ -26,7 +26,7 @@
     name: "cookie_consent",
     heading: t('account.manage.change_cookies.title'),
     heading_size: "l",
-    is_page_heading: true,
+    heading_level: 1,
     description: description,
     items: [
       {

--- a/app/views/edit_consent/feedback.html.erb
+++ b/app/views/edit_consent/feedback.html.erb
@@ -26,7 +26,7 @@
     name: "feedback_consent",
     heading: t("account.manage.change_feedback.title"),
     heading_size: "l",
-    is_page_heading: true,
+    heading_level: 1,
     description: description,
     items: [
       {


### PR DESCRIPTION
The account manager uses the radio component with the `is_page_heading` option in a few places. 
The radio component is [being refactored](https://github.com/alphagov/govuk_publishing_components/pull/2051) to remove the `is_page_heading` parameter in favour of using `heading_level` and/or `heading_size` to achieve the same result. 

In this case, `is_page_heading: true` can simply be swapped for `heading_level: 1` without causing any visual changes.

Relevant issue: https://github.com/alphagov/govuk_publishing_components/issues/1953