### PR TITLE
Add rate limiting to all sign-in and new-account POSTs & drop period

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,8 +1,15 @@
-LIMIT_LOGIN_ATTEMPTS_PER_IP = 16
+RATE_LIMIT_COUNT = 16
+RATE_LIMIT_PERIOD = 1.minute
 
-Rack::Attack.throttle("limit login attempts per IP", limit: LIMIT_LOGIN_ATTEMPTS_PER_IP, period: 1.hour) do |request|
-  if request.path == "/sign-in" && request.post?
-    request.env["action_dispatch.remote_ip"].to_s
+Rack::Attack.throttle("limit /sign-in* attempts per IP", limit: RATE_LIMIT_COUNT, period: RATE_LIMIT_PERIOD) do |request|
+  if request.path.is_a?(String) && request.path.start_with?("/sign-in") && request.post?
+    "#{request.path} #{request.env['action_dispatch.remote_ip']}"
+  end
+end
+
+Rack::Attack.throttle("limit /new-account* attempts per IP", limit: RATE_LIMIT_COUNT, period: RATE_LIMIT_PERIOD) do |request|
+  if request.path.is_a?(String) && request.path.start_with?("/new-account") && request.post?
+    "#{request.path} #{request.env['action_dispatch.remote_ip']}"
   end
 end
 

--- a/spec/requests/throttling_spec.rb
+++ b/spec/requests/throttling_spec.rb
@@ -8,9 +8,33 @@ RSpec.describe "Throttling" do
     Rack::Attack.enabled = false
   end
 
-  context "POST /sign-in" do
+  context "GET sign-in" do
+    it "doesn't throttle" do
+      (RATE_LIMIT_COUNT + 1).times { get new_user_session_path }
+      expect(response).to_not have_http_status(429)
+      expect(response.body).to_not have_content(I18n.t("standard_errors.too_many_requests.heading"))
+    end
+  end
+
+  context "POST sign-in" do
     it "throttles" do
-      (LIMIT_LOGIN_ATTEMPTS_PER_IP + 1).times { post new_user_session_path, params: { "user[email]" => "email@example.com" } }
+      (RATE_LIMIT_COUNT + 1).times { post new_user_session_path }
+      expect(response).to have_http_status(429)
+      expect(response.body).to have_content(I18n.t("standard_errors.too_many_requests.heading"))
+    end
+  end
+
+  context "GET new-account" do
+    it "doesn't throttle" do
+      (RATE_LIMIT_COUNT + 1).times { get new_user_registration_start_path }
+      expect(response).to_not have_http_status(429)
+      expect(response.body).to_not have_content(I18n.t("standard_errors.too_many_requests.heading"))
+    end
+  end
+
+  context "POST new-account" do
+    it "throttles" do
+      (RATE_LIMIT_COUNT + 1).times { post new_user_registration_phone_verify_path }
       expect(response).to have_http_status(429)
       expect(response.body).to have_content(I18n.t("standard_errors.too_many_requests.heading"))
     end


### PR DESCRIPTION
The new rate limit is 16 POST requests from the same IP to the same
path in a minute.