### PR TITLE
Upgrade level0 users to level1, if they have MFA configured

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -15,14 +15,13 @@ Doorkeeper.configure do
       )
 
     if current_user
-      current_level_of_authentication = session[:level_of_authentication]
+      current_level_of_authentication = session.fetch(:level_of_authentication, "level0")
       current_level_of_authentication_is_good_enough =
-        !Rails.application.config.feature_flag_enforce_levels_of_authentication ||
         LevelOfAuthentication.current_auth_greater_or_equal_to_required(
           current_level_of_authentication, required_level_of_authentication
         )
 
-      if current_level_of_authentication_is_good_enough
+      if current_level_of_authentication_is_good_enough || MultiFactorAuth.choose_mfa_method(current_user).nil?
         current_user
       else
         destination_url =

--- a/spec/feature/login_spec.rb
+++ b/spec/feature/login_spec.rb
@@ -224,27 +224,16 @@ RSpec.feature "Logging in" do
           expect(page.current_url).to start_with("https://www.gov.uk/")
         end
 
-        it "redirects to set up MFA if a higher scope is requested" do
+        it "does not redirect to set up MFA if a higher scope is requested" do
           visit authorization_endpoint_url(client: application, scope: "openid level1")
-          expect(page).to have_content(I18n.t("mfa.phone.update.start.new.heading"))
-          set_up_mfa
+          expect(page).to_not have_content(I18n.t("mfa.phone.update.start.new.heading"))
           expect(page.current_url).to start_with("https://www.gov.uk/")
         end
 
-        it "redirects to set up MFA if no scope is requested" do
+        it "does not redirect to set up MFA if no scope is requested" do
           visit authorization_endpoint_url(client: application, scope: "openid")
-          expect(page).to have_content(I18n.t("mfa.phone.update.start.new.heading"))
-          set_up_mfa
+          expect(page).to_not have_content(I18n.t("mfa.phone.update.start.new.heading"))
           expect(page.current_url).to start_with("https://www.gov.uk/")
-        end
-
-        def set_up_mfa
-          fill_in "phone", with: "07958123456"
-          fill_in "current_password", with: user.password
-          click_on I18n.t("mfa.phone.update.start.new.fields.submit.label")
-          click_on I18n.t("mfa.phone.update.confirm.fields.submit.label")
-          fill_in "phone_code", with: user.reload.phone_code
-          click_on I18n.t("mfa.phone.code.fields.submit.label")
         end
       end
 

--- a/spec/requests/oauth_authorization_spec.rb
+++ b/spec/requests/oauth_authorization_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 RSpec.describe "/oauth/authorize" do
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:user, phone: nil) }
 
   let(:application) do
     FactoryBot.create(

--- a/spec/requests/security_activity_spec.rb
+++ b/spec/requests/security_activity_spec.rb
@@ -155,12 +155,12 @@ RSpec.describe "security activities" do
           :oauth_application,
           name: "name",
           redirect_uri: "http://localhost",
-          scopes: %i[openid],
+          scopes: %i[openid level0],
         )
       end
 
       it "records LOGIN_SUCCESS events for OAuth authorizations" do
-        get authorization_endpoint_url(client: application, scope: "openid")
+        get authorization_endpoint_url(client: application, scope: "openid level0")
 
         expect_event SecurityActivity::LOGIN_SUCCESS, { application: application }
         expect_event_on_security_page SecurityActivity::LOGIN_SUCCESS


### PR DESCRIPTION
Users can log in at level0, but account-api enforces levels of
authentication.  This means that we need to be able to reauthenticate
a user at level1 in this app.

We only have placeholder content for the MFA set-up journey, but
currently users can only create a level1 account, so this works:

- If the user has MFA, and is authenticated to too low a level,
upgrade them.

- If the user does not have MFA, and is authenticated to too low a
level, do not upgrade them.

This will result in broken journeys for users without MFA, but there
are no such users.