### PR TITLE
Revert "Always show the Transition Checker service card"

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -1,5 +1,9 @@
 class AccountController < ApplicationController
   before_action :authenticate_user!
 
-  def show; end
+  def show
+    @user_info = Rails.cache.fetch("remote_user_info/#{current_user.id}", expires_in: 5.minutes) do
+      RemoteUserInfo.call(current_user)
+    end
+  end
 end

--- a/app/views/account/show.html.erb
+++ b/app/views/account/show.html.erb
@@ -27,27 +27,42 @@
   </p>
 <% end %>
 
-<div class="accounts-panel">
-  <%= render "govuk_publishing_components/components/heading", {
-    text: t("account.your_account.transition.heading"),
-    heading_level: 2,
-    font_size: "m",
-    margin_bottom: 4,
-  } %>
+<% if @user_info && @user_info[:transition_checker_state] %>
+  <div class="accounts-panel">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("account.your_account.transition.heading"),
+      heading_level: 2,
+      font_size: "m",
+      margin_bottom: 4,
+    } %>
 
-  <p class="govuk-body"><%= t("account.your_account.transition.description") %></p>
+    <p class="govuk-body"><%= t("account.your_account.transition.description") %></p>
 
-  <p class="govuk-body govuk-!-margin-0">
-    <a href="<%= transition_checker_path %>/saved-results" class="govuk-link" data-module="gem-track-click" data-track-category="account-manage" data-track-action="your-account" data-track-label="see-results">
-      <%= sanitize(t("account.your_account.transition.link1")) %>
-    </a>
-  </p>
-  <p class="govuk-body"><%= t("account.your_account.transition.link1_description") %></p>
+    <p class="govuk-body govuk-!-margin-0">
+      <a href="<%= transition_checker_path %>/saved-results" class="govuk-link" data-module="gem-track-click" data-track-category="account-manage" data-track-action="your-account" data-track-label="see-results">
+        <%= sanitize(t("account.your_account.transition.link1")) %>
+      </a>
+    </p>
+    <p class="govuk-body"><%= t("account.your_account.transition.link1_description") %></p>
 
-  <p class="govuk-body govuk-!-margin-0">
-    <a href="<%= transition_checker_path %>/edit-saved-results" class="govuk-link" data-module="gem-track-click" data-track-category="account-manage" data-track-action="your-account" data-track-label="update-results">
-      <%= t("account.your_account.transition.link2") %>
-    </a>
-  </p>
-  <p class="govuk-body"><%= t("account.your_account.transition.link2_description") %></p>
-</div>
+    <p class="govuk-body govuk-!-margin-0">
+      <a href="<%= transition_checker_path %>/edit-saved-results" class="govuk-link" data-module="gem-track-click" data-track-category="account-manage" data-track-action="your-account" data-track-label="update-results">
+        <%= t("account.your_account.transition.link2") %>
+      </a>
+    </p>
+    <p class="govuk-body"><%= t("account.your_account.transition.link2_description") %></p>
+  </div>
+<% else %>
+  <div class="accounts-panel">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("account.your_account.account_not_used.heading"),
+      heading_level: 2,
+      font_size: "m",
+      margin_bottom: 4,
+    } %>
+
+    <p class="govuk-body"><%= t("account.your_account.account_not_used.description") %></p>
+
+    <p class="govuk-body"><%= sanitize(t("account.your_account.account_not_used.action", link: link_to(t("account.your_account.account_not_used.link_text"), "#{transition_checker_path.to_s}/edit-saved-results", html_options = { class: "govuk-link"} ))) %></p>
+  </div>
+<% end %>

--- a/config/locales/account/your_account.en.yml
+++ b/config/locales/account/your_account.en.yml
@@ -2,6 +2,11 @@
 en:
   account:
     your_account:
+      account_not_used:
+        action: "%{link} to start getting the most out of your account."
+        description: GOV.UK accounts are designed to make it easier for you to use online government services. At the moment you can only use your account with the Brexit checker.
+        heading: You have not used your account to access any services yet
+        link_text: Answer the questions in the Brexit checker
       heading: Your GOV.UK account
       transition:
         description: A personalised list of Brexit actions for you, your family and your business.

--- a/spec/requests/account_spec.rb
+++ b/spec/requests/account_spec.rb
@@ -1,13 +1,46 @@
 require "spec_helper"
 
 RSpec.describe "/account" do
+  let!(:application) do
+    FactoryBot.create(
+      :oauth_application,
+      name: "Transition Checker",
+      redirect_uri: "https://www.gov.uk/transition-checker/login/callback",
+      scopes: [],
+    )
+  end
+
   let(:user) { FactoryBot.create(:user) }
 
-  before { sign_in user }
+  let(:userinfo) { {} }
 
-  it "shows the service card" do
-    get user_root_path
+  before do
+    sign_in user
 
-    expect(response.body).to have_content(I18n.t("account.your_account.transition.heading"))
+    stub_request(:get, "http://attribute-service/oidc/user_info").to_return(body: userinfo.to_json)
+  end
+
+  around do |example|
+    ClimateControl.modify(ATTRIBUTE_SERVICE_URL: "http://attribute-service") do
+      example.run
+    end
+  end
+
+  context "without any states" do
+    it "shows the zero state service card" do
+      get user_root_path
+
+      expect(response.body).to have_content(I18n.t("account.your_account.account_not_used.heading"))
+    end
+  end
+
+  context "with transition checker state" do
+    let(:userinfo) { { transition_checker_state: { timestamp: 42 } } }
+
+    it "shows the service card" do
+      get user_root_path
+
+      expect(response.body).to have_content(I18n.t("account.your_account.transition.heading"))
+    end
   end
 end


### PR DESCRIPTION
Reverts alphagov/govuk-account-manager-prototype#821

Whoops, I thought trying to register without going via the Checker told you off; but it's only *logging in to a non-existent account* which gives you a Checker-related error.