### PR TITLE
Add an endpoint to migrate users to account-api

### DIFF
--- a/app/controllers/api/v1/migrate_users_to_account_api_controller.rb
+++ b/app/controllers/api/v1/migrate_users_to_account_api_controller.rb
@@ -1,0 +1,45 @@
+class Api::V1::MigrateUsersToAccountApiController < Doorkeeper::ApplicationController
+  PAGE_SIZE = 100
+
+  before_action -> { doorkeeper_authorize! :migrate_users }
+
+  respond_to :json
+
+  rescue_from ActionController::ParameterMissing do
+    head :bad_request
+  end
+
+  def process_batch
+    page = params.fetch(:page).to_i
+
+    batch = User.order(created_at: :asc).page(page).per(PAGE_SIZE)
+
+    render json: {
+      users: migrate_batch_of_users(batch),
+      is_last_page: batch.last_page?,
+    }
+  end
+
+private
+
+  def migrate_batch_of_users(batch)
+    batch.map do |user|
+      subject_identifier = Doorkeeper::OpenidConnect.configuration.subject.call(user, account_api).to_s
+      remote_user_info = RemoteUserInfo.call(user)
+      subscription = user.email_subscriptions.first
+
+      subscription.update!(migrated_to_account_api: true) if subscription
+
+      {
+        subject_identifier: subject_identifier,
+        transition_checker_state: remote_user_info[:transition_checker_state],
+        topic_slug: subscription&.topic_slug,
+        email_alert_api_subscription_id: subscription&.subscription_id,
+      }
+    end
+  end
+
+  def account_api
+    @account_api ||= Doorkeeper::Application.find_by(uid: ENV.fetch("ACCOUNT_API_DOORKEEPER_UID"))
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -121,6 +121,8 @@ Rails.application.routes.draw do
       get "/deanonymise-token", to: "deanonymise_token#show"
       get "/ephemeral-state", to: "ephemeral_state#show"
 
+      get "/migrate-users-to-account-api", to: "migrate_users_to_account_api#process_batch"
+
       scope "transition-checker", module: :transition_checker, as: :transition_checker do
         get "/email-subscription", to: "emails#show"
         post "/email-subscription", to: "emails#update"

--- a/config/scopes.yml
+++ b/config/scopes.yml
@@ -6,6 +6,7 @@ optional_scopes:
   - deanonymise_tokens
   - email
   - reporting_access
+  - migrate_users
   - transition_checker
   - level0
   - level1

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :user do
-    email { "email@example.com" }
+    sequence(:email) { |n| "email-#{n}@example.com" }
     password { "abcd1234" }
     phone { "+447958123456" }
 

--- a/spec/requests/api/v1/migrate_users_to_account_api_spec.rb
+++ b/spec/requests/api/v1/migrate_users_to_account_api_spec.rb
@@ -1,0 +1,73 @@
+RSpec.describe "/api/v1/migrate-users-to-account-api" do
+  let(:account_api_application) { FactoryBot.create(:oauth_application, name: "account-api") }
+  let(:attribute_service_url) { "https://attribute-service" }
+
+  around do |example|
+    ClimateControl.modify(ATTRIBUTE_SERVICE_URL: attribute_service_url, ACCOUNT_API_DOORKEEPER_UID: account_api_application.uid) do
+      example.run
+    end
+  end
+
+  let(:token) do
+    FactoryBot.create(
+      :oauth_access_token,
+      application_id: account_api_application.id,
+      scopes: %i[migrate_users],
+    )
+  end
+
+  let(:headers) do
+    {
+      Accept: "application/json",
+      Authorization: "Bearer #{token.token}",
+    }
+  end
+
+  let(:params) do
+    {
+      page: page,
+    }.compact
+  end
+
+  let(:page) { 1 }
+
+  before do
+    stub_request(:get, "#{attribute_service_url}/oidc/user_info")
+      .to_return(body: { transition_checker_state: { foo: "bar" } }.to_json)
+  end
+
+  it "returns a 200" do
+    get api_v1_migrate_users_to_account_api_path, params: params, headers: headers
+    expect(response).to be_successful
+  end
+
+  context "when there are more than PAGE_SIZE users" do
+    let!(:users) { FactoryBot.create_list(:user, Api::V1::MigrateUsersToAccountApiController::PAGE_SIZE + 1) }
+
+    it "returns users paginated by PAGE_SIZE" do
+      get api_v1_migrate_users_to_account_api_path, params: params, headers: headers
+      body = JSON.parse(response.body)
+      expect(body["users"].count).to eq(Api::V1::MigrateUsersToAccountApiController::PAGE_SIZE)
+      expect(body["is_last_page"]).to be(false)
+    end
+  end
+
+  context "when a user is subscribed to Transition Checker emails" do
+    let!(:user) { FactoryBot.create(:user) }
+    let!(:subscription) { FactoryBot.create(:email_subscription, user_id: user.id) }
+
+    it "marks the subscription as migrated" do
+      get api_v1_migrate_users_to_account_api_path, params: params, headers: headers
+      expect(subscription.reload.migrated_to_account_api).to be(true)
+    end
+  end
+
+  context "with the page missing" do
+    let(:page) { nil }
+
+    it "returns a 400" do
+      get api_v1_migrate_users_to_account_api_path, params: params, headers: headers
+      expect(response).to have_http_status(:bad_request)
+    end
+  end
+end


### PR DESCRIPTION
We'll add a rake task to account-api to call this and page through the
results, importing all the transition checker state & subscriptions.

Then we can:

- mark the transition checker state attribute as "local" in
account-api,
- remove the attribute from the attribute service,
- remove the subscription management logic from the account manager.

---

[Trello card](https://trello.com/c/4ulBaTFk/887-bulk-migrate-older-transition-checker-state-from-account-manager-to-account-api)