### PR TITLE
Always show the Transition Checker service card

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -1,9 +1,5 @@
 class AccountController < ApplicationController
   before_action :authenticate_user!
 
-  def show
-    @user_info = Rails.cache.fetch("remote_user_info/#{current_user.id}", expires_in: 5.minutes) do
-      RemoteUserInfo.call(current_user)
-    end
-  end
+  def show; end
 end

--- a/app/views/account/show.html.erb
+++ b/app/views/account/show.html.erb
@@ -27,42 +27,27 @@
   </p>
 <% end %>
 
-<% if @user_info && @user_info[:transition_checker_state] %>
-  <div class="accounts-panel">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("account.your_account.transition.heading"),
-      heading_level: 2,
-      font_size: "m",
-      margin_bottom: 4,
-    } %>
+<div class="accounts-panel">
+  <%= render "govuk_publishing_components/components/heading", {
+    text: t("account.your_account.transition.heading"),
+    heading_level: 2,
+    font_size: "m",
+    margin_bottom: 4,
+  } %>
 
-    <p class="govuk-body"><%= t("account.your_account.transition.description") %></p>
+  <p class="govuk-body"><%= t("account.your_account.transition.description") %></p>
 
-    <p class="govuk-body govuk-!-margin-0">
-      <a href="<%= transition_checker_path %>/saved-results" class="govuk-link" data-module="gem-track-click" data-track-category="account-manage" data-track-action="your-account" data-track-label="see-results">
-        <%= sanitize(t("account.your_account.transition.link1")) %>
-      </a>
-    </p>
-    <p class="govuk-body"><%= t("account.your_account.transition.link1_description") %></p>
+  <p class="govuk-body govuk-!-margin-0">
+    <a href="<%= transition_checker_path %>/saved-results" class="govuk-link" data-module="gem-track-click" data-track-category="account-manage" data-track-action="your-account" data-track-label="see-results">
+      <%= sanitize(t("account.your_account.transition.link1")) %>
+    </a>
+  </p>
+  <p class="govuk-body"><%= t("account.your_account.transition.link1_description") %></p>
 
-    <p class="govuk-body govuk-!-margin-0">
-      <a href="<%= transition_checker_path %>/edit-saved-results" class="govuk-link" data-module="gem-track-click" data-track-category="account-manage" data-track-action="your-account" data-track-label="update-results">
-        <%= t("account.your_account.transition.link2") %>
-      </a>
-    </p>
-    <p class="govuk-body"><%= t("account.your_account.transition.link2_description") %></p>
-  </div>
-<% else %>
-  <div class="accounts-panel">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("account.your_account.account_not_used.heading"),
-      heading_level: 2,
-      font_size: "m",
-      margin_bottom: 4,
-    } %>
-
-    <p class="govuk-body"><%= t("account.your_account.account_not_used.description") %></p>
-
-    <p class="govuk-body"><%= sanitize(t("account.your_account.account_not_used.action", link: link_to(t("account.your_account.account_not_used.link_text"), "#{transition_checker_path.to_s}/edit-saved-results", html_options = { class: "govuk-link"} ))) %></p>
-  </div>
-<% end %>
+  <p class="govuk-body govuk-!-margin-0">
+    <a href="<%= transition_checker_path %>/edit-saved-results" class="govuk-link" data-module="gem-track-click" data-track-category="account-manage" data-track-action="your-account" data-track-label="update-results">
+      <%= t("account.your_account.transition.link2") %>
+    </a>
+  </p>
+  <p class="govuk-body"><%= t("account.your_account.transition.link2_description") %></p>
+</div>

--- a/config/locales/account/your_account.en.yml
+++ b/config/locales/account/your_account.en.yml
@@ -2,11 +2,6 @@
 en:
   account:
     your_account:
-      account_not_used:
-        action: "%{link} to start getting the most out of your account."
-        description: GOV.UK accounts are designed to make it easier for you to use online government services. At the moment you can only use your account with the Brexit checker.
-        heading: You have not used your account to access any services yet
-        link_text: Answer the questions in the Brexit checker
       heading: Your GOV.UK account
       transition:
         description: A personalised list of Brexit actions for you, your family and your business.

--- a/spec/requests/account_spec.rb
+++ b/spec/requests/account_spec.rb
@@ -1,46 +1,13 @@
 require "spec_helper"
 
 RSpec.describe "/account" do
-  let!(:application) do
-    FactoryBot.create(
-      :oauth_application,
-      name: "Transition Checker",
-      redirect_uri: "https://www.gov.uk/transition-checker/login/callback",
-      scopes: [],
-    )
-  end
-
   let(:user) { FactoryBot.create(:user) }
 
-  let(:userinfo) { {} }
+  before { sign_in user }
 
-  before do
-    sign_in user
+  it "shows the service card" do
+    get user_root_path
 
-    stub_request(:get, "http://attribute-service/oidc/user_info").to_return(body: userinfo.to_json)
-  end
-
-  around do |example|
-    ClimateControl.modify(ATTRIBUTE_SERVICE_URL: "http://attribute-service") do
-      example.run
-    end
-  end
-
-  context "without any states" do
-    it "shows the zero state service card" do
-      get user_root_path
-
-      expect(response.body).to have_content(I18n.t("account.your_account.account_not_used.heading"))
-    end
-  end
-
-  context "with transition checker state" do
-    let(:userinfo) { { transition_checker_state: { timestamp: 42 } } }
-
-    it "shows the service card" do
-      get user_root_path
-
-      expect(response.body).to have_content(I18n.t("account.your_account.transition.heading"))
-    end
+    expect(response.body).to have_content(I18n.t("account.your_account.transition.heading"))
   end
 end


### PR DESCRIPTION
We don't need to check if the user has used the Transition Checker,
because you can't sign up without going via it.

We are going to launch another experiment, the save-a-page experiment,
but for that we'll be designing and building a separate "your account"
style page on GOV.UK itself, and retiring this page.

Removing this conditionality here will make this page faster to load,
reduce requests to the Attribute Service, and make it easier to
migrate the `transition_checker_state` attribute from the Attribute
Service and into the Account API (though that's unlikely to get done
before we retire this page anyway).