### PR TITLE
Persist subject identifiers to the database on save & add rake task to update old users

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -156,6 +156,7 @@ class RegistrationsController < Devise::RegistrationsController
         session[:has_done_mfa] = false
       end
 
+      resource.generate_subject_identifier
       resource.update_remote_user_info
 
       record_security_event(SecurityActivity::USER_CREATED, user: resource)

--- a/db/migrate/20211001085914_add_subject_identifier_to_user.rb
+++ b/db/migrate/20211001085914_add_subject_identifier_to_user.rb
@@ -1,0 +1,5 @@
+class AddSubjectIdentifierToUser < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :subject_identifier, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_02_085832) do
+ActiveRecord::Schema.define(version: 2021_10_01_085914) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -200,6 +200,7 @@ ActiveRecord::Schema.define(version: 2021_07_02_085832) do
     t.boolean "has_received_onboarding_email", default: false, null: false
     t.boolean "banned_password_match"
     t.boolean "has_received_2021_03_survey", default: false, null: false
+    t.string "subject_identifier"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/lib/remote_user_info.rb
+++ b/lib/remote_user_info.rb
@@ -33,10 +33,7 @@ class RemoteUserInfo
       )
 
       GdsApi.account_api.update_user_by_subject_identifier(
-        subject_identifier: Doorkeeper::OpenidConnect.configuration.subject.call(
-          @user,
-          Doorkeeper::Application.find_by(uid: ENV.fetch("ACCOUNT_API_DOORKEEPER_UID")),
-        ).to_s,
+        subject_identifier: @user.generate_subject_identifier,
         **attributes,
       )
     end
@@ -76,10 +73,7 @@ protected
 
   def delete_user_data_in_account_api
     GdsApi.account_api.delete_user_by_subject_identifier(
-      subject_identifier: Doorkeeper::OpenidConnect.configuration.subject.call(
-        @user,
-        Doorkeeper::Application.find_by(uid: ENV.fetch("ACCOUNT_API_DOORKEEPER_UID")),
-      ).to_s,
+      subject_identifier: @user.generate_subject_identifier,
     )
   end
 end

--- a/lib/tasks/migration.rake
+++ b/lib/tasks/migration.rake
@@ -1,0 +1,13 @@
+namespace :migration do
+  desc "Persist subject identifiers for all users without them already saved"
+  task persist_missing_subject_identifiers: :environment do
+    users = User.where(subject_identifier: nil)
+    total = users.count
+    done = 0
+    users.find_each do |user|
+      user.generate_subject_identifier
+      done += 1
+      puts "Progress: #{done} / #{total}" if (done % 100).zero?
+    end
+  end
+end

--- a/spec/lib/remote_user_info_spec.rb
+++ b/spec/lib/remote_user_info_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe RemoteUserInfo do
   let(:bearer_token) { AccountManagerApplication.user_token(user.id).token }
 
   let(:account_api_application) { FactoryBot.create(:oauth_application) }
-  let(:account_api_subject_identifier) { Doorkeeper::OpenidConnect.configuration.subject.call(user, account_api_application).to_s }
+  let(:account_api_subject_identifier) { user.generate_subject_identifier }
 
   around do |example|
     ClimateControl.modify(ATTRIBUTE_SERVICE_URL: attribute_service_url, ACCOUNT_API_DOORKEEPER_UID: account_api_application.uid) do


### PR DESCRIPTION
When we migrate to DI, all the internal database identifiers will
change, and so will the subject identifiers.  DI are persisting the
old subject identifiers as a custom claim, so that we can match up
data if we need to (eg) examine old audit logs or suchlike.  Storing
the subject identifiers here as well makes it possible to do that just
with database queries, which will be much faster than running Ruby
code.

---

[Trello card](https://trello.com/c/3nDEIlRE/1059-put-subject-identifiers-into-account-manager-database)