### PR TITLE
Update email confirmation reminder

### DIFF
--- a/app/assets/stylesheets/accounts.scss
+++ b/app/assets/stylesheets/accounts.scss
@@ -107,12 +107,6 @@ $_current-indicator-width: 4px;
   margin-bottom: govuk-spacing(7);
 }
 
-.user-reminder {
-  padding: govuk-spacing(3);
-  margin-bottom: govuk-spacing(7);
-  background: govuk-colour("light-grey");
-}
-
 .summary-list {
   @include govuk-font(19);
   @include govuk-clearfix;

--- a/app/views/application/_user-reminders.html.erb
+++ b/app/views/application/_user-reminders.html.erb
@@ -1,19 +1,21 @@
 <% if show_confirmation_reminder? %>
-  <section class="user-reminder" aria-label="Notice" role="region">
-    <p class="govuk-body govuk-!-margin-0">
+  <%= render "govuk_publishing_components/components/notice" do %>
+    <p class="govuk-body">
       <%= sanitize(t("confirm.intro.#{confirmation_banner_prompt_type}")) %>
+    </p>
+    <p class="govuk-body govuk-!-margin-bottom-0">
       <a href="<%= new_user_confirmation_path %>" class="govuk-link"><%= t("confirm.link_text") %></a>
     </p>
-  </section>
+  <% end %>
 <% end %>
 
 <% if current_user.banned_password_match %>
-  <section class="user-reminder" aria-label="Notice" role="region">
+  <%= render "govuk_publishing_components/components/notice" do %>
     <p class="govuk-body govuk-!-font-weight-bold">
       <%= t("insecure_password.notice.message") %>
     </p>
     <p class="govuk-body govuk-!-margin-bottom-0">
       <a href="<%= edit_user_password_path %>" class="govuk-link"><%= t("insecure_password.notice.link") %></a>
     </p>
-  </section>
+  <% end %>
 <% end %>

--- a/config/locales/account/confirmations.en.yml
+++ b/config/locales/account/confirmations.en.yml
@@ -2,9 +2,9 @@
 en:
   confirm:
     intro:
-      set_up: "<strong>Confirm your email address</strong> to finish setting up your account and email alerts."
+      set_up: "<strong>Confirm your email address</strong> to finish setting up your account and start getting email updates."
       update: "<strong>Confirm your email address</strong> to finish updating your account and email alerts."
-    link_text: Resend confirmation email
+    link_text: Send confirmation email again
   confirmation_sent:
     continue_to_account: Go to your GOV.UK account
     continue_to_service: Finish saving your Brexit checker results


### PR DESCRIPTION
This updates the email confirmation reminder notice to use the gov.uk [notice component](https://components.publishing.service.gov.uk/component-guide/notice) instead of the previously used grey banner. 
It also updates the copy to make it clearer for the user. This is another step in the efforts to [unbodge the Brexit checker](https://docs.google.com/document/d/1xRdT56CgAF__c_Yjzdy6UuR0LacXIt0EACRonEgbUiM/edit?ts=60eea456#) 😄.

### Before

<img width="652" alt="Screenshot 2021-07-14 at 16 07 33" src="https://user-images.githubusercontent.com/7116819/125646280-31b2c925-03cc-4880-8ad9-be0f5d8c1c06.png">

### After
<img width="654" alt="Screenshot 2021-07-14 at 16 06 50" src="https://user-images.githubusercontent.com/7116819/125646278-4bade001-ac47-405d-8f87-f74320de9da5.png">
