### PR TITLE
Don't throw an error if no scopes are passed

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -11,7 +11,7 @@ Doorkeeper.configure do
   resource_owner_authenticator do
     required_level_of_authentication =
       LevelOfAuthentication.select_highest_level(
-        request.params[:scope].split(" ").select { |scope| scope.starts_with?("level") },
+        request.params.fetch(:scope, "").split(" ").select { |scope| scope.starts_with?("level") },
       )
 
     if current_user


### PR DESCRIPTION
This won't happen legitimately, as the account-api passes some default
scopes (and a user who auths with no scopes can't do anything anyway),
but it can happen if someone is tampering with the URL.