### PR TITLE
Update GOV.UK Account header link to link to new account home page

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -64,6 +64,7 @@
   <%= render "govuk_publishing_components/components/layout_header", {
     product_name: "Account",
     navigation_items: navigation_items,
+    logo_link: user_root_path,
     navigation_aria_label: "Account access",
   } %>
 


### PR DESCRIPTION
The "home" link in the header defaults to root so it was pointing to `account.publishing.service.gov.uk`. 

We want it to go to `gov.uk/account/home` instead since that's our new homepage.