### PR TITLE
Tweak account confusion content again

### DIFF
--- a/app/views/registrations/start.html.erb
+++ b/app/views/registrations/start.html.erb
@@ -15,9 +15,9 @@
     margin_bottom: 3,
   } %>
 
-  <%= sanitize(t("account_confusion.this_is_a_trial")) %>
+  <%= sanitize(t("devise.registrations.account_confusion.this_is_a_trial")) %>
   <%= render "govuk_publishing_components/components/inset_text", {
-    text: t("account_confusion.other_government_accounts")
+    text: t("devise.registrations.account_confusion.other_government_accounts")
   } %>
 
   <%= render "govuk_publishing_components/components/input", {

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -10,9 +10,9 @@
   margin_bottom: 3,
 } %>
 
-<%= sanitize(t("account_confusion.this_is_a_trial")) %>
+<%= sanitize(t("devise.sessions.account_confusion.this_is_a_trial")) %>
 <%= render "govuk_publishing_components/components/inset_text", {
-  text: t("account_confusion.other_government_accounts")
+  text: t("devise.sessions.account_confusion.other_government_accounts")
 } %>
 
 <div data-module="gem-track-click">

--- a/config/locales/account/login.en.yml
+++ b/config/locales/account/login.en.yml
@@ -14,6 +14,11 @@ en:
       failure: Could not authenticate you from %{kind} because "%{reason}".
       success: Successfully authenticated from %{kind} account.
     sessions:
+      account_confusion:
+        other_government_accounts: You cannot use this to sign in to other government accounts, for example your personal tax account or Government Gateway.
+        this_is_a_trial: |
+          <p class="govuk-body">We’re still building GOV.UK accounts.</p>
+          <p class="govuk-body">At the moment you can only use GOV.UK accounts to return to your <a class="govuk-link" href="https://www.gov.uk/transition-check/questions">Brexit checker</a> results.</p>
       already_signed_out: Signed out successfully.
       new:
         fields:

--- a/config/locales/account/registration.en.yml
+++ b/config/locales/account/registration.en.yml
@@ -2,6 +2,11 @@
 en:
   devise:
     registrations:
+      account_confusion:
+        other_government_accounts: This is separate from other government accounts, for example your personal tax account or Government Gateway.
+        this_is_a_trial: |
+          <p class="govuk-body">We’re still building GOV.UK accounts.</p>
+          <p class="govuk-body">At the moment you can only use GOV.UK accounts to save your <a class="govuk-link" href="https://www.gov.uk/transition-check/questions">Brexit checker</a> results.</p>
       destroyed: Bye! Your account has been successfully cancelled. We hope to see you again soon.
       start:
         checker_inset_text: If you do not have a mobile phone, you can still get %{link}.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,10 +1,5 @@
 ---
 en:
-  account_confusion:
-    other_government_accounts: GOV.UK accounts are separate from other government accounts (for example your personal tax account or Government Gateway).
-    this_is_a_trial: |
-      <p class="govuk-body">We’re still building GOV.UK accounts.</p>
-      <p class="govuk-body">At the moment you can only use GOV.UK accounts to save your <a class="govuk-link" href="https://www.gov.uk/transition-check/questions">Brexit checker</a> results.</p>
   cookie_banner:
     confirmation_message: You have accepted cookies.
     cookie_preferences_text: How GOV.UK accounts use cookies


### PR DESCRIPTION
The inset text has changed and the sign in page now says "to return
to" instead of "to save".

<img width="805" alt="Screenshot 2021-06-07 at 10 19 47" src="https://user-images.githubusercontent.com/75235/120992028-1956f980-c77a-11eb-84e5-93c57c40e042.png">

<img width="758" alt="Screenshot 2021-06-07 at 10 20 11" src="https://user-images.githubusercontent.com/75235/120992042-1e1bad80-c77a-11eb-8f77-db0feb6b08ed.png">

---

[Trello card](https://trello.com/c/J6CSzns0/816-explain-what-the-account-is-for-on-sign-in-and-create-an-account-pages)