### PR TITLE
Change /transition to /brexit

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -73,7 +73,7 @@ module ApplicationHelper
 
   def transition_path
     base_url = Rails.env.development? ? Plek.find("collections") : Plek.new.website_root
-    "#{base_url}/transition"
+    "#{base_url}/brexit"
   end
 
   def service_for(previous_url)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,7 +35,7 @@ en:
           track_action: coronavirusLinks
   - title: Brexit
     links:
-    - href: https://www.gov.uk/transition
+    - href: https://www.gov.uk/brexit
       text: Check how the new rules affect you
       attributes:
         data:


### PR DESCRIPTION
The page is being redirected.  Currently /brexit redirects to
/transition, so there's no harm in making this change now.