### PR TITLE
Add query params to new-account link

### DIFF
--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -77,4 +77,6 @@
 
 <%= sanitize(t("devise.sessions.new.reset_password", reset_password: reset_password_path)) %>
 
-<%= sanitize(t("devise.sessions.new.register", register: new_user_registration_start_path)) %>
+<%= sanitize(t("devise.sessions.new.register", register: new_user_registration_start_path(
+    previous_url: params[:previous_url],
+    authenticate_to_level: params[:authenticate_to_level]))) %>


### PR DESCRIPTION
When moving between the login & sign-up journeys we need to preserve
the `previous_url` and `authenticate_to_level` params; otherwise we
won't send the user back to the right place or authenticate them at
the right level.