### PR TITLE
Change "return" link on post-registration page to a button

### DIFF
--- a/app/controllers/redirect_to_previous_url_controller.rb
+++ b/app/controllers/redirect_to_previous_url_controller.rb
@@ -1,0 +1,5 @@
+class RedirectToPreviousUrlController < ApplicationController
+  def show
+    redirect_to after_sign_in_path_for(nil)
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -81,24 +81,6 @@ module ApplicationHelper
     "#{base_url}/brexit"
   end
 
-  def service_for(previous_url)
-    return unless previous_url&.start_with? oauth_authorization_path
-
-    bits = previous_url.split("?")
-    return unless bits.length > 1
-
-    querystring = CGI.parse(bits[1])
-    return unless querystring["client_id"]
-
-    app = Doorkeeper::Application.by_uid(querystring["client_id"].first)
-    return unless app
-
-    {
-      name: app.name,
-      url: previous_url,
-    }
-  end
-
   def footer_navigation
     navigation = []
     t("footer_sections").each do |section|

--- a/app/views/confirmations/sent.html.erb
+++ b/app/views/confirmations/sent.html.erb
@@ -1,5 +1,4 @@
 <% content_for :title, t("confirmation_sent.heading") %>
-<% service = service_for(params[:previous_url]) if @user_is_new %>
 
 <%= render "govuk_publishing_components/components/heading", {
   text: yield(:title),
@@ -30,17 +29,27 @@
   } %>
 <% end %>
 
-<p class="govuk-body" data-module="gem-track-click">
-  <% if service %>
-    <a class="govuk-link" href="<%= service[:url] %>" data-module="explicit-cross-domain-links" data-track-category="account-create" data-track-action="confirm-email" data-track-label="<%= service[:name] %>">
-      <%= t("confirmation_sent.continue_to_service", service_name: service[:name]) %>
-    </a>
-  <% else %>
+<% if @user_is_new && params[:previous_url]&.start_with?(oauth_authorization_path) %>
+  <%= form_tag redirect_to_previous_url_path, method: :post, :"data-module" => "explicit-cross-domain-links" do %>
+    <%= hidden_field_tag :previous_url, params[:previous_url] %>
+    <%= render "govuk_publishing_components/components/button", {
+      text: t("confirmation_sent.continue_to_service"),
+      data_attributes: {
+        module: "gem-track-click",
+        "track-category": "account-create",
+        "track-action": "confirm-email",
+        "track-label": "Brexit checker",
+      },
+      margin_bottom: 3,
+    } %>
+  <% end %>
+<% else %>
+  <p class="govuk-body" data-module="gem-track-click">
     <a class="govuk-link" href="<%= user_root_path %>" data-track-category="account-create" data-track-action="confirm-email" data-track-label="Account">
       <%= t("confirmation_sent.continue_to_account") %>
     </a>
-  <% end %>
-</p>
+  </p>
+<% end %>
 
 <%= render "govuk_publishing_components/components/heading", {
   text: t("confirmation_sent.re_register_subtitle"),

--- a/config/locales/account/confirmations.en.yml
+++ b/config/locales/account/confirmations.en.yml
@@ -7,7 +7,7 @@ en:
     link_text: Resend confirmation email
   confirmation_sent:
     continue_to_account: Go to your GOV.UK account
-    continue_to_service: Go back to %{service_name}
+    continue_to_service: Finish saving your Brexit checker results
     delay_consequence: You will be locked out of your account if you do not confirm your email address within 7 days.
     existing_user_instruction_list: |
       <ul class="govuk-list govuk-list--bullet">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -139,6 +139,8 @@ Rails.application.routes.draw do
     end
   end
 
+  post "/redirect-to-previous-url", to: "redirect_to_previous_url#show", as: :redirect_to_previous_url
+
   mount GovukPublishingComponents::Engine, at: "/component-guide" if Rails.env.development?
 
   use_doorkeeper

--- a/spec/feature/registration_from_another_application_spec.rb
+++ b/spec/feature/registration_from_another_application_spec.rb
@@ -125,7 +125,7 @@ RSpec.feature "Registration (coming from another application)" do
         register_without_mfa
 
         expect(page).to have_text(I18n.t("confirmation_sent.heading"))
-        expect(return_to_app_link(page)).to include("scope=openid+level0")
+        expect(return_to_app_url(page)).to include("scope=openid+level0")
       end
     end
 
@@ -137,15 +137,15 @@ RSpec.feature "Registration (coming from another application)" do
         register_with_mfa
 
         expect(page).to have_text(I18n.t("confirmation_sent.heading"))
-        expect(return_to_app_link(page)).to include("scope=openid+level1")
+        expect(return_to_app_url(page)).to include("scope=openid+level1")
       end
     end
   end
 
-  def return_to_app_link(page)
-    return_link_css_selector = ".govuk-link[data-module='explicit-cross-domain-links']"
+  def return_to_app_url(page)
+    url_input_css_selector = "form[data-module='explicit-cross-domain-links'] > input[type='hidden']"
     html = Nokogiri.parse(page.body)
-    html.css(return_link_css_selector).first.attributes["href"].value
+    html.css(url_input_css_selector).first.attributes["value"].value
   end
 
   def start_journey

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -56,32 +56,4 @@ RSpec.describe ApplicationHelper do
       expect(redacted_phone_number("+447958123456")).to eq("xxxxx xxx456")
     end
   end
-
-  describe "#service_for" do
-    let(:application) do
-      FactoryBot.create(
-        :oauth_application,
-        name: "Some Other Government Service",
-        redirect_uri: "https://www.gov.uk",
-        scopes: [],
-      )
-    end
-
-    it "extracts the service name using the client_id parameter" do
-      url = "#{oauth_authorization_path}?#{Rack::Utils.build_nested_query(client_id: application.uid)}"
-      expect(service_for(url)[:name]).to eq(application.name)
-    end
-
-    it "only produces a service name if the link looks like an OAuth content URL" do
-      url = "//nefarious-attempt-to-embed-an-arbitrary-link?#{Rack::Utils.build_nested_query(client_id: application.uid)}"
-      expect(service_for(url)).to be_nil
-    end
-
-    context "the client_id doesn't match an application" do
-      it "returns nil" do
-        url = "#{oauth_authorization_path}?#{Rack::Utils.build_nested_query(client_id: 'breadbread')}"
-        expect(service_for(url)).to be_nil
-      end
-    end
-  end
 end


### PR DESCRIPTION
I had to introduce a controller which just performs a redirect to the
previous URL, which is a bit awkward.  It can't just be a GET form
with action `previous_url` because `previous_url` has a querystring
and GET forms can't have a querystring in the action.

I also changed the `continue_to_service` text to not be generic.  We
only have one service using the account manager: GOV.UK.  When we end
up in Digital Auth land we'll still only be one app, so we should
start to get used to only having one piece of text.

---

<img width="1111" alt="Screenshot 2021-07-12 at 12 48 21" src="https://user-images.githubusercontent.com/75235/125282630-82003b80-e30f-11eb-8e35-83321b3d7c28.png">

---

[Trello card](https://trello.com/c/JuzRNvA4/832-remove-the-email-signup-from-the-transition-checker-registration-journey)