### PR TITLE
Add notice about the 25th deadline to post-registration page & email

### DIFF
--- a/config/locales/account/confirmations.en.yml
+++ b/config/locales/account/confirmations.en.yml
@@ -6,7 +6,7 @@ en:
       update: "<strong>Confirm your email address</strong> to finish updating your account and email alerts."
     link_text: Send confirmation email again
   confirmation_sent:
-    delay_consequence: You will be locked out of your account if you do not confirm your email address within 7 days.
+    delay_consequence: We're making some changes to how you sign in to your GOV.UK account. You need to confirm your email address by 9am on the 25th of October or your account and all the information stored in it will be deleted.
     finish:
       creating: Finish
       updating: Go to your GOV.UK account

--- a/config/locales/mailer.en.yml
+++ b/config/locales/mailer.en.yml
@@ -26,7 +26,7 @@ en:
 
           You need to click on the confirmation link to finish creating your GOV.UK account.
 
-          You will be locked out of your account if you do not confirm your email address within 7 days.
+          We're making some changes to how you sign in to your GOV.UK account. You need to confirm your email address by 9am on the 25th of October or your account and all the information stored in it will be deleted.
 
           Confirm your email address:
           %{link}


### PR DESCRIPTION
This is so that newly-created accounts, who wouldn't have received the
downtime email, will be told about the deadline.

<img width="771" alt="Screenshot 2021-10-22 at 13 50 11" src="https://user-images.githubusercontent.com/75235/138456368-9210baca-f687-459d-b930-e5bb4f5ddeb8.png">

---

[Trello card](https://trello.com/c/6eAzQex4/1079-prepare-to-make-the-account-manager-read-only)