### PR TITLE
Change transition checker subscription endpoints so we can start to migrate data

### DIFF
--- a/app/models/email_subscription.rb
+++ b/app/models/email_subscription.rb
@@ -4,6 +4,7 @@ class EmailSubscription < ApplicationRecord
   before_destroy :deactivate_immediately
 
   def reactivate_if_confirmed
+    return if migrated_to_account_api
     return unless user.confirmed?
 
     deactivate_immediately

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -128,6 +128,7 @@ Rails.application.routes.draw do
       scope "transition-checker", module: :transition_checker, as: :transition_checker do
         get "/email-subscription", to: "emails#show"
         post "/email-subscription", to: "emails#update"
+        delete "/email-subscription", to: "emails#destroy"
       end
 
       namespace :report do

--- a/db/migrate/20210702085832_add_migrated_to_account_api_to_subscriptions.rb
+++ b/db/migrate/20210702085832_add_migrated_to_account_api_to_subscriptions.rb
@@ -1,0 +1,5 @@
+class AddMigratedToAccountApiToSubscriptions < ActiveRecord::Migration[6.0]
+  def change
+    add_column :email_subscriptions, :migrated_to_account_api, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_05_141533) do
+ActiveRecord::Schema.define(version: 2021_07_02_085832) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -36,6 +36,7 @@ ActiveRecord::Schema.define(version: 2021_05_05_141533) do
     t.bigint "user_id", null: false
     t.string "topic_slug", null: false
     t.string "subscription_id"
+    t.boolean "migrated_to_account_api", default: false, null: false
     t.index ["user_id"], name: "index_email_subscriptions_on_user_id"
   end
 


### PR DESCRIPTION
This PR makes the `show` and `update` endpoints return the subscription details in the form

```json
{
    "topic_slug": "email-topic-slug",
    "subscription_id": "aaa-bbb-ccc",
}
```

This involves changing the response codes from 204 (no content) to 200, but that's fine because we consider both of those successes: https://github.com/alphagov/account-api/blob/main/app/lib/oidc_client.rb#L136 https://github.com/alphagov/account-api/blob/main/app/lib/oidc_client.rb#L151

This PR also adds a `delete` endpoint which marks a subscription as *migrated to account-api*.  When migrated, the other endpoints treat it as if it doesn't exist, and it won't be updated if the user changes their email address.

The path to migration will be something like this:

1. Change the get-transition-checker-subscription endpoint in account-api to:
   - If the data is present in its database, return that
   - Otherwise, fetch the data from acount-manager, mark it as migrated, and store the data in its database
2. Change the set-transition-checker-subscription endpoint in account-api to:
   - If the data is present in its database, update that
   - Otherwise, update the data in account-manager, mark it as migrated, and store the data in its database

When we switch off the JWT stuff, which we plan to do as soon as email signups have been removed from the registration journey, the account-api will become the only path to sign up for transition checker notifications.  So new data will only be created there, and old data will be gradually pulled across as people check or update their subscriptions.

We'll also need to do a bulk import of older data at some point, for those users who haven't returned in a while.