### PR TITLE
Show the confirmation success flash on the account manage page

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -40,10 +40,13 @@ class ConfirmationsController < Devise::ConfirmationsController
   end
 
   def after_resending_confirmation_instructions_path_for(_resource_name)
+    flash.discard
+
     session[:confirmations] = {
       email: resource.unconfirmed_email || resource.email,
       user_is_confirmed: resource.confirmed?,
     }
+
     confirmation_email_sent_path
   end
 end

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -31,9 +31,9 @@ class ConfirmationsController < Devise::ConfirmationsController
     @email = current_user&.unconfirmed_email || current_user&.email
   end
 
-  def after_confirmation_path_for(resource_name, resource)
+  def after_confirmation_path_for(resource_name, _resource)
     if signed_in?(resource_name)
-      signed_in_root_path(resource)
+      account_manage_path
     else
       new_session_path(resource_name, from_confirmation_email: true)
     end


### PR DESCRIPTION
We could do away with this flash entirely, as when the email address
is confirmed the "you need to confirm your address" banner will go
away, but that's not really as obvious as a big success box.

---

[Trello card](https://trello.com/c/a89ztkY5/855-move-flash-messages-from-your-account-page-to-manage-page)