### PR TITLE
Switch to new Design System link styles

### DIFF
--- a/app/assets/stylesheets/accounts.scss
+++ b/app/assets/stylesheets/accounts.scss
@@ -39,7 +39,6 @@ $_current-indicator-width: 4px;
 
   &:not(:focus):hover {
     color: $govuk-link-colour;
-    text-decoration: underline;
   }
 }
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,3 +1,5 @@
+$govuk-new-link-styles: true;
+
 @import "govuk_publishing_components/govuk_frontend_support";
 @import "govuk_publishing_components/component_support";
 @import "govuk_publishing_components/components/back-link";


### PR DESCRIPTION
The new DS link styles are being rolled out across GOVUK. 
We've
already applied the new styles to the individual components in the components gem, so the next step is to switch the flag on in the frontend apps themselves.
This sets `$govuk-new-link-styles` to `true`, which enables the new styles on the account manager prototype.

# Visual changes

## Regular link before


https://user-images.githubusercontent.com/7116819/121034417-ebd37580-c7a4-11eb-8579-9c08b4496f0d.mov

## Regular link after


https://user-images.githubusercontent.com/7116819/121034395-e70ec180-c7a4-11eb-8d50-924f2819d405.mov

## Account menu link before

https://user-images.githubusercontent.com/7116819/121034423-ed04a280-c7a4-11eb-8f6d-8e115fb45b8f.mov

## Account menu link after


https://user-images.githubusercontent.com/7116819/121034431-ee35cf80-c7a4-11eb-83fd-469c8547a1c8.mov
