### PR TITLE
Add interest cohort permissions policy test

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -40,6 +40,9 @@ module GovukAccountManagerPrototype
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
     config.action_dispatch.default_headers["X-Frame-Options"] = "DENY"
 
+    # Add permissions policy to opt out of FLoC
+    config.action_dispatch.default_headers["Permissions-Policy"] = "interest-cohort=()"
+
     # GOV.UK convention is to use lib over app/lib
     config.autoload_paths << "lib"
 

--- a/spec/requests/welcome_spec.rb
+++ b/spec/requests/welcome_spec.rb
@@ -1,4 +1,9 @@
 RSpec.describe "welcome" do
+  it "presents the permissions-policy header" do
+    get welcome_path
+    expect(response.headers["Permissions-Policy"]).to eq("interest-cohort=()")
+  end
+
   it "redirects to /sign-in" do
     get welcome_path
     expect(response).to redirect_to(new_user_session_path)


### PR DESCRIPTION
Add Permission-Policy header and set interest-cohort=().

This satisfies [RFC 142](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-142-add-interest-cohort-permssion-policy-header.md). The account manager prototype is hosted on the PaaS and the suggestion is to set the header in app because it's simpler than trying to set it in Cloudfront(which anecdotally requires a lambda to be set up).

When we upgrade to Rails 6.1, we could consider using the [dedicated DSL](https://github.com/rails/rails/blob/v6.1.0/actionpack/CHANGELOG.md#rails-610-december-09-2020) to configure Permissions-Policy.