### PR TITLE
Change layout of confirmation page when signing up via a service

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -2,8 +2,9 @@ class ConfirmationsController < Devise::ConfirmationsController
   def sent
     if session[:confirmations]
       @email = session[:confirmations]["email"]
-      @user_is_confirmed = session[:confirmations].fetch("user_is_confirmed", false)
-      @user_is_new = session[:confirmations].fetch("user_is_new", false)
+      @user_is_confirmed = user_is_confirmed
+      @user_is_new = user_is_new
+      @returning_service = returning_service
       session.delete(:confirmations)
     else
       redirect_to "/"
@@ -48,5 +49,21 @@ class ConfirmationsController < Devise::ConfirmationsController
     }
 
     confirmation_email_sent_path
+  end
+
+private
+
+  def user_is_new
+    session[:confirmations].fetch("user_is_new", false)
+  end
+
+  def user_is_confirmed
+    session[:confirmations].fetch("user_is_confirmed", false)
+  end
+
+  def returning_service
+    return :brexit if params[:previous_url]&.start_with?(oauth_authorization_path)
+
+    :dashboard
   end
 end

--- a/app/views/confirmations/_sent/_confirm_change.html.erb
+++ b/app/views/confirmations/_sent/_confirm_change.html.erb
@@ -1,0 +1,31 @@
+<% content_for :title, t("confirmation_sent.heading.confirm_change") %>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: yield(:title),
+  heading_level: 1,
+  margin_bottom: 4,
+  font_size: "xl",
+} %>
+
+<%= sanitize(t("confirmation_sent.instructions.confirm_change.details.dashboard", email: email)) %>
+
+<% unless user_is_confirmed %>
+  <%= render "govuk_publishing_components/components/inset_text", {
+    text: t("confirmation_sent.delay_consequence")
+  } %>
+<% end %>
+
+<p class="govuk-body" data-module="gem-track-click">
+  <a class="govuk-link" href="<%= user_root_path %>" data-track-category="account-create" data-track-action="confirm-email" data-track-label="Account">
+    <%= t("confirmation_sent.continue_to.account") %>
+  </a>
+</p>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("confirmation_sent.help.heading"),
+  heading_level: 2,
+  margin_bottom: 3,
+  font_size: 19,
+} %>
+
+<%= sanitize(t("confirmation_sent.help.instructions.confirm_change", resend_confirmation_link: new_user_confirmation_path, retry_link: edit_user_registration_email_path, email: email)) %>

--- a/app/views/confirmations/_sent/_finish_creating.html.erb
+++ b/app/views/confirmations/_sent/_finish_creating.html.erb
@@ -1,0 +1,57 @@
+<% content_for :title, t("confirmation_sent.heading.finish_creating") %>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: yield(:title),
+  heading_level: 1,
+  margin_bottom: 4,
+  font_size: "xl",
+} %>
+
+<% if returning_service == :brexit %>
+  <p class="govuk-body"><%= t("confirmation_sent.instructions.finish_creating.must_continue") %></p>
+
+  <%= form_tag redirect_to_previous_url_path, method: :post, :"data-module" => "explicit-cross-domain-links" do %>
+    <%= hidden_field_tag :previous_url, params[:previous_url] %>
+    <%= render "govuk_publishing_components/components/button", {
+      text: t("confirmation_sent.continue_to.brexit"),
+      data_attributes: {
+        module: "gem-track-click",
+        "track-category": "account-create",
+        "track-action": "confirm-email",
+        "track-label": "Brexit checker",
+      },
+      margin_bottom: 3,
+    } %>
+  <% end %>
+<% end %>
+
+<%= sanitize(t("confirmation_sent.instructions.finish_creating.details.#{returning_service}", email: email)) %>
+
+<%= render "govuk_publishing_components/components/inset_text", {
+  text: t("confirmation_sent.delay_consequence")
+} %>
+
+<% if returning_service == :dashboard %>
+  <p class="govuk-body" data-module="gem-track-click">
+    <a class="govuk-link" href="<%= user_root_path %>" data-track-category="account-create" data-track-action="confirm-email" data-track-label="Account">
+      <%= t("confirmation_sent.continue_to.account") %>
+    </a>
+  </p>
+<% end %>
+
+<% if returning_service == :brexit %>
+  <%= render "govuk_publishing_components/components/details", {
+    title: t("confirmation_sent.help.title"),
+  } do %>
+    <%= sanitize(t("confirmation_sent.help.instructions.finish_creating", resend_confirmation_link: new_user_confirmation_path, retry_link: edit_user_registration_email_path, email: email)) %>
+  <% end %>
+<% else %>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: t("confirmation_sent.help.heading"),
+    heading_level: 2,
+    margin_bottom: 3,
+    font_size: 19,
+  } %>
+
+  <%= sanitize(t("confirmation_sent.help.instructions.finish_creating", resend_confirmation_link: new_user_confirmation_path, retry_link: edit_user_registration_email_path, email: email)) %>
+<% end %>

--- a/app/views/confirmations/sent.html.erb
+++ b/app/views/confirmations/sent.html.erb
@@ -1,61 +1,13 @@
-<% content_for :title, t("confirmation_sent.heading") %>
-
-<%= render "govuk_publishing_components/components/heading", {
-  text: yield(:title),
-  heading_level: 1,
-  margin_bottom: 4,
-  font_size: "xl",
-} %>
-
-<p class="govuk-body">
-  <%= t("confirmation_sent.instruction_one") %> <strong><%= @email %></strong>
-</p>
-
-<p class="govuk-body">
-  <%= t("confirmation_sent.instruction_two") %>
-</p>
-
-<p class="govuk-body">
-  <% if @user_is_new %>
-    <%= sanitize(t("confirmation_sent.new_user_instruction_list")) %>
-  <% else %>
-    <%= sanitize(t("confirmation_sent.existing_user_instruction_list")) %>
-  <% end %>
-</p>
-
-<% unless @user_is_confirmed %>
-  <%= render "govuk_publishing_components/components/inset_text", {
-    text: t("confirmation_sent.delay_consequence")
-  } %>
-<% end %>
-
-<% if @user_is_new && params[:previous_url]&.start_with?(oauth_authorization_path) %>
-  <%= form_tag redirect_to_previous_url_path, method: :post, :"data-module" => "explicit-cross-domain-links" do %>
-    <%= hidden_field_tag :previous_url, params[:previous_url] %>
-    <%= render "govuk_publishing_components/components/button", {
-      text: t("confirmation_sent.continue_to_service"),
-      data_attributes: {
-        module: "gem-track-click",
-        "track-category": "account-create",
-        "track-action": "confirm-email",
-        "track-label": "Brexit checker",
-      },
-      margin_bottom: 3,
+<% if @user_is_new %>
+  <%= render partial: "confirmations/_sent/finish_creating", locals: {
+    returning_service: @returning_service,
+    email: @email,
+    user_is_confirmed: @user_is_confirmed
     } %>
-  <% end %>
 <% else %>
-  <p class="govuk-body" data-module="gem-track-click">
-    <a class="govuk-link" href="<%= user_root_path %>" data-track-category="account-create" data-track-action="confirm-email" data-track-label="Account">
-      <%= t("confirmation_sent.continue_to_account") %>
-    </a>
-  </p>
+  <%= render partial: "confirmations/_sent/confirm_change", locals: {
+    returning_service: @returning_service,
+    email: @email,
+    user_is_confirmed: @user_is_confirmed
+    }  %>
 <% end %>
-
-<%= render "govuk_publishing_components/components/heading", {
-  text: t("confirmation_sent.re_register_subtitle"),
-  heading_level: 2,
-  margin_bottom: 3,
-  font_size: 19,
-} %>
-
-<%= sanitize(t("confirmation_sent.re_register_instructions", resend_confirmation_link: new_user_confirmation_path, retry_link: edit_user_registration_email_path)) %>

--- a/config/locales/account/confirmations.en.yml
+++ b/config/locales/account/confirmations.en.yml
@@ -6,26 +6,40 @@ en:
       update: "<strong>Confirm your email address</strong> to finish updating your account and email alerts."
     link_text: Send confirmation email again
   confirmation_sent:
-    continue_to_account: Go to your GOV.UK account
-    continue_to_service: Finish saving your Brexit checker results
+    continue_to:
+      account: Go to your GOV.UK account
+      brexit: Continue to your Brexit checker results
     delay_consequence: You will be locked out of your account if you do not confirm your email address within 7 days.
-    existing_user_instruction_list: |
-      <ul class="govuk-list govuk-list--bullet">
-        <li>finish updating the email address for your account</li>
-        <li>get email updates about Brexit sent to your new email address</li>
-      </ul>
-    heading: Confirm your email address
-    instruction_one: We’ve sent an email to
-    instruction_two: 'You need to click on the confirmation link in the email to:'
-    new_user_instruction_list: |
-      <ul class="govuk-list govuk-list--bullet">
-        <li>finish creating your account</li>
-        <li>start receiving email updates about Brexit</li>
-      </ul>
-    re_register_instructions: |
-      <p class="govuk-body">We can <a class="govuk-link" href="%{resend_confirmation_link}" data-module="gem-track-click" data-track-category="account-create" data-track-action="confirm-email" data-track-label="resend-email">send the confirmation email again</a> if you did not get it.</a>
-      <p class="govuk-body">You can <a class="govuk-link" href="%{retry_link}" data-module="gem-track-click" data-track-category="account-create" data-track-action="confirm-email" data-track-label="different-email">use a different email address</a> if your email address is not correct.</p>
-    re_register_subtitle: If you did not get the email or want to use a different address
+    heading:
+      confirm_change: Finish updating your email address
+      finish_creating: Finish creating your account
+    help:
+      heading: If you did not get the confirmation email
+      instructions:
+        confirm_change: <p class="govuk-body">We can <a class="govuk-link" href="%{resend_confirmation_link}" data-module="gem-track-click" data-track-category="confirm-change" data-track-action="confirm-email" data-track-label="resend-email">send the confirmation email again</a> if you did not get it.</a></p>
+        finish_creating: |
+          <p class="govuk-body">We can <a class="govuk-link" href="%{resend_confirmation_link}" data-module="gem-track-click" data-track-category="account-create" data-track-action="confirm-email" data-track-label="resend-email">send the confirmation email again</a> if you did not get it.</a></p>
+          <p class="govuk-body">You can <a class="govuk-link" href="%{retry_link}" data-module="gem-track-click" data-track-category="account-create" data-track-action="confirm-email" data-track-label="different-email">use a different email address</a> if your email address is not correct.</p>
+      title: Help if you did not get the confirmation email
+    instructions:
+      confirm_change:
+        details:
+          dashboard: |
+            <p class="govuk-body">You need to confirm your new email address.</p>
+            <p class="govuk-body">We’ve sent an email to <strong>%{email}</strong>. Click on the confirmation link in the email to finish updating the email address for your GOV.UK account.</p>
+      finish_creating:
+        details:
+          brexit: |
+            <p class="govuk-body">You also need to confirm your email address.</p>
+            <p class="govuk-body">We’ve sent an email to <strong>%{email}</strong>. Click on the confirmation link in the email to:</p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>finish creating your account</li>
+              <li>start receiving email updates about Brexit</li>
+            </ul>
+          dashboard: |
+            <p class="govuk-body">You need to confirm your email address.</p>
+            <p class="govuk-body">We’ve sent an email to <strong>%{email}</strong>. Click on the confirmation link in the email to finish creating your account.</p>
+        must_continue: You must continue to your Brexit checker results to finish saving them to your account.
   devise:
     confirmations:
       confirmed: You’ve successfully confirmed your email address.

--- a/config/locales/mailer.en.yml
+++ b/config/locales/mailer.en.yml
@@ -153,7 +153,7 @@ en:
 
         You’ve finished creating your GOV.UK account.
 
-        GOV.UK accounts are a trial. They’re a first step towards creating a GOV.UK that is more tailored to you and your circumstances.
+        GOV.​UK accounts are a trial. They’re a first step towards creating a GOV.​UK that is more tailored to you and your circumstances.
 
         At the moment, you can only use your account with the Brexit checker.
 
@@ -164,7 +164,9 @@ en:
           - get updates about guidance that might be helpful to you
           - reuse data about you between different services
 
-        If you have any questions, problems or suggestions for how we could make your GOV.​UK account better, please give us feedback: (%{feedback_link})
+        If you have any questions, problems or suggestions for how we could make your GOV.​UK account better, please give us feedback:
+
+        (%{feedback_link}).
 
         Sign in to your GOV.UK account: (%{login_link})
 

--- a/config/locales/mailer.en.yml
+++ b/config/locales/mailer.en.yml
@@ -136,9 +136,9 @@ en:
       body: |
         Hello
 
-        You said you want to update the email address for your GOV.UK account.
+        You’ve said you want to update the email address for your GOV.UK account.
 
-        We sent a confirmation link to %{new_address}. The email address for your account will not be updated until you click that link.
+        You need to click on the confirmation link we sent to your new address to finish this update.
 
         If this was not you, contact us:
         %{feedback_link}.

--- a/config/locales/mailer.en.yml
+++ b/config/locales/mailer.en.yml
@@ -6,11 +6,7 @@ en:
         body: |
           Hello
 
-          You’ve said you want to update the email address for your GOV.UK account.
-
-          You need to click on the confirmation link to:
-            - finish updating the email address for your account
-            - get email updates about Brexit sent to your new email address
+          You need to click on the confirmation link to finish updating the email address for your GOV.UK account.
 
           If this was not you, you can ignore this email.
 

--- a/config/locales/mailer.en.yml
+++ b/config/locales/mailer.en.yml
@@ -24,14 +24,15 @@ en:
         body: |
           Hello
 
-          You need to click on the confirmation link to:
-            - finish creating your account
-            - start receiving email updates about Brexit
+          You need to click on the confirmation link to finish creating your GOV.UK account.
 
           You will be locked out of your account if you do not confirm your email address within 7 days.
 
           Confirm your email address:
           %{link}
+
+          If you need help confirming your email address, contact us:
+          %{feedback_link}
 
           -----
 

--- a/spec/feature/change_email_spec.rb
+++ b/spec/feature/change_email_spec.rb
@@ -13,8 +13,7 @@ RSpec.feature "Change Email" do
       enter_new_email
       enter_password
 
-      expect(page).to have_text(I18n.t("confirmation_sent.heading"))
-      expect(page).to have_text("#{I18n.t('confirmation_sent.instruction_one')} #{new_email}")
+      expect(page).to have_text(I18n.t("confirmation_sent.heading.confirm_change"))
     end
 
     it "notifies the user about the update" do

--- a/spec/feature/registration_from_another_application_spec.rb
+++ b/spec/feature/registration_from_another_application_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature "Registration (coming from another application)" do
         i_enter_registration_details_without_phone
         i_consent_my_information_being_used
 
-        expect(page).to have_text(I18n.t("confirmation_sent.heading"))
+        expect(page).to have_text(I18n.t("confirmation_sent.heading.finish_creating"))
         expect(return_to_app_url(page)).to include("scope=openid+level0")
       end
     end
@@ -48,7 +48,7 @@ RSpec.feature "Registration (coming from another application)" do
         i_enter_phone_code
         i_consent_my_information_being_used
 
-        expect(page).to have_text(I18n.t("confirmation_sent.heading"))
+        expect(page).to have_text(I18n.t("confirmation_sent.heading.finish_creating"))
         expect(return_to_app_url(page)).to include("scope=openid+level1")
       end
     end

--- a/spec/feature/registration_spec.rb
+++ b/spec/feature/registration_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "Registration" do
     enter_mfa
     provide_consent
 
-    expect(page).to have_text(I18n.t("confirmation_sent.heading"))
+    expect(page).to have_text(I18n.t("confirmation_sent.heading.finish_creating"))
 
     expect(User.last).to_not be_nil
     expect(User.last.email).to eq(email)
@@ -323,7 +323,7 @@ RSpec.feature "Registration" do
         enter_mfa
         provide_consent
 
-        expect(page).to have_text(I18n.t("confirmation_sent.heading"))
+        expect(page).to have_text(I18n.t("confirmation_sent.heading.finish_creating"))
       end
     end
   end

--- a/spec/feature/resend_confirmation_spec.rb
+++ b/spec/feature/resend_confirmation_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Resending confirmation email" do
     enter_email_address
 
     assert_enqueued_jobs 1, only: NotifyDeliveryJob
-    expect(page).to have_text(I18n.t("reset_sent.subheading"))
+    expect(page).to have_text(I18n.t("confirmation_sent.help.heading"))
     expect(page).to have_text(user.email)
   end
 


### PR DESCRIPTION
[Trello](https://trello.com/c/JuzRNvA4/832-remove-the-email-signup-from-the-transition-checker-registration-journey)

We've got new designs for this page in the case where a user signs up
through a service.  Since the same template is used for both
registration confirmation and change-of-email confirmation (whose
bright idea was that? oh right, me) there's a bit of conditional logic
in it now to render the right things.

We don't have a new design for the case where a user signs up by going
to `/new-account` directly (not via a service), so I've kept that
close to old design.

---

**Creating an account via a service:**

<img width="1061" alt="Screenshot 2021-07-16 at 12 01 48" src="https://user-images.githubusercontent.com/75235/125944508-3f780643-c97c-485e-b910-3171f335f0e7.png">

**Creating an account directly:**

<img width="1083" alt="Screenshot 2021-07-16 at 11 57 51" src="https://user-images.githubusercontent.com/75235/125944507-449fc79c-f0fb-4e83-9e4a-b9bdbe6f73d8.png">

**Changing email address:**

<img width="1068" alt="Screenshot 2021-07-16 at 12 02 30" src="https://user-images.githubusercontent.com/75235/125944510-a20f2fcc-e7b6-40b4-a776-ff5c8c456500.png">

---

[Trello card](https://trello.com/c/JuzRNvA4/832-remove-the-email-signup-from-the-transition-checker-registration-journey)