### PR TITLE
Tweak sign in & sign up page content

### DIFF
--- a/app/views/registrations/start.html.erb
+++ b/app/views/registrations/start.html.erb
@@ -15,6 +15,11 @@
     margin_bottom: 3,
   } %>
 
+  <%= sanitize(t("account_confusion.this_is_a_trial")) %>
+  <%= render "govuk_publishing_components/components/inset_text", {
+    text: t("account_confusion.other_government_accounts")
+  } %>
+
   <%= render "govuk_publishing_components/components/input", {
     label: {
       text: t("devise.registrations.start.fields.email.label"),

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -76,3 +76,5 @@
 </div>
 
 <%= sanitize(t("devise.sessions.new.reset_password", reset_password: reset_password_path)) %>
+
+<%= sanitize(t("devise.sessions.new.register", register: new_user_registration_start_path)) %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -10,6 +10,11 @@
   margin_bottom: 3,
 } %>
 
+<%= sanitize(t("account_confusion.this_is_a_trial")) %>
+<%= render "govuk_publishing_components/components/inset_text", {
+  text: t("account_confusion.other_government_accounts")
+} %>
+
 <div data-module="gem-track-click">
   <%= form_with url: new_user_session_path, html: { "data-module" => "explicit-cross-domain-links" } do %>
     <% if resource %>

--- a/config/locales/account/login.en.yml
+++ b/config/locales/account/login.en.yml
@@ -28,8 +28,8 @@ en:
         heading: Sign in to your GOV.UK account
         meta_description: Sign in to your GOV.UK account. GOV.UK accounts are a trial. At the moment you can only use the GOV.UK account with the Brexit checker.
         page_title: Sign in
-        register: <p class="govuk-body">You can <a class="govuk-link" href="%{register}">sign up for a new account</a> if this is your first visit.</p>
-        reset_password: <p class="govuk-body govuk-!-margin-bottom-0">You can <a class="govuk-link" href="%{reset_password}">change your password</a> if you’ve forgotten it.</p>
+        register: <p class="govuk-body"><a class="govuk-link" href="%{register}">Create a GOV.UK account</a> if you do not have one.</p>
+        reset_password: <p class="govuk-body">You can <a class="govuk-link" href="%{reset_password}">change your password</a> if you’ve forgotten it.</p>
     unlocks:
       heading: Resend unlock instructions to unlock your GOV.UK account
       label: Enter your email

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,10 @@
 ---
 en:
+  account_confusion:
+    other_government_accounts: GOV.UK accounts are separate from other government accounts (for example your personal tax account or Government Gateway).
+    this_is_a_trial: |
+      <p class="govuk-body">We’re still building GOV.UK accounts.</p>
+      <p class="govuk-body">At the moment you can only use GOV.UK accounts to save your <a class="govuk-link" href="https://www.gov.uk/transition-check/questions">Brexit checker</a> results.</p>
   cookie_banner:
     confirmation_message: You have accepted cookies.
     cookie_preferences_text: How GOV.UK accounts use cookies


### PR DESCRIPTION
Sign in page:

<img width="740" alt="Screenshot 2021-06-04 at 13 43 40" src="https://user-images.githubusercontent.com/75235/120803099-1cb07200-c53b-11eb-8a7b-a4d0ce20ec0c.png">

Sign up page:

<img width="748" alt="Screenshot 2021-06-04 at 13 38 09" src="https://user-images.githubusercontent.com/75235/120803116-21752600-c53b-11eb-81d2-7748708c8ff1.png">

---

[Trello card](https://trello.com/c/J6CSzns0/816-explain-what-the-account-is-for-on-sign-in-and-create-an-account-pages)