### PR TITLE
Exclude smokey user from reports

### DIFF
--- a/lib/report.rb
+++ b/lib/report.rb
@@ -2,4 +2,6 @@
 
 module Report
   TIME_FORMAT = "%Y-%m-%d %H:%M:%S %:z"
+
+  SMOKEY_USER = "smokey@alphagov.co.uk"
 end

--- a/lib/report/account_events.rb
+++ b/lib/report/account_events.rb
@@ -56,12 +56,17 @@ module Report
       SecurityActivity
         .of_type(SecurityActivity::LOGIN_SUCCESS)
         .where(oauth_application_id: nil)
+        .where.not(user_id: smokey_user_id)
         .where("created_at < ?", end_date)
     end
 
     def all_login_events_in_report
       all_login_events
         .where("created_at >= ?", start_date)
+    end
+
+    def smokey_user_id
+      @smokey_user_id ||= User.find_by(email: Report::SMOKEY_USER)&.id
     end
 
     def hashed_id(user_id)

--- a/lib/report/accounts.rb
+++ b/lib/report/accounts.rb
@@ -5,12 +5,12 @@ module Report
     end
 
     def all
-      User.all.map { |user| user_to_row(user) }
+      User.all.map { |user| user_to_row(user) }.compact
     end
 
     def in_batches(batch_size: 200)
       User.find_in_batches(batch_size: batch_size) do |batch|
-        rows = batch.map { |user| user_to_row(user) }
+        rows = batch.map { |user| user_to_row(user) }.compact
         yield rows
       end
     end
@@ -20,6 +20,8 @@ module Report
     attr_reader :user_id_pepper
 
     def user_to_row(user)
+      return if user.email == Report::SMOKEY_USER
+
       {
         user_id: hashed_id(user.id),
         registration_timestamp: user.created_at,

--- a/lib/report/general_statistics.rb
+++ b/lib/report/general_statistics.rb
@@ -74,7 +74,9 @@ module Report
     end
 
     def all_users
-      User.where("created_at < ?", end_date)
+      User
+        .where("created_at < ?", end_date)
+        .where.not(id: smokey_user_id)
     end
 
     def interval_users
@@ -85,7 +87,12 @@ module Report
       SecurityActivity
         .of_type(SecurityActivity::LOGIN_SUCCESS)
         .where(oauth_application_id: nil)
+        .where.not(user_id: smokey_user_id)
         .where("created_at < ?", end_date)
+    end
+
+    def smokey_user_id
+      @smokey_user_id ||= User.find_by(email: Report::SMOKEY_USER)&.id
     end
 
     def interval_logins

--- a/spec/lib/report/account_events_spec.rb
+++ b/spec/lib/report/account_events_spec.rb
@@ -11,8 +11,14 @@ RSpec.describe Report::AccountEvents do
   end
 
   context "with events in the period" do
+    let(:smokey_user) { FactoryBot.create(:user, email: Report::SMOKEY_USER) }
     let(:user1) { FactoryBot.create(:user, email: "foo@example.com") }
     let(:user2) { FactoryBot.create(:user, email: "bar@example.com") }
+
+    it "excludes the smokey user" do
+      create_login_event(smokey_user, start_date)
+      expect(report).to eq([])
+    end
 
     it "#in_batches" do
       create_login_event(user1, start_date + 59.minutes)

--- a/spec/lib/report/accounts_spec.rb
+++ b/spec/lib/report/accounts_spec.rb
@@ -8,6 +8,11 @@ RSpec.describe Report::Accounts do
   end
 
   context "with users" do
+    it "excludes the smokey user" do
+      FactoryBot.create(:user, email: Report::SMOKEY_USER)
+      expect(report).to eq([])
+    end
+
     it "#in_batches" do
       FactoryBot.create(:user, email: "foo@example.com", cookie_consent: false, feedback_consent: true)
       FactoryBot.create(:user, email: "bar@example.com", cookie_consent: true, feedback_consent: false)


### PR DESCRIPTION
We'll also want to clean up the events from the Bigquery table for the
smokey user:

    require "google/cloud/bigquery"

    bigquery = Google::Cloud::Bigquery.new(credentials: Rails.application.secrets.bigquery_credentials)
    dataset = bigquery.dataset BigqueryReportExportJob::DATASET_NAME

    smokey_user = User.find_by!(email: Report::SMOKEY_USER)
    hashed_user_id = Digest::SHA256.hexdigest("#{smokey_user.id}#{Rails.application.secrets.reporting_user_id_pepper}")

    delete_job = dataset.query_job "DELETE FROM #{BigqueryReportExportJob::EVENTS_TABLE_NAME} WHERE user_id = '#{hashed_user_id}'"
    delete_job.wait_until_done!
    raise BigqueryReportExportJob::DeleteError, delete_job.error["message"] if delete_job.failed?