### PR TITLE
Fix missing feedback link was causing confirmation emails to error

### DIFF
--- a/app/views/devise_mailer/confirmation_instructions.text.erb
+++ b/app/views/devise_mailer/confirmation_instructions.text.erb
@@ -1,4 +1,5 @@
 <%= t("devise.mailer.confirmation_instructions.body",
     email: @email,
     link: confirmation_url(@resource, confirmation_token: @token),
+    feedback_link: feedback_form_url,
 ) %>


### PR DESCRIPTION
Got added to the locale file without being added to the mailer