### PR TITLE
Return a 404 for all unknown paths when redirecting

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -71,7 +71,7 @@
   <div class="govuk-width-container app-width-container">
     <% message = capture do %>
       <%= t("feedback.banners.phase_intro") %>
-      <a class="govuk-link" href='<%= feedback_form_path %>'><%= t("feedback.banners.phase_link") %></a>
+      <a class="govuk-link" href=''><%= t("feedback.banners.phase_link") %></a>
       <%= t("feedback.banners.phase_outro") %>
     <% end %>
     <%= render "govuk_publishing_components/components/phase_banner", {
@@ -105,7 +105,7 @@
 
         <p class="govuk-body govuk-!-margin-bottom-0">
           <%= t("feedback.banners.footer_intro") %>
-          <a href="<%= feedback_form_path %>" class="govuk-link"><%= t("feedback.banners.footer_link") %></a>
+          <a href="" class="govuk-link"><%= t("feedback.banners.footer_link") %></a>
           <%= t("feedback.banners.footer_outro") %>
         </p>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,9 @@ Rails.application.routes.draw do
 
     get "/new-account", to: redirect("https://www.gov.uk/sign-in/redirect")
     get "/new-account/*path", to: redirect("https://www.gov.uk/sign-in/redirect")
+
+    get "/healthcheck", to: "healthcheck#show"
+    get "*path", to: proc { [404, {}, ["not found"]] }
   else
     devise_scope :user do
       get "/", to: "welcome#show", as: :welcome
@@ -136,14 +139,14 @@ Rails.application.routes.draw do
 
     use_doorkeeper
     use_doorkeeper_openid_connect
+
+    get "/healthcheck", to: "healthcheck#show"
   end
 
   get "/404", to: "standard_errors#not_found"
   get "/429", to: "standard_errors#too_many_requests"
   get "/422", to: "standard_errors#unprocessable_entity"
   get "/500", to: "standard_errors#internal_server_error"
-
-  get "/healthcheck", to: "healthcheck#show"
 
   mount GovukPublishingComponents::Engine, at: "/component-guide" if Rails.env.development?
 


### PR DESCRIPTION
For some paths in production we seem to be serving a 500 response
instead of a 404.  I'm not really sure why, and this wouldn't really
be a problem, but we still have the alerting for too-high 5xx rate,
and traffic to this app has died down.  So ideally we won't be
serving *any* 5xx responses, or we risk calling someone until that
alert gets removed.

<img width="968" alt="Screenshot 2021-10-28 at 16 57 37" src="https://user-images.githubusercontent.com/75235/139292432-a21c6db8-8b82-48bf-9495-0bd9ee7b19d4.png">

I've raised a PR to remove the alert, but RE won't get to it until
tomorrow.  To avoid the risk of calling someone overnight, let's add
some special handling for missing files.