### PR TITLE
Move flash alerts to manage page

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -17,7 +17,7 @@ class ConfirmationsController < Devise::ConfirmationsController
         record_security_event(SecurityActivity::EMAIL_CHANGED, user: resource, notes: "to #{resource.email}")
       elsif resource.errors.details[:email].first&.dig(:error) == :already_confirmed
         if current_user
-          redirect_to user_root_path
+          redirect_to account_manage_path
         else
           redirect_to "/", flash: { notice: I18n.t("errors.messages.already_confirmed") }
         end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -210,7 +210,6 @@ class RegistrationsController < Devise::RegistrationsController
   # from https://github.com/heartcombo/devise/blob/f5cc775a5feea51355036175994edbcb5e6af13c/app/controllers/devise/registrations_controller.rb#L46
   def update
     self.resource = resource_class.to_adapter.get!(send(:"current_#{resource_name}").to_key)
-    prev_unconfirmed_email = resource.unconfirmed_email if resource.respond_to?(:unconfirmed_email)
 
     @old_email = resource.email
 
@@ -240,7 +239,6 @@ class RegistrationsController < Devise::RegistrationsController
 
       resource.update!(banned_password_match: false) if new_password
 
-      set_flash_message_for_update(resource, prev_unconfirmed_email)
       bypass_sign_in resource, scope: resource_name if sign_in_after_change_password?
 
       if new_email
@@ -253,7 +251,7 @@ class RegistrationsController < Devise::RegistrationsController
         respond_with resource, location: confirmation_email_sent_path
       else
         flash[:notice] = I18n.t("devise.registrations.edit.success")
-        redirect_to :user_root
+        redirect_to account_manage_path
       end
     else
       clean_up_passwords resource

--- a/app/controllers/unlocks_controller.rb
+++ b/app/controllers/unlocks_controller.rb
@@ -4,7 +4,7 @@ class UnlocksController < Devise::UnlocksController
     super do
       if resource.errors.details[:email].first&.dig(:error) == :not_locked
         if current_user
-          redirect_to user_root_path
+          redirect_to account_manage_path
         else
           redirect_to new_user_session_path, flash: { notice: I18n.t("errors.messages.not_locked") }
         end

--- a/app/helpers/manage_helper.rb
+++ b/app/helpers/manage_helper.rb
@@ -49,4 +49,10 @@ module ManageHelper
 
     [email, password, current_user.phone ? phone : nil].compact
   end
+
+  def flash_as_notice(notice)
+    [
+      I18n.t("devise.registrations.update_needs_confirmation"),
+    ].include? notice
+  end
 end

--- a/app/views/account/show.html.erb
+++ b/app/views/account/show.html.erb
@@ -7,6 +7,7 @@
 <%= render "user-reminders" %>
 
 <% if flash[:notice] %>
+  <% GovukError.notify("unexpected flash message on account home page: #{flash[:notice]}") %>
   <% if flash_as_notice(flash[:notice]) %>
     <%= render "govuk_publishing_components/components/notice", { description_text: flash[:notice] } %>
   <% else %>


### PR DESCRIPTION
We're moving the "your account" page onto GOV.UK, and don't want to
have to figure out cross-app flash messages just yet.

I've removed the `set_flash_message_for_update`, as that was only used
to show the flash for when you've changed your email address; but we
have a separate banner for that.

I've also changed the view to report an error to Sentry if it gets a
flash message, which will help us track down any others.

---

[Trello card](https://trello.com/c/a89ztkY5/855-move-flash-messages-from-your-account-page-to-manage-page)