### PR TITLE
Add `email` to `hidden_scopes`

### DIFF
--- a/config/scopes.yml
+++ b/config/scopes.yml
@@ -11,6 +11,7 @@ optional_scopes:
   - level1
 hidden_scopes:
   - openid
+  - email
   - transition_checker
   - level0
   - level1

--- a/spec/requests/oauth_authorization_spec.rb
+++ b/spec/requests/oauth_authorization_spec.rb
@@ -47,10 +47,10 @@ RSpec.describe "/oauth/authorize" do
   context "with a user logged in" do
     before { sign_in user }
 
-    it "asks for authorization to access the email address" do
+    it "does not ask for authorization to access the email address" do
       get authorization_endpoint_url(client: application, scope: "openid email transition_checker")
 
-      expect(response.body).to have_content(I18n.t("doorkeeper.scopes.email"))
+      expect(response.body).not_to have_content(I18n.t("doorkeeper.scopes.email"))
     end
 
     it "does not ask for authorization to access transition checker state" do


### PR DESCRIPTION
We're soon going to be requesting `email` scope from the account-api,
and don't want to prompt users for consent.

See also https://github.com/alphagov/account-api/pull/91

---

[Trello card](https://trello.com/c/lIDQNATi/813-implement-the-govuk-account-home-page)