### PR TITLE
Delete account

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,9 +1,15 @@
 RSpec.describe User do
+  include GdsApi::TestHelpers::AccountApi
+
   let(:attribute_service_url) { "https://attribute-service" }
+  let(:account_api_url) { "https://account-api" }
 
   let(:user) { FactoryBot.create(:user) }
 
   let(:bearer_token) { AccountManagerApplication.user_token(user.id).token }
+
+  let(:account_api_application) { FactoryBot.create(:oauth_application) }
+  let(:account_api_subject_identifier) { Doorkeeper::OpenidConnect.configuration.subject.call(user, account_api_application).to_s }
 
   around do |example|
     ClimateControl.modify(ATTRIBUTE_SERVICE_URL: attribute_service_url) do
@@ -13,9 +19,21 @@ RSpec.describe User do
 
   context "#destroy!" do
     it "calls the attribute service to delete the attributes" do
-      attribute_service_stub = stub_attribute_service_delete_all
-      user.destroy!
-      expect(attribute_service_stub).to have_been_made
+      ClimateControl.modify ACCOUNT_API_DOORKEEPER_UID: account_api_application.uid do
+        stub_account_api_delete_user_by_subject_identifier(subject_identifier: account_api_subject_identifier)
+        attribute_service_stub = stub_attribute_service_delete_all
+        user.destroy!
+        expect(attribute_service_stub).to have_been_made
+      end
+    end
+
+    it "calls the account-api to delete remote data held there" do
+      ClimateControl.modify ACCOUNT_API_DOORKEEPER_UID: account_api_application.uid do
+        stub_attribute_service_delete_all
+        account_api_delete_user_stub = stub_account_api_delete_user_by_subject_identifier(subject_identifier: account_api_subject_identifier)
+        user.destroy!
+        expect(account_api_delete_user_stub).to have_been_made
+      end
     end
 
     def stub_attribute_service_delete_all

--- a/spec/requests/delete_spec.rb
+++ b/spec/requests/delete_spec.rb
@@ -1,0 +1,57 @@
+require "spec_helper"
+
+RSpec.describe "delete account requests" do
+  context "when logged out" do
+    it "redirects GET /account/delete requests to the login form" do
+      get account_delete_path
+      follow_redirect!
+      expect(response.body).to have_text(I18n.t("devise.sessions.new.heading"))
+    end
+
+    it "redirects DELETE /account/delete requests to the login form" do
+      delete account_delete_path
+      follow_redirect!
+      expect(response.body).to have_text(I18n.t("devise.sessions.new.heading"))
+    end
+
+    it "GET /account/delete/confirmation renders confirmation text" do
+      get account_delete_confirmation_path
+      expect(response.body).to have_text(I18n.t("account.delete.confirmation.heading"))
+    end
+  end
+
+  context "when logged in" do
+    let(:user) { FactoryBot.create(:user) }
+    let(:account_api_application) { FactoryBot.create(:oauth_application) }
+    let(:account_api_subject_identifier) { Doorkeeper::OpenidConnect.configuration.subject.call(user, account_api_application).to_s }
+
+    before { sign_in(user) }
+
+    describe "GET /delete" do
+      it "renders the form" do
+        get account_delete_path
+        expect(response.body).to have_text(I18n.t("account.delete.heading"))
+      end
+    end
+
+    describe "DELETE /delete" do
+      let(:instance) { instance_double(RemoteUserInfo) }
+      let(:double_class) { class_double(RemoteUserInfo).as_stubbed_const }
+
+      it "renders the form if current user does not have a valid password" do
+        allow(user).to receive(:valid_password?).and_return(false)
+        delete account_delete_path
+        expect(response.body).to have_text(I18n.t("account.delete.heading"))
+      end
+
+      it "deletes account in the account manager and api and sends an email if current users password is valid" do
+        allow(user).to receive(:valid_password?).and_return(true)
+        allow(double_class).to receive(:new).and_return(instance)
+        allow(instance).to receive(:destroy!).and_return(true)
+        ClimateControl.modify ACCOUNT_API_DOORKEEPER_UID: account_api_application.uid do
+          expect { delete account_delete_path }.to change(User, :count).by(-1)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
A part of: [trello ticket](https://trello.com/c/b95YV8qC/912-%E2%9D%97-delete-users-in-account-api-when-theyre-deleted-in-account-manager)
See also: [account-api#154](https://github.com/alphagov/account-api/pull/154)
And also: [gds-api-adapters#1098](https://github.com/alphagov/gds-api-adapters/pull/1098)

**Draft pending: gds-api-adapters#1098**

We are currently migrating features from our PaaS based
account-manager-prototype
to account-api.

Accounts API now acts as an additional store of user data. When a user
deletes their account through the account manager we require an
authenticated endpoint that will forward the request to account-api so
we can remove their data there too.

This PR ensures we call the new account-api delete endpoint via the GDS
API adaptors whenever a user record is deleted.