### PR TITLE
Remove conditionality from confirmation screen

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -4,7 +4,6 @@ class ConfirmationsController < Devise::ConfirmationsController
       @email = session[:confirmations]["email"]
       @user_is_confirmed = user_is_confirmed
       @user_is_new = user_is_new
-      @returning_service = returning_service
       session.delete(:confirmations)
     else
       redirect_to "/"
@@ -59,11 +58,5 @@ private
 
   def user_is_confirmed
     session[:confirmations].fetch("user_is_confirmed", false)
-  end
-
-  def returning_service
-    return :brexit if params[:previous_url]&.start_with?(oauth_authorization_path)
-
-    :dashboard
   end
 end

--- a/app/views/confirmations/_sent/_confirm_change.html.erb
+++ b/app/views/confirmations/_sent/_confirm_change.html.erb
@@ -17,7 +17,7 @@
 
 <p class="govuk-body" data-module="gem-track-click">
   <a class="govuk-link" href="<%= user_root_path %>" data-track-category="account-create" data-track-action="confirm-email" data-track-label="Account">
-    <%= t("confirmation_sent.continue_to.account") %>
+    <%= t("confirmation_sent.finish.updating") %>
   </a>
 </p>
 

--- a/app/views/confirmations/_sent/_finish_creating.html.erb
+++ b/app/views/confirmations/_sent/_finish_creating.html.erb
@@ -7,51 +7,30 @@
   font_size: "xl",
 } %>
 
-<% if returning_service == :brexit %>
-  <p class="govuk-body"><%= t("confirmation_sent.instructions.finish_creating.must_continue") %></p>
+<%= sanitize(t("confirmation_sent.instructions.finish_creating.details")) %>
 
-  <%= form_tag redirect_to_previous_url_path, method: :post, :"data-module" => "explicit-cross-domain-links" do %>
-    <%= hidden_field_tag :previous_url, params[:previous_url] %>
-    <%= render "govuk_publishing_components/components/button", {
-      text: t("confirmation_sent.continue_to.brexit"),
-      data_attributes: {
-        module: "gem-track-click",
-        "track-category": "account-create",
-        "track-action": "confirm-email",
-        "track-label": "Brexit checker",
-      },
-      margin_bottom: 3,
-    } %>
-  <% end %>
+<%= form_tag redirect_to_previous_url_path, method: :post, :"data-module" => "explicit-cross-domain-links" do %>
+  <%= hidden_field_tag :previous_url, params[:previous_url] %>
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("confirmation_sent.finish.creating"),
+    data_attributes: {
+      module: "gem-track-click",
+      "track-category": "account-create",
+      "track-action": "confirm-email",
+      "track-label": "Finish Creating account",
+    },
+    margin_bottom: 3,
+  } %>
 <% end %>
 
-<%= sanitize(t("confirmation_sent.instructions.finish_creating.details.#{returning_service}", email: email)) %>
+<%= sanitize(t("confirmation_sent.instructions.finish_creating.address_confirmation", email: email)) %>
 
 <%= render "govuk_publishing_components/components/inset_text", {
   text: t("confirmation_sent.delay_consequence")
 } %>
 
-<% if returning_service == :dashboard %>
-  <p class="govuk-body" data-module="gem-track-click">
-    <a class="govuk-link" href="<%= user_root_path %>" data-track-category="account-create" data-track-action="confirm-email" data-track-label="Account">
-      <%= t("confirmation_sent.continue_to.account") %>
-    </a>
-  </p>
-<% end %>
-
-<% if returning_service == :brexit %>
-  <%= render "govuk_publishing_components/components/details", {
-    title: t("confirmation_sent.help.title"),
-  } do %>
-    <%= sanitize(t("confirmation_sent.help.instructions.finish_creating", resend_confirmation_link: new_user_confirmation_path, retry_link: edit_user_registration_email_path, email: email)) %>
-  <% end %>
-<% else %>
-  <%= render "govuk_publishing_components/components/heading", {
-    text: t("confirmation_sent.help.heading"),
-    heading_level: 2,
-    margin_bottom: 3,
-    font_size: 19,
-  } %>
-
+<%= render "govuk_publishing_components/components/details", {
+  title: t("confirmation_sent.help.title"),
+} do %>
   <%= sanitize(t("confirmation_sent.help.instructions.finish_creating", resend_confirmation_link: new_user_confirmation_path, retry_link: edit_user_registration_email_path, email: email)) %>
 <% end %>

--- a/app/views/confirmations/sent.html.erb
+++ b/app/views/confirmations/sent.html.erb
@@ -1,12 +1,10 @@
 <% if @user_is_new %>
   <%= render partial: "confirmations/_sent/finish_creating", locals: {
-    returning_service: @returning_service,
     email: @email,
     user_is_confirmed: @user_is_confirmed
     } %>
 <% else %>
   <%= render partial: "confirmations/_sent/confirm_change", locals: {
-    returning_service: @returning_service,
     email: @email,
     user_is_confirmed: @user_is_confirmed
     }  %>

--- a/config/locales/account/confirmations.en.yml
+++ b/config/locales/account/confirmations.en.yml
@@ -6,13 +6,13 @@ en:
       update: "<strong>Confirm your email address</strong> to finish updating your account and email alerts."
     link_text: Send confirmation email again
   confirmation_sent:
-    continue_to:
-      account: Go to your GOV.UK account
-      brexit: Continue to your Brexit checker results
     delay_consequence: You will be locked out of your account if you do not confirm your email address within 7 days.
+    finish:
+      creating: Finish
+      updating: Go to your GOV.UK account
     heading:
       confirm_change: Finish updating your email address
-      finish_creating: Finish creating your account
+      finish_creating: Finish creating your GOV.UK account
     help:
       heading: If you did not get the confirmation email
       instructions:
@@ -28,18 +28,10 @@ en:
             <p class="govuk-body">You need to confirm your new email address.</p>
             <p class="govuk-body">We’ve sent an email to <strong>%{email}</strong>. Click on the confirmation link in the email to finish updating the email address for your GOV.UK account.</p>
       finish_creating:
-        details:
-          brexit: |
-            <p class="govuk-body">You also need to confirm your email address.</p>
-            <p class="govuk-body">We’ve sent an email to <strong>%{email}</strong>. Click on the confirmation link in the email to:</p>
-            <ul class="govuk-list govuk-list--bullet">
-              <li>finish creating your account</li>
-              <li>start receiving email updates about Brexit</li>
-            </ul>
-          dashboard: |
-            <p class="govuk-body">You need to confirm your email address.</p>
-            <p class="govuk-body">We’ve sent an email to <strong>%{email}</strong>. Click on the confirmation link in the email to finish creating your account.</p>
-        must_continue: You must continue to your Brexit checker results to finish saving them to your account.
+        address_confirmation: |
+          <p class="govuk-body">You'll also need to confirm your email address. Click on the confirmation link we've emailed to <strong>%{email}</strong>.</p>
+          <p class="govuk-body">If you've subscribed to email updates about Brexit, you will not start receiving emails until you've confirmed your email address.</p>
+        details: <p class="govuk-body">You need to finish creating your account.</p>
   devise:
     confirmations:
       confirmed: You’ve successfully confirmed your email address.


### PR DESCRIPTION
In govuk-account-manager-prototype#911 we added conditionality that
varied the confirmation page based on the user's origin. This was an
attempt to provide some content to users that were specific to their
jouernys.

However this has a few drawbacks.

1. The account manager can only really tell if the user arrived via the
auth path, or did not. This is a reasonable proxy for "signed up from
our only service" or "signed up directly", but does not really prove
they came from the brexit checker. This has led to a few odd journeys
where the user comes to the sign up journey via gov.uk/sign-in, which
preserves previous_url parameters. This also will not work when we
immimently add a second service.

2. It also implies a level of knowlege / access to GOV.UK storage
(brexit checker attribtutes) that we cannot expect a Digital Identity
product to have. It is therefore a re-entangling of the checker and the
auth journey, whilst we're trying to separate the two.

As a result we've chosen here to opt for a single generic completion
page that sends the user back to the previous_url